### PR TITLE
[疑問・よければmerge] http request 内で path の中身を読み、content を返す

### DIFF
--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -19,23 +19,19 @@ void Http::ParseRequest(const std::string &read_buf) {
 }
 
 namespace {
-	bool FileExists(const std::string &file_path) {
+	std::string FileToString(const std::ifstream &file) {
+		std::stringstream ss;
+		ss << file.rdbuf();
+		return ss.str();
+	}
+
+	std::string ReadFile(const std::string &file_path) {
 		std::ifstream file(file_path.c_str());
-		return file.good();
-	}
-
-	std::ifstream open_file(const std::string &file_path) {
-		if (!FileExists(file_path)) {
-			return std::ifstream("html/404.html");
+		if (!file) {
+			std::ifstream error_file("html/404.html");
+			return FileToString(error_file);
 		}
-		return std::ifstream(file_path.c_str());
-	}
-
-	const std::string ReadFile(const std::string &file_path) {
-		std::ifstream     file = open_file(file_path);
-		std::stringstream buffer;
-		buffer << file.rdbuf();
-		return buffer.str();
+		return FileToString(file);
 	}
 } // namespace
 

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -1,5 +1,7 @@
 #include "http.hpp"
 #include "convert.hpp"
+#include <fstream>
+#include <sstream>
 
 Http::Http(const std::string &read_buf) {
 	ParseRequest(read_buf);
@@ -16,13 +18,30 @@ void Http::ParseRequest(const std::string &read_buf) {
 	request_[HTTP_PATH]   = "/html/index.html";
 }
 
+namespace {
+	bool FileExists(const std::string &file_path) {
+		std::ifstream file(file_path.c_str());
+		return file.good();
+	}
+
+	std::ifstream open_file(const std::string &file_path) {
+		if (!FileExists(file_path)) {
+			return std::ifstream("html/404.html");
+		}
+		return std::ifstream(file_path.c_str());
+	}
+
+	const std::string ReadFile(const std::string &file_path) {
+		std::ifstream     file = open_file(file_path);
+		std::stringstream buffer;
+		buffer << file.rdbuf();
+		return buffer.str();
+	}
+} // namespace
+
 // todo: tmp content
 void Http::ReadPathContent() {
-	const std::string path = request_[HTTP_PATH];
-	(void)path;
-	// todo: read path content
-	const std::string content = "<!DOCTYPE html><html<body><h1>Hello "
-								"from webserv!(tmp)</h1></body></html>";
+	const std::string content = ReadFile(request_[HTTP_PATH]);
 	request_[HTTP_CONTENT]    = content;
 	request_[HTTP_STATUS]     = "200";
 }


### PR DESCRIPTION
Issue #46 

## したこと
- [x] request_ (map) の中に入ってる path の中身を読み込んで content として request_ (map) に設定する

- #28 の `ReadFile()` をそのまま移植したらエラーが出てどこが原因かすぐ分からなかったです… 試したコミット →  d7e28a291d75716b926c57180726eff1b2a823bb
- なので 1 度だけ file を開いてその結果からエラーを判定するように変更してみました 44cb41ba3d5a79ef5a3c5258e12d6b34f49e23e3

何でそのまま移植したらエラーなのか調査したいかもなので一旦コミットで残しましたが、merge する時には 1 つに統合しても良いかもしれないです