### PR TITLE
http requeset の path だけ一旦 parse 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 !Dockerfile
 !docker-compose.yml
+
+!html/**

--- a/html/404.html
+++ b/html/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Web Server</title>
+</head>
+<body>
+    <h1>404 Bad request... (tmp)</h1>
+</body>
+</html>

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Web Server</title>
+</head>
+<body>
+    <h1>Hello from webserv! (tmp)</h1>
+</body>
+</html>

--- a/html/sub/index.html
+++ b/html/sub/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Web Server</title>
+</head>
+<body>
+    <h1>Sub page (tmp)</h1>
+</body>
+</html>

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -8,14 +8,6 @@ Http::Http(const std::string &read_buf) {
 
 Http::~Http() {}
 
-// todo: tmp request_
-void Http::ParseRequest(const std::string &read_buf) {
-	(void)read_buf;
-	// todo: parse
-	request_[HTTP_METHOD] = "GET";
-	request_[HTTP_PATH]   = "/html/index.html";
-}
-
 // todo: tmp content
 void Http::ReadPathContent() {
 	const std::string path = request_[HTTP_PATH];

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -10,7 +10,7 @@ Http::~Http() {}
 
 // todo: tmp content
 void Http::ReadPathContent() {
-	const std::string path = request_[HTTP_PATH];
+	const std::string path = request_[HTTP_REQUEST_TARGET];
 	(void)path;
 	// todo: read path content
 	const std::string content = "<!DOCTYPE html><html<body><h1>Hello "

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -9,7 +9,7 @@ class Http {
   public:
 	enum MessageType {
 		HTTP_METHOD,
-		HTTP_PATH,
+		HTTP_REQUEST_TARGET,
 		HTTP_VERSION,
 		HTTP_CONTENT,
 		HTTP_STATUS

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -10,6 +10,7 @@ class Http {
 	enum MessageType {
 		HTTP_METHOD,
 		HTTP_PATH,
+		HTTP_VERSION,
 		HTTP_CONTENT,
 		HTTP_STATUS
 	};

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -1,0 +1,9 @@
+#include "http.hpp"
+
+// todo: tmp request_
+void Http::ParseRequest(const std::string &read_buf) {
+	(void)read_buf;
+	// todo: parse
+	request_[HTTP_METHOD] = "GET";
+	request_[HTTP_PATH]   = "/html/index.html";
+}

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -38,7 +38,8 @@ void Http::ParseRequest(const std::string &read_buf) {
 	const std::string              start_line = lines[0];
 
 	const std::vector<std::string> request_line = SplitStr(start_line, " ");
-	// set request-line(method, request-target)
-	request_[HTTP_METHOD] = request_line[0];
-	request_[HTTP_PATH]   = CreateDefaultPath(request_line[1]);
+	// set request-line(method, request-target, HTTP-version)
+	request_[HTTP_METHOD]  = request_line[0];
+	request_[HTTP_PATH]    = CreateDefaultPath(request_line[1]);
+	request_[HTTP_VERSION] = request_line[2];
 }

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -39,7 +39,7 @@ void Http::ParseRequest(const std::string &read_buf) {
 
 	const std::vector<std::string> request_line = SplitStr(start_line, " ");
 	// set request-line(method, request-target, HTTP-version)
-	request_[HTTP_METHOD]  = request_line[0];
-	request_[HTTP_PATH]    = CreateDefaultPath(request_line[1]);
-	request_[HTTP_VERSION] = request_line[2];
+	request_[HTTP_METHOD]         = request_line[0];
+	request_[HTTP_REQUEST_TARGET] = CreateDefaultPath(request_line[1]);
+	request_[HTTP_VERSION]        = request_line[2];
 }

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -1,9 +1,33 @@
 #include "http.hpp"
+#include <vector>
+
+namespace {
+	std::vector<std::string>
+	SplitStr(const std::string &str, const std::string delim) {
+		std::vector<std::string> split_str;
+
+		std::string::const_iterator it = str.begin();
+		while (it != str.end()) {
+			const std::string      head = &(*it);
+			std::string::size_type pos  = head.find(delim);
+			if (pos == std::string::npos) {
+				split_str.push_back(head.substr(0));
+				break;
+			}
+			split_str.push_back(head.substr(0, pos));
+			std::advance(it, pos);
+			++it;
+		}
+		return split_str;
+	}
+} // namespace
 
 // todo: tmp request_
 void Http::ParseRequest(const std::string &read_buf) {
-	(void)read_buf;
-	// todo: parse
+	const std::vector<std::string> lines      = SplitStr(read_buf, "\r\n");
+	const std::string              start_line = lines[0];
+	(void)start_line;
+
 	request_[HTTP_METHOD] = "GET";
 	request_[HTTP_PATH]   = "/html/index.html";
 }

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -20,14 +20,25 @@ namespace {
 		}
 		return split_str;
 	}
+
+	// todo: create path (/, /aaa, /aaa/)
+	std::string CreateDefaultPath(const std::string &path) {
+		static const std::string location = "html";
+
+		if (path.size() == 1) {
+			return location + "/index.html";
+		}
+		return location + path + "/index.html";
+	}
 } // namespace
 
 // todo: tmp request_
 void Http::ParseRequest(const std::string &read_buf) {
 	const std::vector<std::string> lines      = SplitStr(read_buf, "\r\n");
 	const std::string              start_line = lines[0];
-	(void)start_line;
 
-	request_[HTTP_METHOD] = "GET";
-	request_[HTTP_PATH]   = "/html/index.html";
+	const std::vector<std::string> request_line = SplitStr(start_line, " ");
+	// set request-line(method, request-target)
+	request_[HTTP_METHOD] = request_line[0];
+	request_[HTTP_PATH]   = CreateDefaultPath(request_line[1]);
 }

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -6,17 +6,15 @@ namespace {
 	SplitStr(const std::string &str, const std::string delim) {
 		std::vector<std::string> split_str;
 
-		std::string::const_iterator it = str.begin();
-		while (it != str.end()) {
-			const std::string      head = &(*it);
-			std::string::size_type pos  = head.find(delim);
+		std::size_t start = 0;
+		while (start < str.size()) {
+			const std::string::size_type pos = str.find(delim, start);
 			if (pos == std::string::npos) {
-				split_str.push_back(head.substr(0));
+				split_str.push_back(str.substr(start));
 				break;
 			}
-			split_str.push_back(head.substr(0, pos));
-			std::advance(it, pos);
-			++it;
+			split_str.push_back(str.substr(start, pos - start));
+			start = pos + delim.size();
 		}
 		return split_str;
 	}


### PR DESCRIPTION
Issue #33 

## したこと
- [x] http request から start-line (= request-line) の `method`, `request-target`, `HTTP-version` だけ parse して返す

- 一旦 http request で `PATH` が来たら  `/html/PATH/index.html` を返してます



[RFC7230](https://tex2e.github.io/rfc-translater/html/rfc7230.html#3--Message-Format) HTTP-message
```
HTTP-message = start-line *( header-field CRLF ) CRLF [ message-body ]

# start-line
request-line = method SP request-target SP HTTP-version CRLF
```

ex) リクエストがこれ ↓ の場合
`curl -X 'GET' 'http://localhost:8080/`
これ ↓ を返してます
```
std::map<MessageType, std::string> request_ = {0: "GET", 1: "/html/index.html", 2: "HTTP/1.1"}
```


## 今後する予定
- `request-target` : nginx がどこにファイルを置いてるのか確認する、location で設定
- MessageType の enum や、std::map を使ってるところを構造体にするなど、型を必要に応じて変えていく
- path が `/` 終わり・`?` 以降は別扱い・ブラウザの場合に独特な path が来る などにも対応
- `index.html` はいつどこで扱うのかの調査

## 今後相談したいこと
- `SplitStr()` が `utils/` にあっても良いのかも
- `http-message` という枠で共通してる `SP` や `CRLF` などは request と response で共通して使うのが自然かも、と思ったのでここではリテラルで書いてます
- index.html の置き場 (push するのか、dockerfile 編集して mount するのか。ここでは push していません)


---
実行
```
make run

curl -X 'GET' 'http://localhost:8080/'
curl -X 'GET' 'http://localhost:8080/aaa'

# これでも良い
telnet localhost 8080
文字列
文字列
ctrl+]     # telnet プロンプト
q          # 切断。telnet終了

# ブラウザで http://localhost:8080/ などにアクセス
# ブラウザだと path に付加情報が付いていてまだ成形してないので 404 bad request
```

ちなみに curl の option
```shell
# Http method の指定
curl -X GET http://対象のURL

# Http response header 取得
curl -I http://対象のURL

# 詳細ログ表示
curl -v http://対象のURL
```