### PR TITLE
[fix] server / readしたbufferをstd::stringに変換していなかったバグを修正

### DIFF
--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -77,7 +77,7 @@ void Server::SendResponseToClient(int client_fd) {
 		Debug("server", "disconnected client (fd: " + ToString(client_fd) + ")");
 		return;
 	}
-	const std::string response = CreateHttpResponse(buffer);
+	const std::string response = CreateHttpResponse(std::string(buffer, read_ret));
 	send(client_fd, response.c_str(), response.size(), 0);
 	Debug("server", "send to client (fd: " + ToString(client_fd) + ")");
 }


### PR DESCRIPTION
Issue #48

`make val`
してリクエストを処理した後に出る valgrind のエラー
```
==79537== Conditional jump or move depends on uninitialised value(s)
==79537==    at 0x484ED88: __strlen_sse2 (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==79537==    by 0x49B93F3: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==79537==    by 0x10DE22: Server::SendResponseToClient(int) (in /home/user42/Documents/42tokyo/webserv/42_webserv/webserv)
==79537==    by 0x10D884: Server::HandleEvent(Event) (in /home/user42/Documents/42tokyo/webserv/42_webserv/webserv)
==79537==    by 0x10D7A8: Server::Run() (in /home/user42/Documents/42tokyo/webserv/42_webserv/webserv)
==79537==    by 0x10AE09: main (in /home/user42/Documents/42tokyo/webserv/42_webserv/webserv)
==79537== 
```
原因は buffer の char[] を string に適切に変換できてなかったからっぽいです
1 行修正だけの PR です
これで valgrind が出してくれたエラーを修正できたと思います