### PR TITLE
[add] BUFFER_SIZE より大きな request 処理 (nonblocking用)

### DIFF
--- a/srcs/buffer.cpp
+++ b/srcs/buffer.cpp
@@ -1,0 +1,30 @@
+#include "buffer.hpp"
+#include <stdio.h>  // perror
+#include <unistd.h> // read
+
+Buffer::Buffer() {}
+
+Buffer::~Buffer() {}
+
+ssize_t Buffer::Read(int fd) {
+	char buffer[BUFFER_SIZE];
+
+	ssize_t read_ret = read(fd, buffer, BUFFER_SIZE);
+	if (read_ret <= 0) {
+		if (read_ret == SYSTEM_ERROR) {
+			perror("read failed");
+		}
+		return read_ret;
+	}
+	buffers_[fd] += std::string(buffer, read_ret);
+	return read_ret;
+}
+
+void Buffer::Delete(int fd) {
+	buffers_[fd].erase();
+}
+
+std::string Buffer::GetBuffer(int fd) const {
+	// todo: fd error handle
+	return buffers_.at(fd);
+}

--- a/srcs/buffer.hpp
+++ b/srcs/buffer.hpp
@@ -1,0 +1,30 @@
+#ifndef SERVER_BUFFER_HPP_
+#define SERVER_BUFFER_HPP_
+
+#include "debug.hpp" // todo: tmp
+#include <map>
+#include <string>
+#include <sys/types.h> // ssize_t
+
+class Buffer {
+  public:
+	// int: fd, std::string: buffer
+	typedef std::map<int, std::string> Buffers;
+	Buffer();
+	~Buffer();
+	ssize_t     Read(int fd);
+	void        Delete(int fd);
+	std::string GetBuffer(int fd) const;
+
+  private:
+	// prohibit copy
+	Buffer(const Buffer &other);
+	Buffer &operator=(const Buffer &other);
+	// const
+	static const int          SYSTEM_ERROR = -1;
+	static const unsigned int BUFFER_SIZE  = 1024;
+	// request buffers
+	Buffers buffers_;
+};
+
+#endif /* SERVER_BUFFER_HPP_ */

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -28,6 +28,26 @@ namespace {
 		}
 		return ret_type;
 	}
+
+	uint32_t ConvertToEventType(uint32_t event) {
+		uint32_t ret_type = EVENT_NONE;
+
+		if (event & EPOLLIN) {
+			ret_type |= EVENT_READ;
+		}
+		if (event & EPOLLOUT) {
+			ret_type |= EVENT_WRITE;
+		}
+		// todo: tmp
+		return ret_type;
+	}
+
+	Event ConvertToEventDto(const struct epoll_event &event) {
+		Event ret_event;
+		ret_event.fd   = event.data.fd;
+		ret_event.type = ConvertToEventType(event.events);
+		return ret_event;
+	}
 } // namespace
 
 void Epoll::AddNewConnection(int socket_fd, EventType type) {
@@ -55,28 +75,6 @@ int Epoll::CreateReadyList() {
 	}
 	return ready;
 }
