### PR TITLE
[add] SplitStr()のunit test追加。それに関連した修正

### DIFF
--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -16,10 +16,10 @@ namespace {
 
 // todo: tmp request_
 void Http::ParseRequest(const std::string &read_buf) {
-	const std::vector<std::string> lines      = SplitStr(read_buf, "\r\n");
+	const std::vector<std::string> lines      = utils::SplitStr(read_buf, "\r\n");
 	const std::string              start_line = lines[0];
 
-	const std::vector<std::string> request_line = SplitStr(start_line, " ");
+	const std::vector<std::string> request_line = utils::SplitStr(start_line, " ");
 	// set request-line(method, request-target, HTTP-version)
 	request_[HTTP_METHOD]         = request_line[0];
 	request_[HTTP_REQUEST_TARGET] = CreateDefaultPath(request_line[1]);

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -4,20 +4,22 @@ namespace utils {
 	std::vector<std::string>
 	SplitStr(const std::string &src, const std::string &substring) {
 		std::vector<std::string> split_str;
+		const std::size_t        src_size    = src.size();
+		const std::size_t        substr_size = substring.size();
 
-		if (substring.size() == 0) {
+		if (substr_size == 0) {
 			split_str.push_back(src);
 			return split_str;
 		}
 		std::size_t start = 0;
-		while (start <= src.size()) {
+		while (start <= src_size) {
 			const std::string::size_type pos = src.find(substring, start);
 			if (pos == std::string::npos) {
 				split_str.push_back(src.substr(start));
 				break;
 			}
 			split_str.push_back(src.substr(start, pos - start));
-			start = pos + substring.size();
+			start = pos + substr_size;
 		}
 		return split_str;
 	}

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -10,7 +10,7 @@ namespace utils {
 			return split_str;
 		}
 		std::size_t start = 0;
-		while (start < src.size()) {
+		while (start <= src.size()) {
 			const std::string::size_type pos = src.find(substring, start);
 			if (pos == std::string::npos) {
 				split_str.push_back(src.substr(start));

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -1,17 +1,20 @@
 #include "split.hpp"
 
-std::vector<std::string> SplitStr(const std::string &str, const std::string &delim) {
-	std::vector<std::string> split_str;
+namespace utils {
+	std::vector<std::string>
+	SplitStr(const std::string &str, const std::string &delim) {
+		std::vector<std::string> split_str;
 
-	std::size_t start = 0;
-	while (start < str.size()) {
-		const std::string::size_type pos = str.find(delim, start);
-		if (pos == std::string::npos) {
-			split_str.push_back(str.substr(start));
-			break;
+		std::size_t start = 0;
+		while (start < str.size()) {
+			const std::string::size_type pos = str.find(delim, start);
+			if (pos == std::string::npos) {
+				split_str.push_back(str.substr(start));
+				break;
+			}
+			split_str.push_back(str.substr(start, pos - start));
+			start = pos + delim.size();
 		}
-		split_str.push_back(str.substr(start, pos - start));
-		start = pos + delim.size();
+		return split_str;
 	}
-	return split_str;
-}
+} // namespace utils

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -5,6 +5,10 @@ namespace utils {
 	SplitStr(const std::string &str, const std::string &delim) {
 		std::vector<std::string> split_str;
 
+		if (delim.size() == 0) {
+			split_str.push_back(str);
+			return split_str;
+		}
 		std::size_t start = 0;
 		while (start < str.size()) {
 			const std::string::size_type pos = str.find(delim, start);

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -2,22 +2,22 @@
 
 namespace utils {
 	std::vector<std::string>
-	SplitStr(const std::string &str, const std::string &delim) {
+	SplitStr(const std::string &src, const std::string &substring) {
 		std::vector<std::string> split_str;
 
-		if (delim.size() == 0) {
-			split_str.push_back(str);
+		if (substring.size() == 0) {
+			split_str.push_back(src);
 			return split_str;
 		}
 		std::size_t start = 0;
-		while (start < str.size()) {
-			const std::string::size_type pos = str.find(delim, start);
+		while (start < src.size()) {
+			const std::string::size_type pos = src.find(substring, start);
 			if (pos == std::string::npos) {
-				split_str.push_back(str.substr(start));
+				split_str.push_back(src.substr(start));
 				break;
 			}
-			split_str.push_back(str.substr(start, pos - start));
-			start = pos + delim.size();
+			split_str.push_back(src.substr(start, pos - start));
+			start = pos + substring.size();
 		}
 		return split_str;
 	}

--- a/srcs/utils/split.hpp
+++ b/srcs/utils/split.hpp
@@ -4,6 +4,9 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> SplitStr(const std::string &str, const std::string &delim);
+namespace utils {
+	std::vector<std::string>
+	SplitStr(const std::string &str, const std::string &delim);
+}
 
 #endif /* UTILS_SPLIT_HPP_ */

--- a/srcs/utils/split.hpp
+++ b/srcs/utils/split.hpp
@@ -6,7 +6,7 @@
 
 namespace utils {
 	std::vector<std::string>
-	SplitStr(const std::string &str, const std::string &delim);
+	SplitStr(const std::string &src, const std::string &substring);
 }
 
 #endif /* UTILS_SPLIT_HPP_ */

--- a/test/unit/split/Makefile
+++ b/test/unit/split/Makefile
@@ -1,0 +1,56 @@
+NAME		:=	a.out
+
+TARGET_DIR	:=	../../../srcs/utils
+
+SRCS		:=	main.cpp \
+				$(TARGET_DIR)/split.cpp \
+				$(TARGET_DIR)/color.cpp
+
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	-I$(TARGET_DIR)/
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+#--------------------------------------------
+.PHONY	: all
+all		: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(OBJ_DIR)/%.o: $(TARGET_DIR)/%.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+.PHONY	: run
+run: all
+	@./$(NAME)
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -52,10 +52,15 @@ namespace {
 	// SplitStr()を実行してexpectedと比較
 	void
 	Run(const std::string &src, const std::string &substring, const Strs &expected) {
+		static unsigned int test_case = 0;
+		test_case++;
+
 		if (IsSame(utils::SplitStr(src, substring), expected)) {
-			std::cerr << COLOR_GREEN << "[OK] " << COLOR_RESET << src << std::endl;
+			std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src
+					  << std::endl;
 		} else {
-			std::cerr << COLOR_RED << "[NG] " << COLOR_RESET << src << std::endl;
+			std::cerr << COLOR_RED << test_case << ".[NG] " << COLOR_RESET << src
+					  << std::endl;
 			throw std::logic_error("SplitStr()");
 		}
 	}

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -1,8 +1,6 @@
 #include "color.hpp"
 #include "split.hpp"
-#include <cstdarg> // va_list
 #include <cstdlib>
-#include <cstring> // strlen
 #include <iostream>
 #include <stdexcept> // logic_error
 #include <string>
@@ -12,23 +10,10 @@ namespace {
 	typedef std::vector<std::string> Strs;
 
 	// expectedのStrsを作成
-	// templateのパラメータパックがc++11以降で使用不可なのでva_listを使用
+	// templateのパラメータパックがc++11以降なので使っていない
 	// 手動で正しいsizeをセットする必要有り
-	Strs CreateExpect(std::size_t size, const char *head, ...) {
-		Strs ret;
-
-		if (size == 0) {
-			return ret;
-		}
-		ret.push_back(std::string(head, std::strlen(head)));
-		std::va_list args;
-		va_start(args, head);
-		for (std::size_t i = 0; i + 1 < size; i++) {
-			const char *arg = va_arg(args, const char *);
-			ret.push_back(std::string(arg, std::strlen(arg)));
-		}
-		va_end(args);
-		return ret;
+	Strs CreateExpect(const std::string *array, std::size_t size) {
+		return Strs(array, array + size);
 	}
 
 	// SplitStr()の結果とexpectedを比較(他でも使用できそうなのでtemplateにしてみている)
@@ -72,51 +57,80 @@ int main() {
 		// test for SP(" "). substring:1文字
 		// ---------------------------------------------------------------------
 		// substringのみのstr
-		Run(" ", " ", CreateExpect(2, "", ""));
-		Run("  ", " ", CreateExpect(3, "", "", ""));
-		// substringがstrの中にない
-		Run("", " ", CreateExpect(1, ""));
-		Run("abbccc", " ", CreateExpect(1, "abbccc"));
+		const std::string expected_1[] = {"", ""};
+		Run(" ", " ", CreateExpect(expected_1, 2));
+		const std::string expected_2[] = {"", "", ""};
+		Run("  ", " ", CreateExpect(expected_2, 3));
+
+		// // substringがstrの中にない
+		const std::string expected_3[] = {""};
+		Run("", " ", CreateExpect(expected_3, 1));
+		const std::string expected_4[] = {"abbccc"};
+		Run("abbccc", " ", CreateExpect(expected_4, 1));
+
 		// substringが1つずつ
-		Run("a bb ccc", " ", CreateExpect(3, "a", "bb", "ccc"));
+		const std::string expected_5[] = {"a", "bb", "ccc"};
+		Run("a bb ccc", " ", CreateExpect(expected_5, 3));
 		// substringが連続
-		Run("abb   ccc", " ", CreateExpect(4, "abb", "", "", "ccc"));
+		const std::string expected_6[] = {"abb", "", "", "ccc"};
+		Run("abb   ccc", " ", CreateExpect(expected_6, 4));
+
 		// 先頭にsubstring
-		Run("  abbccc", " ", CreateExpect(3, "", "", "abbccc"));
+		const std::string expected_7[] = {"", "", "abbccc"};
+		Run("  abbccc", " ", CreateExpect(expected_7, 3));
 		// 末尾にsubstring
-		Run("abbccc ", " ", CreateExpect(2, "abbccc", ""));
+		const std::string expected_8[] = {"abbccc", ""};
+		Run("abbccc ", " ", CreateExpect(expected_8, 2));
 		// 前後にsubstring
-		Run(" abbccc   ", " ", CreateExpect(5, "", "abbccc", "", "", ""));
+		const std::string expected_9[] = {"", "abbccc", "", "", ""};
+		Run(" abbccc   ", " ", CreateExpect(expected_9, 5));
 
 		// ---------------------------------------------------------------------
 		// test for CRLF("\r\n"). substring:2文字
 		// ---------------------------------------------------------------------
 		// substringのみのstr
-		Run("\r\n", "\r\n", CreateExpect(2, "", ""));
-		Run("\r\n\r\n", "\r\n", CreateExpect(3, "", "", ""));
+		const std::string expected_10[] = {"", ""};
+		Run("\r\n", "\r\n", CreateExpect(expected_10, 2));
+		const std::string expected_11[] = {"", "", ""};
+		Run("\r\n\r\n", "\r\n", CreateExpect(expected_11, 3));
+
 		// substringがstrの中にない
-		Run("", "\r\n", CreateExpect(1, ""));
-		Run("abbccc", "\r\n", CreateExpect(1, "abbccc"));
+		const std::string expected_12[] = {""};
+		Run("", "\r\n", CreateExpect(expected_12, 1));
+		const std::string expected_13[] = {"abbccc"};
+		Run("abbccc", "\r\n", CreateExpect(expected_13, 1));
+
 		// substringが1つずつ
-		Run("a\r\nbb\r\nccc", "\r\n", CreateExpect(3, "a", "bb", "ccc"));
+		const std::string expected_14[] = {"a", "bb", "ccc"};
+		Run("a\r\nbb\r\nccc", "\r\n", CreateExpect(expected_14, 3));
 		// substringが連続
-		Run("abb\r\n\r\nccc", "\r\n", CreateExpect(3, "abb", "", "ccc"));
+		const std::string expected_15[] = {"abb", "", "ccc"};
+		Run("abb\r\n\r\nccc", "\r\n", CreateExpect(expected_15, 3));
+
 		// 先頭にsubstring
-		Run("\r\nabbccc", "\r\n", CreateExpect(2, "", "abbccc"));
+		const std::string expected_16[] = {"", "abbccc"};
+		Run("\r\nabbccc", "\r\n", CreateExpect(expected_16, 2));
 		// 末尾にsubstring
-		Run("abbccc\r\n", "\r\n", CreateExpect(2, "abbccc", ""));
+		const std::string expected_17[] = {"abbccc", ""};
+		Run("abbccc\r\n", "\r\n", CreateExpect(expected_17, 2));
 		// 前後にsubstring
-		Run("\r\nabbccc\r\n\r\n", "\r\n", CreateExpect(4, "", "abbccc", "", ""));
+		const std::string expected_18[] = {"", "abbccc", "", ""};
+		Run("\r\nabbccc\r\n\r\n", "\r\n", CreateExpect(expected_18, 4));
+
 		// substringの中のcharがあっても何も起こらない
-		Run("a\rbb\r\nccc", "\r\n", CreateExpect(2, "a\rbb", "ccc"));
-		Run("a\nbb\r\nccc", "\r\n", CreateExpect(2, "a\nbb", "ccc"));
+		const std::string expected_19[] = {"a\rbb", "ccc"};
+		Run("a\rbb\r\nccc", "\r\n", CreateExpect(expected_19, 2));
+		const std::string expected_20[] = {"a\nbb", "ccc"};
+		Run("a\nbb\r\nccc", "\r\n", CreateExpect(expected_20, 2));
 
 		// ---------------------------------------------------------------------
 		// test for another case
 		// ---------------------------------------------------------------------
 		// substringが空文字列
-		Run("", "", CreateExpect(1, ""));
-		Run("abc", "", CreateExpect(1, "abc"));
+		const std::string expected_21[] = {""};
+		Run("", "", CreateExpect(expected_21, 1));
+		const std::string expected_22[] = {"abc"};
+		Run("abc", "", CreateExpect(expected_22, 1));
 
 	} catch (const std::exception &e) {
 		std::cerr << COLOR_RED << "Error: " << e.what() << COLOR_RESET << std::endl;

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -16,31 +16,13 @@ namespace {
 		return Strs(array, array + size);
 	}
 
-	// SplitStr()の結果とexpectedを比較(他でも使用できそうなのでtemplateにしてみている)
-	template <typename T>
-	bool IsSame(const T &a, const T &b) {
-		if (a.size() != b.size()) {
-			return false;
-		}
-		typename T::const_iterator it_a = a.begin();
-		typename T::const_iterator it_b = b.begin();
-		while (it_a != a.end()) {
-			if (*it_a != *it_b) {
-				return false;
-			}
-			++it_a;
-			++it_b;
-		}
-		return true;
-	}
-
 	// SplitStr()を実行してexpectedと比較
 	void
 	Run(const std::string &src, const std::string &substring, const Strs &expected) {
 		static unsigned int test_case = 0;
 		test_case++;
 
-		if (IsSame(utils::SplitStr(src, substring), expected)) {
+		if (utils::SplitStr(src, substring) == expected) {
 			std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src
 					  << std::endl;
 		} else {

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -1,0 +1,121 @@
+#include "color.hpp"
+#include "split.hpp"
+#include <cstdarg> // va_list
+#include <cstdlib>
+#include <cstring> // strlen
+#include <iostream>
+#include <stdexcept> // logic_error
+#include <string>
+
+namespace {
+	// 比較する型
+	typedef std::vector<std::string> Strs;
+
+	// expectedのStrsを作成
+	// templateのパラメータパックがc++11以降で使用不可なのでva_listを使用
+	// 手動で正しいsizeをセットする必要有り
+	Strs CreateExpect(std::size_t size, const char *head, ...) {
+		Strs ret;
+
+		if (size == 0) {
+			return ret;
+		}
+		ret.push_back(std::string(head, std::strlen(head)));
+		std::va_list args;
+		va_start(args, head);
+		for (std::size_t i = 0; i + 1 < size; i++) {
+			const char *arg = va_arg(args, const char *);
+			ret.push_back(std::string(arg, std::strlen(arg)));
+		}
+		va_end(args);
+		return ret;
+	}
+
+	// SplitStr()の結果とexpectedを比較(他でも使用できそうなのでtemplateにしてみている)
+	template <typename T>
+	bool IsSame(const T &a, const T &b) {
+		if (a.size() != b.size()) {
+			return false;
+		}
+		typename T::const_iterator it_a = a.begin();
+		typename T::const_iterator it_b = b.begin();
+		while (it_a != a.end()) {
+			if (*it_a != *it_b) {
+				return false;
+			}
+			++it_a;
+			++it_b;
+		}
+		return true;
+	}
+
+	// SplitStr()を実行してexpectedと比較
+	void
+	Run(const std::string &src, const std::string &substring, const Strs &expected) {
+		if (IsSame(utils::SplitStr(src, substring), expected)) {
+			std::cerr << COLOR_GREEN << "[OK] " << COLOR_RESET << src << std::endl;
+		} else {
+			std::cerr << COLOR_RED << "[NG] " << COLOR_RESET << src << std::endl;
+			throw std::logic_error("SplitStr()");
+		}
+	}
+} // namespace
+
+int main() {
+	try {
+		// ---------------------------------------------------------------------
+		// test for SP(" "). substring:1文字
+		// ---------------------------------------------------------------------
+		// substringのみのstr
+		Run(" ", " ", CreateExpect(2, "", ""));
+		Run("  ", " ", CreateExpect(3, "", "", ""));
+		// substringがstrの中にない
+		Run("", " ", CreateExpect(1, ""));
+		Run("abbccc", " ", CreateExpect(1, "abbccc"));
+		// substringが1つずつ
+		Run("a bb ccc", " ", CreateExpect(3, "a", "bb", "ccc"));
+		// substringが連続
+		Run("abb   ccc", " ", CreateExpect(4, "abb", "", "", "ccc"));
+		// 先頭にsubstring
+		Run("  abbccc", " ", CreateExpect(3, "", "", "abbccc"));
+		// 末尾にsubstring
+		Run("abbccc ", " ", CreateExpect(2, "abbccc", ""));
+		// 前後にsubstring
+		Run(" abbccc   ", " ", CreateExpect(5, "", "abbccc", "", "", ""));
+
+		// ---------------------------------------------------------------------
+		// test for CRLF("\r\n"). substring:2文字
+		// ---------------------------------------------------------------------
+		// substringのみのstr
+		Run("\r\n", "\r\n", CreateExpect(2, "", ""));
+		Run("\r\n\r\n", "\r\n", CreateExpect(3, "", "", ""));
+		// substringがstrの中にない
+		Run("", "\r\n", CreateExpect(1, ""));
+		Run("abbccc", "\r\n", CreateExpect(1, "abbccc"));
+		// substringが1つずつ
+		Run("a\r\nbb\r\nccc", "\r\n", CreateExpect(3, "a", "bb", "ccc"));
+		// substringが連続
+		Run("abb\r\n\r\nccc", "\r\n", CreateExpect(3, "abb", "", "ccc"));
+		// 先頭にsubstring
+		Run("\r\nabbccc", "\r\n", CreateExpect(2, "", "abbccc"));
+		// 末尾にsubstring
+		Run("abbccc\r\n", "\r\n", CreateExpect(2, "abbccc", ""));
+		// 前後にsubstring
+		Run("\r\nabbccc\r\n\r\n", "\r\n", CreateExpect(4, "", "abbccc", "", ""));
+		// substringの中のcharがあっても何も起こらない
+		Run("a\rbb\r\nccc", "\r\n", CreateExpect(2, "a\rbb", "ccc"));
+		Run("a\nbb\r\nccc", "\r\n", CreateExpect(2, "a\nbb", "ccc"));
+
+		// ---------------------------------------------------------------------
+		// test for another case
+		// ---------------------------------------------------------------------
+		// substringが空文字列
+		Run("", "", CreateExpect(1, ""));
+		Run("abc", "", CreateExpect(1, "abc"));
+
+	} catch (const std::exception &e) {
+		std::cerr << COLOR_RED << "Error: " << e.what() << COLOR_RESET << std::endl;
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## したこと
- [x] `SplitStr()` の unit test 追加

```shell
cd test/unit/split
make run
```

<br>

関連した修正・変更
`SplitStr()`
- [x] namespace utils で囲う
- [x] `find()` の delimiter に 空文字列`""` が来た場合の処理を追加
- [x] `find()` は delimiter じゃなくて部分文字列だったので、変数名を substring に変更
- [x] src の最後に substring がある場合に空文字列を追加できていなかったので修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - `SplitStr`関数を`utils`名前空間に移動し、パラメータ名を更新。
  - `Http::ParseRequest`メソッドで`utils::SplitStr`を使用するように変更。

- **テスト**
  - `SplitStr`関数のテストを更新し、期待される出力を検証するための新しいシナリオを追加。
  - テスト用の`Makefile`を更新し、ビルドプロセスを改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->