### PR TITLE
[add] http-message で使う const string を定義して反映する

### DIFF
--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -16,7 +16,7 @@ class Http {
 		HTTP_STATUS_TEXT
 	};
 	typedef std::map<MessageType, std::string> RequestMessage;
-	Http(const std::string &read_buf);
+	explicit Http(const std::string &read_buf);
 	~Http();
 	std::string CreateResponse();
 

--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -1,4 +1,7 @@
 #include "http_message.hpp"
 
-const std::string SP   = " ";
-const std::string CRLF = "\r\n";
+const std::string SP             = " ";
+const std::string CRLF           = "\r\n";
+const std::string HTTP_VERSION   = "HTTP/1.1";
+const std::string CONNECTION     = "Connection";
+const std::string CONTENT_LENGTH = "Content-Length";

--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -1,4 +1,4 @@
-#include "character.hpp"
+#include "http_message.hpp"
 
 const std::string SP   = " ";
 const std::string CRLF = "\r\n";

--- a/srcs/http/http_message.hpp
+++ b/srcs/http/http_message.hpp
@@ -5,5 +5,8 @@
 
 extern const std::string SP;
 extern const std::string CRLF;
+extern const std::string HTTP_VERSION;
+extern const std::string CONNECTION;
+extern const std::string CONTENT_LENGTH;
 
 #endif /* HTTP_MESSAGE_HPP_ */

--- a/srcs/http/http_message.hpp
+++ b/srcs/http/http_message.hpp
@@ -1,0 +1,9 @@
+#ifndef HTTP_MESSAGE_HPP_
+#define HTTP_MESSAGE_HPP_
+
+#include <string>
+
+extern const std::string SP;
+extern const std::string CRLF;
+
+#endif /* HTTP_MESSAGE_HPP_ */

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -1,4 +1,5 @@
 #include "http.hpp"
+#include "http_message.hpp"
 #include "split.hpp"
 #include <vector>
 
@@ -16,10 +17,10 @@ namespace {
 
 // todo: tmp request_
 void Http::ParseRequest(const std::string &read_buf) {
-	const std::vector<std::string> lines      = SplitStr(read_buf, "\r\n");
+	const std::vector<std::string> lines      = SplitStr(read_buf, CRLF);
 	const std::string              start_line = lines[0];
 
-	const std::vector<std::string> request_line = SplitStr(start_line, " ");
+	const std::vector<std::string> request_line = SplitStr(start_line, SP);
 	// set request-line(method, request-target, HTTP-version)
 	request_[HTTP_METHOD]         = request_line[0];
 	request_[HTTP_REQUEST_TARGET] = CreateDefaultPath(request_line[1]);

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -1,5 +1,3 @@
-#include "convert.hpp" // use ToString()
-#include "debug.hpp"   // tmp to do
 #include "http.hpp"
 #include "http_message.hpp"
 #include <iostream>
@@ -13,10 +11,9 @@ namespace http_response {
 						<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
 	}
 
+	template <typename T>
 	void CreateHeaderField(
-		std::ostream      &response_stream,
-		const std::string &name,
-		const std::string &value
+		std::ostream &response_stream, const std::string &name, const T &value
 	) {
 		response_stream << name << ":" << SP << value << SP << CRLF;
 	}
@@ -26,9 +23,7 @@ namespace http_response {
 	) {
 		CreateHeaderField(response_stream, CONNECTION, "close");
 		CreateHeaderField(
-			response_stream,
-			CONTENT_LENGTH,
-			ToString(request.at(Http::HTTP_CONTENT).size())
+			response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size()
 		);
 	}
 

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -10,7 +10,7 @@ namespace http_response {
 		std::ostream &response_stream, const Http::RequestMessage &request
 	) {
 		response_stream << "HTTP/1.1" << SP << request.at(Http::HTTP_STATUS) << SP
-						<< request.at(Http::HTTP_STATUS_TEXT) << CR << LF;
+						<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
 	}
 
 	void CreateHeaderField(
@@ -18,7 +18,7 @@ namespace http_response {
 		const std::string &name,
 		const std::string &value
 	) {
-		response_stream << name << ":" << SP << value << SP << CR << LF;
+		response_stream << name << ":" << SP << value << SP << CRLF;
 	}
 
 	void CreateHeaderFields(
@@ -33,7 +33,7 @@ namespace http_response {
 	}
 
 	void CreateCRLF(std::ostream &response_stream) {
-		response_stream << CR << LF;
+		response_stream << CRLF;
 	}
 
 	void

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -9,7 +9,7 @@ namespace http_response {
 	void CreateStatusLine(
 		std::ostream &response_stream, const Http::RequestMessage &request
 	) {
-		response_stream << "HTTP/1.1" << SP << request.at(Http::HTTP_STATUS) << SP
+		response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
 						<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
 	}
 
@@ -24,10 +24,10 @@ namespace http_response {
 	void CreateHeaderFields(
 		std::ostream &response_stream, const Http::RequestMessage &request
 	) {
-		CreateHeaderField(response_stream, "Connection", "close");
+		CreateHeaderField(response_stream, CONNECTION, "close");
 		CreateHeaderField(
 			response_stream,
-			"Content-Length",
+			CONTENT_LENGTH,
 			ToString(request.at(Http::HTTP_CONTENT).size())
 		);
 	}

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -1,7 +1,7 @@
-#include "character.hpp"
 #include "convert.hpp" // use ToString()
 #include "debug.hpp"   // tmp to do
 #include "http.hpp"
+#include "http_message.hpp"
 #include <iostream>
 #include <sstream>
 

--- a/srcs/http/utils/character.cpp
+++ b/srcs/http/utils/character.cpp
@@ -1,5 +1,4 @@
 #include "character.hpp"
 
-const char SP = 0x20;
-const char CR = 0x0D;
-const char LF = 0x0A;
+const std::string SP   = " ";
+const std::string CRLF = "\r\n";

--- a/srcs/http/utils/character.hpp
+++ b/srcs/http/utils/character.hpp
@@ -1,9 +1,0 @@
-#ifndef HTTP_UTILS_CHARACTER_HPP_
-#define HTTP_UTILS_CHARACTER_HPP_
-
-#include <string>
-
-extern const std::string SP;
-extern const std::string CRLF;
-
-#endif /* HTTP_UTILS_CHARACTER_HPP_ */

--- a/srcs/http/utils/character.hpp
+++ b/srcs/http/utils/character.hpp
@@ -1,8 +1,9 @@
 #ifndef HTTP_UTILS_CHARACTER_HPP_
 #define HTTP_UTILS_CHARACTER_HPP_
 
-extern const char SP;
-extern const char CR;
-extern const char LF;
+#include <string>
+
+extern const std::string SP;
+extern const std::string CRLF;
 
 #endif /* HTTP_UTILS_CHARACTER_HPP_ */


### PR DESCRIPTION
## したこと
- http-message
- [x] `SP`, `CRLF`, `Content-Length` などの http-message で使う文字列を定義 (随時必要になったものを追加していく)
- [x] `character.{cpp, hpp}` のファイル名を変更
<br>

- http-request, http-response
- [x] char やリテラルで書いていた箇所を http_message.hpp に定義した string を使って統一
<br>

- ついでに細かい http 関係の修正
- [x] コンストラクタに explicit 追加
- [x] `CreateHeaderField()` の `value` を template に変更




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - HTTPリクエストの解析ロジックを更新し、ハードコードされた区切り文字の代わりに事前定義された定数を使用するよう変更しました。

- **リファクタリング**
  - HTTPレスポンス作成プロセスを更新し、HTTPバージョンやヘッダー、行末の定数を使用するように変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->