### PR TITLE
[add] sandbox, test に Client class のベースを追加

### DIFF
--- a/sandbox/ab/client/Makefile
+++ b/sandbox/ab/client/Makefile
@@ -1,0 +1,59 @@
+NAME		:=	client
+
+SRCS		:=	client.cpp
+
+OBJ_DIR		:=	objs
+OBJS		:=	$(SRCS:%.cpp=$(OBJ_DIR)/%.o)
+
+INCLUDE_DIR	:=	includes
+INCLUDES	:=	-I./$(INCLUDE_DIR)/
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+#--------------------------------------------
+.PHONY	: all
+all		: $(NAME)
+
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+.PHONY	: run
+run: all
+	@./$(NAME)
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+.PHONY	: check
+check:
+	@cppcheck --enable=all $$(find . -type f -name "*.cpp" | tr '\n' ' ')
+
+#--------------------------------------------
+.PHONY	: req
+req:
+	echo -n "Hello from client" | nc 127.0.0.1 8080
+
+#--------------------------------------------
+
+-include $(DEPS)

--- a/sandbox/ab/client/client.cpp
+++ b/sandbox/ab/client/client.cpp
@@ -1,0 +1,49 @@
+#include <arpa/inet.h> // inet_pton,htons
+#include <cstdlib>
+#include <iostream>
+#include <netinet/in.h>
+#include <stdio.h>      // perror
+#include <sys/socket.h> // socket,connect
+#include <unistd.h>     // read,close
+
+#define PORT         8080
+#define BUFFER_SIZE  1024
+#define SYSTEM_ERROR (-1)
+
+int main() {
+	int                sock_fd = 0;
+	struct sockaddr_in sock_addr;
+	char               buffer[BUFFER_SIZE];
+	std::string        message = "Hello from client";
+
+	// socket
+	if ((sock_fd = socket(AF_INET, SOCK_STREAM, 0)) == SYSTEM_ERROR) {
+		perror("socket failed");
+		return EXIT_FAILURE;
+	}
+	sock_addr.sin_family = AF_INET;
+	sock_addr.sin_port   = htons(PORT);
+
+	// 指定された可読形式のIPアドレスをネットワークバイトオーダIPアドレスへ変換する
+	// IPアドレスが解釈不能の場合 return 0
+	if (inet_pton(AF_INET, "127.0.0.1", &sock_addr.sin_addr) <= 0) {
+		perror("inet_pton failed. Invalid address / Address not supported");
+		return EXIT_FAILURE;
+	}
+
+	// sockfdに指定されたアクティブソケットを、addrおよびaddrlenに指定されたアドレスのリスニングソケットへ接続
+	if (connect(sock_fd, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) ==
+		SYSTEM_ERROR) {
+		perror("connect failed");
+		return EXIT_FAILURE;
+	}
+
+	send(sock_fd, message.c_str(), message.length(), 0);
+	std::cout << "Message sent" << std::endl;
+
+	ssize_t read_ret = read(sock_fd, buffer, BUFFER_SIZE);
+	std::cout << "Echo from server: " << std::string(buffer, read_ret) << std::endl;
+
+	close(sock_fd);
+	return EXIT_SUCCESS;
+}

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -1,0 +1,60 @@
+NAME		:=	client
+
+SRCS		:=	client.cpp \
+				main.cpp
+
+OBJ_DIR		:=	objs
+OBJS		:=	$(SRCS:%.cpp=$(OBJ_DIR)/%.o)
+
+INCLUDE_DIR	:=	includes
+INCLUDES	:=	-I./$(INCLUDE_DIR)/
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+#--------------------------------------------
+.PHONY	: all
+all		: $(NAME)
+
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+.PHONY	: run
+run: all
+	@./$(NAME)
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+.PHONY	: check
+check:
+	@cppcheck --enable=all $$(find . -type f -name "*.cpp" | tr '\n' ' ')
+
+#--------------------------------------------
+.PHONY	: req
+req:
+	echo -n "Hello from client" | nc 127.0.0.1 8080
+
+#--------------------------------------------
+
+-include $(DEPS)

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -1,0 +1,86 @@
+#include "client.hpp"
+#include <arpa/inet.h> // inet_pton,htons
+#include <cstring>     // strlen
+#include <iostream>
+#include <stdio.h>      // perror
+#include <sys/socket.h> // socket,connect
+#include <sys/types.h>
+#include <unistd.h> // read,close
+
+const std::string Client::DEFAULT_MESSAGE = "Hello from client (default)";
+
+Client::Client() : port_(DEFAULT_PORT), request_message_(DEFAULT_MESSAGE) {
+	Init();
+}
+
+Client::Client(int port) : port_(port), request_message_(DEFAULT_MESSAGE) {
+	Init();
+}
+
+Client::Client(const std::string &message)
+	: port_(DEFAULT_PORT), request_message_(message) {
+	Init();
+}
+
+Client::Client(int port, const std::string &message)
+	: port_(port), request_message_(message) {
+	Init();
+}
+
+Client::~Client() {
+	if (sock_fd_ != SYSTEM_ERROR) {
+		close(sock_fd_);
+	}
+}
+
+namespace {
+	static const std::string COLOR_GRAY  = "\033[30m";
+	static const std::string COLOR_RESET = "\033[0m";
+
+	void DebugPrint(const std::string &s) {
+		std::cerr << COLOR_GRAY << s << COLOR_RESET << std::endl;
+	}
+} // namespace
+
+void Client::SetMessage(const std::string &message) {
+	request_message_ = message;
+}
+
+void Client::SendRequestAndReceiveResponse() {
+	// send request message
+	send(sock_fd_, request_message_.c_str(), request_message_.size(), 0);
+	DebugPrint("Message sent.");
+
+	// read response
+	static const unsigned int BUFFER_SIZE = 1024;
+	char                      buffer[BUFFER_SIZE];
+
+	ssize_t read_ret = read(sock_fd_, buffer, BUFFER_SIZE);
+	if (read_ret == SYSTEM_ERROR) {
+		throw std::runtime_error("read failed");
+	}
+	DebugPrint("Response from server:");
+	std::cout << std::string(buffer, read_ret) << std::endl;
+}
+
+void Client::Init() {
+	// socket
+	if ((sock_fd_ = socket(AF_INET, SOCK_STREAM, 0)) == SYSTEM_ERROR) {
+		throw std::runtime_error("socket failed");
+	}
+	sock_addr_.sin_family = AF_INET;
+	sock_addr_.sin_port   = htons(port_);
+
+	// convert address
+	if (inet_pton(AF_INET, "127.0.0.1", &sock_addr_.sin_addr) <= 0) {
+		throw std::runtime_error(
+			"inet_pton failed. Invalid address / Address not supported"
+		);
+	}
+
+	// connect sock_fd & sock_addr_
+	if (connect(sock_fd_, (struct sockaddr *)&sock_addr_, sizeof(sock_addr_)) ==
+		SYSTEM_ERROR) {
+		throw std::runtime_error("connect failed");
+	}
+}

