### PR TITLE
server 再起動時のための `setsockopt()` を設定

### DIFF
--- a/sandbox/ab/server_epoll/socket.cpp
+++ b/sandbox/ab/server_epoll/socket.cpp
@@ -11,11 +11,29 @@ int socket(int domain, int type, int protocol);
 - domain : ソケットの通信を行う通信ドメイン。使用するプロトコルファミリを選択
 - type : ソケット通信の種類
 - protocol : ソケットで使用する特定プロトコルを指定
+
+int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t
+optlen);
+
+- sockfd : ソケットに対応するfd
+- level : プロトコルレベル。ソケットAPIレベルはSOL_SOCKET
+- optnaem : 操作対象のソケットオプション
+	SO_REUSEADDR : 前回実行したサーバがクライアントと通信しアクティブクローズを
+				   実行したなど、動作中のポートへソケットをバインドする際に発生する
+				   エラー(EADDRINUSE)を防ぐ
+- optval : ソケットオプションの値を持つ変数のアドレス
+- optlen : optvalが指すバッファのサイズ
 */
 int CreateSocket() {
 	int server_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (server_fd == -1) {
 		perror("socket failed");
+	}
+	// set socket option to reuse address
+	int optval = 1;
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) ==
+		-1) {
+		perror("setsockopt failed");
 	}
 	return server_fd;
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -81,6 +81,12 @@ void Server::Init() {
 	if (server_fd_ == SYSTEM_ERROR) {
 		throw std::runtime_error("socket failed");
 	}
+	// set socket option to reuse address
+	int optval = 1;
+	if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) ==
+		SYSTEM_ERROR) {
+		throw std::runtime_error("setsockopt failed");
+	}
 	sock_addr_.sin_family      = AF_INET;
 	sock_addr_.sin_addr.s_addr = INADDR_ANY;
 	sock_addr_.sin_port        = htons(port_);


### PR DESCRIPTION
#25 の後に merge

- 再起動して動作中の port に socket を bind する時に発生するエラー `EADDRINUSE` を防ぐために設定する
- これにより server 起動 → ctrl+C などで停止 → 起動 した時に bind error になるのを防げる