### PR TITLE
[test/client] request-messageを引数で渡されたファイルから読み込む

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,3 +2,6 @@ a.out
 __pycache__
 .pytest_cache
 venv
+
+# include
+!client/request_messages/**

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,6 +2,3 @@ a.out
 __pycache__
 .pytest_cache
 venv
-
-# include
-!client/request_messages/**

--- a/test/client/.gitignore
+++ b/test/client/.gitignore
@@ -1,0 +1,2 @@
+# include
+!client/request_messages/**

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -38,13 +38,18 @@ fclean: clean
 re: fclean all
 
 #--------------------------------------------
+DEFAULT_INFILE_PATH=request_messages/200_get_root.txt
+INFILE_PATH=$(DEFAULT_INFILE_PATH)
+
+# ex) make run
+# ex) make run INFILE_PATH=request_messages/200_get_sub.txt
 .PHONY	: run
 run: all
-	@./$(NAME)
+	@./$(NAME) $(INFILE_PATH)
 
 .PHONY	: val
 val: all
-	@valgrind ./$(NAME)
+	@valgrind ./$(NAME) $(INFILE_PATH)
 
 .PHONY	: check
 check:

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -38,8 +38,8 @@ fclean: clean
 re: fclean all
 
 #--------------------------------------------
-DEFAULT_PORT=8080
-PORT=$(DEFAULT_PORT)
+DEFAULT_PORT	:=	8080
+PORT			:=	$(DEFAULT_PORT)
 
 # ex) make run INFILE_PATH=request_messages/200_get_sub.txt
 # ex) make run PORT=4242 INFILE_PATH=request_messages/200_get_sub.txt

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -38,18 +38,22 @@ fclean: clean
 re: fclean all
 
 #--------------------------------------------
+DEFAULT_PORT=8080
 DEFAULT_INFILE_PATH=request_messages/200_get_root.txt
+
+PORT=$(DEFAULT_PORT)
 INFILE_PATH=$(DEFAULT_INFILE_PATH)
 
 # ex) make run
 # ex) make run INFILE_PATH=request_messages/200_get_sub.txt
+# ex) make run PORT=4242 INFILE_PATH=request_messages/200_get_sub.txt
 .PHONY	: run
 run: all
-	@./$(NAME) $(INFILE_PATH)
+	@./$(NAME) $(PORT) $(INFILE_PATH)
 
 .PHONY	: val
 val: all
-	@valgrind ./$(NAME) $(INFILE_PATH)
+	@valgrind ./$(NAME) $(PORT) $(INFILE_PATH)
 
 .PHONY	: check
 check:

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -39,12 +39,8 @@ re: fclean all
 
 #--------------------------------------------
 DEFAULT_PORT=8080
-DEFAULT_INFILE_PATH=request_messages/200_get_root.txt
-
 PORT=$(DEFAULT_PORT)
-INFILE_PATH=$(DEFAULT_INFILE_PATH)
 
-# ex) make run
 # ex) make run INFILE_PATH=request_messages/200_get_sub.txt
 # ex) make run PORT=4242 INFILE_PATH=request_messages/200_get_sub.txt
 .PHONY	: run

--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -51,10 +51,5 @@ check:
 	@cppcheck --enable=all $$(find . -type f -name "*.cpp" | tr '\n' ' ')
 
 #--------------------------------------------
-.PHONY	: req
-req:
-	echo -n "Hello from client" | nc 127.0.0.1 8080
-
-#--------------------------------------------
 
 -include $(DEPS)

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -10,20 +10,7 @@
 const std::string Client::DEFAULT_MESSAGE =
 	"GET / HTTP/1.1\r\nConnection: close \r\n\r\n";
 
-Client::Client() : port_(DEFAULT_PORT), request_message_(DEFAULT_MESSAGE) {
-	Init();
-}
-
-Client::Client(int port) : port_(port), request_message_(DEFAULT_MESSAGE) {
-	Init();
-}
-
-Client::Client(const std::string &message)
-	: port_(DEFAULT_PORT), request_message_(message) {
-	Init();
-}
-
-Client::Client(int port, const std::string &message)
+Client::Client(unsigned int port, const std::string &message)
 	: port_(port), request_message_(message) {
 	Init();
 }

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -1,6 +1,5 @@
 #include "client.hpp"
 #include <arpa/inet.h> // inet_pton,htons
-#include <cstring>     // strlen
 #include <iostream>
 #include <stdio.h>      // perror
 #include <sys/socket.h> // socket,connect
@@ -30,7 +29,7 @@ namespace {
 	}
 } // namespace
 
-void Client::SetMessage(const std::string &message) {
+void Client::UpdateMessage(const std::string &message) {
 	request_message_ = message;
 }
 
@@ -40,9 +39,7 @@ void Client::SendRequestAndReceiveResponse() {
 	DebugPrint("Message sent.");
 
 	// receive response
-	static const unsigned int BUFFER_SIZE = 8;
-	char                      buffer[BUFFER_SIZE];
-
+	char        buffer[BUFFER_SIZE];
 	std::string response;
 	while (true) {
 		ssize_t read_ret = read(sock_fd_, buffer, BUFFER_SIZE);

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -1,16 +1,11 @@
 #include "client.hpp"
 #include <arpa/inet.h> // inet_pton,htons
 #include <iostream>
-#include <stdio.h>      // perror
 #include <sys/socket.h> // socket,connect
 #include <sys/types.h>
 #include <unistd.h> // read,close
 
-const std::string Client::DEFAULT_MESSAGE =
-	"GET / HTTP/1.1\r\nConnection: close \r\n\r\n";
-
-Client::Client(unsigned int port, const std::string &message)
-	: port_(port), request_message_(message) {
+Client::Client(unsigned int port) : port_(port) {
 	Init();
 }
 
@@ -29,13 +24,9 @@ namespace {
 	}
 } // namespace
 
-void Client::UpdateMessage(const std::string &message) {
-	request_message_ = message;
-}
-
-void Client::SendRequestAndReceiveResponse() {
+void Client::SendRequestAndReceiveResponse(const std::string &message) {
 	// send request message
-	send(sock_fd_, request_message_.c_str(), request_message_.size(), 0);
+	send(sock_fd_, message.c_str(), message.size(), 0);
 	DebugPrint("Message sent.");
 
 	// receive response

--- a/test/client/client.hpp
+++ b/test/client/client.hpp
@@ -6,15 +6,16 @@
 
 class Client {
   public:
-	Client();
-	explicit Client(int port);
-	explicit Client(const std::string &message);
-	Client(int port, const std::string &message);
+	Client(
+		unsigned int       port    = DEFAULT_PORT,
+		const std::string &message = DEFAULT_MESSAGE
+	);
 	~Client();
 	void SetMessage(const std::string &message);
 	void SendRequestAndReceiveResponse();
 
   private:
+	Client();
 	// prohibit copy
 	Client(const Client &other);
 	Client &operator=(const Client &other);

--- a/test/client/client.hpp
+++ b/test/client/client.hpp
@@ -6,13 +6,9 @@
 
 class Client {
   public:
-	Client(
-		unsigned int       port    = DEFAULT_PORT,
-		const std::string &message = DEFAULT_MESSAGE
-	);
+	explicit Client(unsigned int port);
 	~Client();
-	void UpdateMessage(const std::string &message);
-	void SendRequestAndReceiveResponse();
+	void SendRequestAndReceiveResponse(const std::string &message);
 
   private:
 	Client();
@@ -22,12 +18,9 @@ class Client {
 	void    Init();
 	// const
 	static const int          SYSTEM_ERROR = -1;
-	static const unsigned int DEFAULT_PORT = 8080;
-	static const std::string  DEFAULT_MESSAGE;
-	static const unsigned int BUFFER_SIZE = 1024;
+	static const unsigned int BUFFER_SIZE  = 1024;
 	// socket
 	unsigned int       port_;
-	std::string        request_message_;
 	int                sock_fd_;
 	struct sockaddr_in sock_addr_;
 };

--- a/test/client/client.hpp
+++ b/test/client/client.hpp
@@ -11,7 +11,7 @@ class Client {
 		const std::string &message = DEFAULT_MESSAGE
 	);
 	~Client();
-	void SetMessage(const std::string &message);
+	void UpdateMessage(const std::string &message);
 	void SendRequestAndReceiveResponse();
 
   private:
@@ -24,6 +24,7 @@ class Client {
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int DEFAULT_PORT = 8080;
 	static const std::string  DEFAULT_MESSAGE;
+	static const unsigned int BUFFER_SIZE = 1024;
 	// socket
 	unsigned int       port_;
 	std::string        request_message_;

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -6,10 +6,6 @@
 #include <sstream> // stringstream
 
 namespace {
-	static const unsigned int DEFAULT_PORT = 8080;
-	static const std::string  DEFAULT_INFILE_PATH =
-		"request_messages/200_get_root.txt";
-
 	static const std::string COLOR_RED   = "\033[31m";
 	static const std::string COLOR_RESET = "\033[0m";
 
@@ -42,27 +38,19 @@ namespace {
 	}
 } // namespace
 
-// default port & message  : ./client
-// original port & message : ./client PORT INFILE_PATH
+// ./client PORT INFILE_PATH
 int main(int argc, char **argv) {
-	if (argc != 1 && argc != 3) {
+	if (argc != 3) {
 		PrintError("Error: invalid arguments");
 		return EXIT_FAILURE;
 	}
 
 	try {
-		unsigned int port;
-		std::string  request_message;
-		if (argc == 1) {
-			port            = DEFAULT_PORT;
-			request_message = ReadFileStr(DEFAULT_INFILE_PATH);
-		} else {
-			port = ConvertStrToUint(argv[1]);
-			request_message =
-				ReadFileStr(std::string(argv[2], std::strlen(argv[2])));
-		}
-		Client client(port, request_message);
-		client.SendRequestAndReceiveResponse();
+		const unsigned int port = ConvertStrToUint(argv[1]);
+		const std::string  request_message =
+			ReadFileStr(std::string(argv[2], std::strlen(argv[2])));
+		Client client(port);
+		client.SendRequestAndReceiveResponse(request_message);
 	} catch (const std::exception &e) {
 		PrintError(e.what());
 		return EXIT_FAILURE;

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 
 namespace {
+	static const unsigned int DEFAULT_PORT = 8080;
+
 	static const std::string COLOR_RED   = "\033[31m";
 	static const std::string COLOR_RESET = "\033[0m";
 
@@ -16,7 +18,7 @@ namespace {
 // original message : ./client "request message"
 int main(int argc, char **argv) {
 	try {
-		Client client;
+		Client client(DEFAULT_PORT);
 		if (argc > 1) {
 			const std::string message = std::string(argv[1], std::strlen(argv[1]));
 			client.SetMessage(message);

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 		Client client(DEFAULT_PORT);
 		if (argc > 1) {
 			const std::string message = std::string(argv[1], std::strlen(argv[1]));
-			client.SetMessage(message);
+			client.UpdateMessage(message);
 		}
 		client.SendRequestAndReceiveResponse();
 	} catch (const std::exception &e) {

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -1,10 +1,14 @@
 #include "client.hpp"
 #include <cstdlib>
 #include <cstring> // strlen
+#include <fstream> // ifstream
 #include <iostream>
+#include <sstream> // stringstream
 
 namespace {
 	static const unsigned int DEFAULT_PORT = 8080;
+	static const std::string  DEFAULT_INFILE_PATH =
+		"request_messages/200_get_root.txt";
 
 	static const std::string COLOR_RED   = "\033[31m";
 	static const std::string COLOR_RESET = "\033[0m";
@@ -12,17 +16,35 @@ namespace {
 	void PrintError(const std::string &s) {
 		std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
 	}
+
+	std::string FileToString(const std::ifstream &file) {
+		std::stringstream ss;
+		ss << file.rdbuf();
+		return ss.str();
+	}
+
+	std::string ReadFileStr(const std::string &file_path) {
+		std::ifstream file(file_path.c_str());
+		if (!file) {
+			throw std::runtime_error("error infile");
+		}
+		return FileToString(file);
+	}
+
+	std::string GetRequestMessage(int argc, char **argv) {
+		if (argc <= 1) {
+			return ReadFileStr(DEFAULT_INFILE_PATH);
+		}
+		return ReadFileStr(std::string(argv[1], std::strlen(argv[1])));
+	}
 } // namespace
 
 // default message  : ./client
-// original message : ./client "request message"
+// original message : ./client INFILE_PATH
 int main(int argc, char **argv) {
 	try {
-		Client client(DEFAULT_PORT);
-		if (argc > 1) {
-			const std::string message = std::string(argv[1], std::strlen(argv[1]));
-			client.UpdateMessage(message);
-		}
+		const std::string request_message = GetRequestMessage(argc, argv);
+		Client            client(DEFAULT_PORT, request_message);
 		client.SendRequestAndReceiveResponse();
 	} catch (const std::exception &e) {
 		PrintError(e.what());

--- a/test/client/request_messages/200_get_root.txt
+++ b/test/client/request_messages/200_get_root.txt
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Connection: close 
+
+

--- a/test/client/request_messages/200_get_sub.txt
+++ b/test/client/request_messages/200_get_sub.txt
@@ -1,0 +1,4 @@
+GET /sub HTTP/1.1
+Connection: close 
+
+

--- a/test/client/request_messages/404_get_not_exist_path.txt
+++ b/test/client/request_messages/404_get_not_exist_path.txt
@@ -1,0 +1,4 @@
+GET /not-exist-path HTTP/1.1
+Connection: close 
+
+


### PR DESCRIPTION
#88 を main に merge 後、main に merge する

## したこと
- [x] test 用 client : `request-message` の書かれたファイルをコマンドライン引数から読み取れるようにした
- [x] 現状動く大まかに 3 パターンについて `request-message` の書かれた `.txt` を用意
- [x] ついでに `port` もコマンドライン引数から指定できるように

今までこれで実行していたのが
`./client request-message文字列`

これでできるようになった
`./client PORT INFILE_PATH`

確認コマンド
```shell
# ------------
# server
# ------------
make run

# ------------
# test/client
# ------------
# default page (GET, /, 200)
make run INFILE_PATH=request_messages/200_get_root.txt 

# /sub, 200
make run INFILE_PATH=request_messages/200_get_sub.txt

# /not-exist-path, 404
make run INFILE_PATH=request_messages/404_get_not_exist_path.txt 

# (port も指定して実行する場合)
# default page 
make run PORT=4242 INFILE_PATH=request_messages/200_get_root.txt 

# /sub, 200
make run PORT=4242 INFILE_PATH=request_messages/200_get_sub.txt

# /not-exist-path, 404
make run PORT=4242 INFILE_PATH=request_messages/404_get_not_exist_path.txt 
```


## 今後
- request-message の正常ケース・エラーケースを実装したものから順に追加していく


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいHTTPリクエストメッセージファイルを追加しました (`200_get_root.txt`, `200_get_sub.txt`, `404_get_not_exist_path.txt`)。

- **改良**
  - デフォルトのポート (`8080`) とメッセージパス (`request_messages/200_get_root.txt`) の設定を追加しました。

- **バグ修正**
  - `Client` クラスのポート引数を `int` から `unsigned int` に変更。
  - メソッド名を `SetMessage` から `UpdateMessage` に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->