-
-namespace {
-	uint32_t ConvertToEventType(uint32_t event) {
-		uint32_t ret_type = EVENT_NONE;
-
-		if (event & EPOLLIN) {
-			ret_type |= EVENT_READ;
-		}
-		if (event & EPOLLOUT) {
-			ret_type |= EVENT_WRITE;
-		}
-		// todo: tmp
-		return ret_type;
-	}
-
-	Event ConvertToEventDto(const struct epoll_event &event) {
-		Event ret_event;
-		ret_event.fd   = event.data.fd;
-		ret_event.type = ConvertToEventType(event.events);
-		return ret_event;
-	}
-} // namespace
 
 Event Epoll::GetEvent(std::size_t index) const {
 	if (index >= MAX_EVENTS) {

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -69,7 +69,7 @@ namespace {
 	}
 } // namespace
 
-const Event Epoll::GetEvent(std::size_t index) const {
+Event Epoll::GetEvent(std::size_t index) const {
 	if (index >= MAX_EVENTS) {
 		throw std::out_of_range("evlist index out of range");
 	}

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -76,6 +76,17 @@ int Epoll::CreateReadyList() {
 	return ready;
 }
 
+void Epoll::AddConnectionState(const Event &event, const EventType new_type) {
+	const int socket_fd = event.fd;
+
+	struct epoll_event ev;
+	ev.events  = (event.type | ConvertToEpollEventType(new_type));
+	ev.data.fd = socket_fd;
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
+		throw std::runtime_error("epoll_ctl failed");
+	}
+}
+
 Event Epoll::GetEvent(std::size_t index) const {
 	if (index >= MAX_EVENTS) {
 		throw std::out_of_range("evlist index out of range");

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -18,11 +18,15 @@ Epoll::~Epoll() {
 
 namespace {
 	uint32_t ConvertToEpollEventType(EventType type) {
-		if (type == EVENT_READ) {
-			return EPOLLIN;
+		uint32_t ret_type = 0;
+
+		if (type & EVENT_READ) {
+			ret_type |= EPOLLIN;
 		}
-		// todo: tmp
-		return 0;
+		if (type & EVENT_WRITE) {
+			ret_type |= EPOLLOUT;
+		}
+		return ret_type;
 	}
 } // namespace
 
@@ -53,12 +57,17 @@ int Epoll::CreateReadyList() {
 }
 
 namespace {
-	EventType ConvertToEventType(uint32_t event) {
+	uint32_t ConvertToEventType(uint32_t event) {
+		uint32_t ret_type = EVENT_NONE;
+
 		if (event & EPOLLIN) {
-			return EVENT_READ;
+			ret_type |= EVENT_READ;
+		}
+		if (event & EPOLLOUT) {
+			ret_type |= EVENT_WRITE;
 		}
 		// todo: tmp
-		return EVENT_NONE;
+		return ret_type;
 	}
 
 	Event ConvertToEventDto(const struct epoll_event &event) {

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -76,11 +76,12 @@ int Epoll::CreateReadyList() {
 	return ready;
 }
 
-void Epoll::AddConnectionState(const Event &event, const EventType new_type) {
+// override with new_type
+void Epoll::UpdateEventType(const Event &event, const EventType new_type) {
 	const int socket_fd = event.fd;
 
 	struct epoll_event ev;
-	ev.events  = (event.type | ConvertToEpollEventType(new_type));
+	ev.events  = ConvertToEpollEventType(new_type);
 	ev.data.fd = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw std::runtime_error("epoll_ctl failed");

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -1,5 +1,4 @@
 #include "epoll.hpp"
-#include "event.hpp"
 #include <errno.h>
 #include <stdint.h> // uint32_t
 #include <unistd.h> // close
@@ -17,10 +16,21 @@ Epoll::~Epoll() {
 	}
 }
 
-void Epoll::AddNewConnection(int socket_fd) {
-	ev_.events  = EPOLLIN;
-	ev_.data.fd = socket_fd;
-	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, socket_fd, &ev_) == SYSTEM_ERROR) {
+namespace {
+	uint32_t ConvertToEpollEventType(EventType type) {
+		if (type == EVENT_READ) {
+			return EPOLLIN;
+		}
+		// todo: tmp
+		return 0;
+	}
+} // namespace
+
+void Epoll::AddNewConnection(int socket_fd, EventType type) {
+	struct epoll_event ev;
+	ev.events  = ConvertToEpollEventType(type);
+	ev.data.fd = socket_fd;
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw std::runtime_error("epoll_ctl failed");
 	}
 }

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -1,16 +1,15 @@
 #ifndef EPOLL_HPP_
 #define EPOLL_HPP_
 
-#include "debug.hpp"   // todo: tmp
+#include "debug.hpp" // todo: tmp
+#include "event.hpp"
 #include <sys/epoll.h> // epoll
-
-struct Event;
 
 class Epoll {
   public:
 	Epoll();
 	~Epoll();
-	void AddNewConnection(int socket_fd);
+	void AddNewConnection(int socket_fd, EventType type);
 	void DeleteConnection(int socket_fd);
 	int  CreateReadyList();
 	// getter
@@ -25,7 +24,6 @@ class Epoll {
 	static const unsigned int MAX_EVENTS   = 10;
 	// variables
 	int                epoll_fd_;
-	struct epoll_event ev_;
 	struct epoll_event evlist_[MAX_EVENTS];
 };
 

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -11,6 +11,7 @@ class Epoll {
 	~Epoll();
 	void AddNewConnection(int socket_fd, EventType type);
 	void DeleteConnection(int socket_fd);
+	void AddConnectionState(const Event &event, EventType new_type);
 	int  CreateReadyList();
 	// getter
 	Event GetEvent(std::size_t index) const;

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -13,7 +13,7 @@ class Epoll {
 	void DeleteConnection(int socket_fd);
 	int  CreateReadyList();
 	// getter
-	const Event GetEvent(std::size_t index) const;
+	Event GetEvent(std::size_t index) const;
 
   private:
 	// prohibit copy

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -11,7 +11,7 @@ class Epoll {
 	~Epoll();
 	void AddNewConnection(int socket_fd, EventType type);
 	void DeleteConnection(int socket_fd);
-	void AddConnectionState(const Event &event, EventType new_type);
+	void UpdateEventType(const Event &event, EventType new_type);
 	int  CreateReadyList();
 	// getter
 	Event GetEvent(std::size_t index) const;

--- a/srcs/event.hpp
+++ b/srcs/event.hpp
@@ -1,3 +1,6 @@
+#ifndef EVENT_HPP_
+#define EVENT_HPP_
+
 enum EventType {
 	EVENT_NONE, // todo: tmp
 	EVENT_READ,
@@ -9,3 +12,5 @@ struct Event {
 	int       fd;
 	EventType type;
 };
+
+#endif /* EVENT_HPP_ */

--- a/srcs/event.hpp
+++ b/srcs/event.hpp
@@ -1,16 +1,19 @@
 #ifndef EVENT_HPP_
 #define EVENT_HPP_
 
+#include <stdint.h> // uint32_t
+
 enum EventType {
-	EVENT_NONE, // todo: tmp
-	EVENT_READ,
-	EVENT_HANGUP,
-	EVENT_ERR
+	EVENT_NONE   = 1 << 0, // todo: tmp
+	EVENT_READ   = 1 << 1,
+	EVENT_WRITE  = 1 << 2,
+	EVENT_ERROR  = 1 << 3,
+	EVENT_HANGUP = 1 << 4
 };
 
 struct Event {
-	int       fd;
-	EventType type;
+	int      fd;
+	uint32_t type;
 };
 
 #endif /* EVENT_HPP_ */

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -40,8 +40,13 @@ void Server::Run() {
 void Server::HandleEvent(const Event &event) {
 	if (event.fd == server_fd_) {
 		AcceptNewConnection();
-	} else if (event.type == EVENT_READ) {
+		return;
+	}
+	if (event.type & EVENT_READ) {
 		SendResponse(event.fd);
+	}
+	if (event.type & EVENT_WRITE) {
+		// todo
 	}
 	// todo: handle other EventType (switch)
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -39,19 +39,13 @@ void Server::Run() {
 
 void Server::HandleEvent(const Event &event) {
 	if (event.fd == server_fd_) {
-		AcceptNewConnection();
-		return;
+		HandleNewConnection();
+	} else {
+		HandleExistingConnection(event);
 	}
-	if (event.type & EVENT_READ) {
-		ReadRequest(event);
-	}
-	if (event.type & EVENT_WRITE) {
-		SendResponse(event.fd);
-	}
-	// todo: handle other EventType (switch)
 }
 
-void Server::AcceptNewConnection() {
+void Server::HandleNewConnection() {
 	const int new_socket =
 		accept(server_fd_, (struct sockaddr *)&sock_addr_, &addrlen_);
 	if (new_socket == SYSTEM_ERROR) {
@@ -59,6 +53,16 @@ void Server::AcceptNewConnection() {
 	}
 	epoll_.AddNewConnection(new_socket, EVENT_READ);
 	Debug("server", "add new client", new_socket);
+}
+
+void Server::HandleExistingConnection(const Event &event) {
+	if (event.type & EVENT_READ) {
+		ReadRequest(event);
+	}
+	if (event.type & EVENT_WRITE) {
+		SendResponse(event.fd);
+	}
+	// todo: handle other EventType
 }
 
 namespace {

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -38,11 +38,11 @@ void Server::Run() {
 	}
 }
 
-void Server::HandleEvent(const Event event) {
+void Server::HandleEvent(const Event &event) {
 	if (event.fd == server_fd_) {
 		AcceptNewConnection();
 	} else if (event.type == EVENT_READ) {
-		SendResponseToClient(event.fd);
+		SendResponse(event.fd);
 	}
 	// todo: handle other EventType (switch)
 }
@@ -64,7 +64,7 @@ namespace {
 	}
 } // namespace
 
-void Server::SendResponseToClient(int client_fd) {
+void Server::SendResponse(int client_fd) {
 	ssize_t read_ret = buffers_.Read(client_fd);
 	if (read_ret <= 0) {
 		if (read_ret == SYSTEM_ERROR) {

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -52,7 +52,7 @@ void Server::AcceptNewConnection() {
 	if (new_socket == SYSTEM_ERROR) {
 		throw std::runtime_error("accept failed");
 	}
-	epoll_.AddNewConnection(new_socket);
+	epoll_.AddNewConnection(new_socket, EVENT_READ);
 	Debug("server", "add new client", new_socket);
 }
 
@@ -110,5 +110,5 @@ void Server::Init() {
 	}
 
 	// add to epoll's interest list
-	epoll_.AddNewConnection(server_fd_);
+	epoll_.AddNewConnection(server_fd_, EVENT_READ);
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -93,7 +93,7 @@ void Server::ReadRequest(const Event &event) {
 	if (IsRequestReceivedComplete(buffers_.GetBuffer(client_fd))) {
 		Debug("server", "received all request from client", client_fd);
 		std::cerr << buffers_.GetBuffer(client_fd) << std::endl;
-		epoll_.AddConnectionState(event, EVENT_WRITE);
+		epoll_.UpdateEventType(event, EVENT_WRITE);
 	}
 }
 

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_HPP_
 #define SERVER_HPP_
 
+#include "buffer.hpp"
 #include "config.hpp"
 #include "debug.hpp" // todo: tmp
 #include "epoll.hpp"
@@ -26,14 +27,15 @@ class Server {
 	const std::string  server_name_;
 	const unsigned int port_;
 	// const
-	static const int          SYSTEM_ERROR = -1;
-	static const unsigned int BUFFER_SIZE  = 1024;
+	static const int SYSTEM_ERROR = -1;
 	// socket
 	struct sockaddr_in sock_addr_;
 	socklen_t          addrlen_;
 	int                server_fd_;
 	// event poll
 	Epoll epoll_;
+	// request buffers
+	Buffer buffers_;
 };
 
 #endif /* SERVER_HPP_ */

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -22,6 +22,7 @@ class Server {
 	void    Init();
 	void    HandleEvent(const Event &event);
 	void    AcceptNewConnection();
+	void    ReadRequest(const Event &event);
 	void    SendResponse(int client_fd);
 	// const variables (todo: tmp)
 	const std::string  server_name_;

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -21,7 +21,8 @@ class Server {
 	Server &operator=(const Server &other);
 	void    Init();
 	void    HandleEvent(const Event &event);
-	void    AcceptNewConnection();
+	void    HandleNewConnection();
+	void    HandleExistingConnection(const Event &event);
 	void    ReadRequest(const Event &event);
 	void    SendResponse(int client_fd);
 	// const variables (todo: tmp)

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -20,9 +20,9 @@ class Server {
 	Server(const Server &other);
 	Server &operator=(const Server &other);
 	void    Init();
-	void    HandleEvent(const Event event);
+	void    HandleEvent(const Event &event);
 	void    AcceptNewConnection();
-	void    SendResponseToClient(int client_fd);
+	void    SendResponse(int client_fd);
 	// const variables (todo: tmp)
 	const std::string  server_name_;
 	const unsigned int port_;

--- a/srcs/utils/debug.hpp
+++ b/srcs/utils/debug.hpp
@@ -15,4 +15,10 @@ void Debug(const std::string &title, const T &x) {
 	std::cerr << COLOR_GLAY << "[" << title << "] " << x << COLOR_RESET << std::endl;
 }
 
+template <typename T, typename U>
+void Debug(const std::string &title, const T &x, const U &y) {
+	std::cerr << COLOR_GLAY << "[" << title << "] " << x << "(" << y << ")"
+			  << COLOR_RESET << std::endl;
+}
+
 #endif /* UTILS_DEBUG_HPP_ */

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -51,16 +51,23 @@ void Client::SendRequestAndReceiveResponse() {
 	send(sock_fd_, request_message_.c_str(), request_message_.size(), 0);
 	DebugPrint("Message sent.");
 
-	// read response
-	static const unsigned int BUFFER_SIZE = 1024;
+	// receive response
+	static const unsigned int BUFFER_SIZE = 8;
 	char                      buffer[BUFFER_SIZE];
 
-	ssize_t read_ret = read(sock_fd_, buffer, BUFFER_SIZE);
-	if (read_ret == SYSTEM_ERROR) {
-		throw std::runtime_error("read failed");
+	std::string response;
+	while (true) {
+		ssize_t read_ret = read(sock_fd_, buffer, BUFFER_SIZE);
+		if (read_ret == SYSTEM_ERROR) {
+			throw std::runtime_error("read failed");
+		}
+		if (read_ret == 0) {
+			break;
+		}
+		response.append(std::string(buffer, read_ret));
 	}
 	DebugPrint("Response from server:");
-	std::cout << std::string(buffer, read_ret) << std::endl;
+	std::cout << response << std::endl;
 }
 
 void Client::Init() {

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -7,7 +7,8 @@
 #include <sys/types.h>
 #include <unistd.h> // read,close
 
-const std::string Client::DEFAULT_MESSAGE = "Hello from client (default)";
+const std::string Client::DEFAULT_MESSAGE =
+	"GET / HTTP/1.1\r\nConnection: close \r\n\r\n";
 
 Client::Client() : port_(DEFAULT_PORT), request_message_(DEFAULT_MESSAGE) {
 	Init();


### PR DESCRIPTION
## したこと
BUFFER_SIZE を超えた request も全部 read できるようにした

- 今まで
  - `EPOLLIN` のみ。read 1 回だけで全ての request を受信したものとして、即 client に send していた
- 今回
  - read と send(write) を別のイベントに分けた
  - request の read が複数回に分かれることもあるため、今まで受け取った request を、 server が fd ごとに保持しておくようにした (`Buffer class` を作り read & 保持を任せてみた。一旦データ構造は `std::map<int fd, std::string buf>`)
  - `EPOLLIN` がセットされている時に read し、request-message の終端に達したら `EPOLLOUT` をセットする。`EPOLLOUT` がセットされていたら client に send する

## 変更内容
- `server` 
  - [x] `EPOLLIN` がセットされていれば何度でも read し、fd ごとに buffer(map) に request を保存する
  - [x] `EPOLLOUT` がセットされていれば send(write) する
  - [x] `EPOLLOUT` は server 側では `EVENT_WRITE` として使う。変換する関数あり
    - `epoll`
    - [x] event の型を bit で管理。(`EPOLLIN` | `EPOLLOUT` のように使うため)
    - [x] `EPOLLOUT` を追加 (これをトリガーに response を送る)
    - [x] event を指定して監視を始められるように
    - [x] 既に監視対象の fd に event を追加できるように
- `test/client`
	- [x] BUFFER_SIZE 以上の response も受取れるように while で read する

## してないこと (今後する)
- 不正な request への対応
- request の終端に達する前に http-message が有効か無効か判定すること
- send を返り値 0 になるまで続ける。0 になったら disconnection すること
- Buffer class の request 保持用データ構造 map は、今後変わるかも
- `fcntl()` を使って fd を non-blocking モードにする (調べる)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - バッファ管理用のクラスを追加し、ファイルディスクリプタの読み取り、削除、および内容取得が可能に。

- **機能改善**
  - Epollクラスのイベント処理ロジックをリファクタリングし、特定の接続タイプのハンドリングを最適化。
  - サーバーロジックを強化し、接続ハンドリングやクライアントリクエストの処理とレスポンス送信を最適化。

- **バグ修正**
  - クライアントクラスのデフォルトメッセージとバッファサイズの調整、およびレスポンスの完全な読み取り処理を更新。

- **スタイル**
  - イベントタイプの列挙型をビットシフト演算子を使用するように変更し、フィールドの型を更新。

- **ドキュメント**
  - デバッグ関数に新しいテンプレートパラメータを追加し、デバッグメッセージに追加情報を出力。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->