--- a/test/client/client.hpp
+++ b/test/client/client.hpp
@@ -1,0 +1,33 @@
+#ifndef TEST_CLIENT_HPP_
+#define TEST_CLIENT_HPP_
+
+#include <netinet/in.h> // struct sockaddr_in
+#include <string>
+
+class Client {
+  public:
+	Client();
+	explicit Client(int port);
+	explicit Client(const std::string &message);
+	Client(int port, const std::string &message);
+	~Client();
+	void SetMessage(const std::string &message);
+	void SendRequestAndReceiveResponse();
+
+  private:
+	// prohibit copy
+	Client(const Client &other);
+	Client &operator=(const Client &other);
+	void    Init();
+	// const
+	static const int          SYSTEM_ERROR = -1;
+	static const unsigned int DEFAULT_PORT = 8080;
+	static const std::string  DEFAULT_MESSAGE;
+	// socket
+	unsigned int       port_;
+	std::string        request_message_;
+	int                sock_fd_;
+	struct sockaddr_in sock_addr_;
+};
+
+#endif /* TEST_CLIENT_HPP_ */

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -1,0 +1,30 @@
+#include "client.hpp"
+#include <cstdlib>
+#include <cstring> // strlen
+#include <iostream>
+
+namespace {
+	static const std::string COLOR_RED   = "\033[31m";
+	static const std::string COLOR_RESET = "\033[0m";
+
+	void PrintError(const std::string &s) {
+		std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
+	}
+} // namespace
+
+// default message  : ./client
+// original message : ./client "request message"
+int main(int argc, char **argv) {
+	try {
+		Client client;
+		if (argc > 1) {
+			const std::string message = std::string(argv[1], std::strlen(argv[1]));
+			client.SetMessage(message);
+		}
+		client.SendRequestAndReceiveResponse();
+	} catch (const std::exception &e) {
+		PrintError(e.what());
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## したこと
test 用に、多分すごい基本的な client を以下に追加しました
- `sanbox/ab/` にかなりざっくり書いた client
- `test/client/` に class で書いてみた client (とそれを実行するための main, Makefile)
  - コマンドライン引数から `request message` を渡せる (引数なしの場合はコード内で定義した default message )


全然変えてしまって大丈夫です！
こんな感じの Client class をベースに色んな client を作れるように変えていければと思いました

## してないこと
- `IP address` ・`port` を外部から設定可能にする (今はコード内で固定なものを使ってるだけです)
- 今は `BUFFER_SIZE `が 1024 で固定です。それより多い response はまだ対応してません
- Makefile に make client とかで test/client/ の make run が実行されるようにする

## 実行
```shell
# server
make run

# client
cd test/client

# コード内で定義した default message を送る
# make run も同じ
./client

# 引数を request message として送る
./client "request message"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいC++クライアントプログラムのビルドプロセスを設定するMakefileを追加しました。
  - 基本的なTCPクライアントを実装する`client.cpp`ファイルを追加しました。
  - クライアントアプリケーションのビルドと実行のためのMakefileルールを追加しました。
  - クライアントとサーバー間の通信を容易にする`Client`クラスを導入しました。

- **改善点**
  - メモリチェックのためのValgrindターゲットを追加しました。
  - 静的コード解析のためのcppcheckターゲットを追加しました。

- **バグ修正**
  - エラー処理と色分けされたエラーメッセージを提供する`main.cpp`を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->