### PR TITLE
[style] clang-format / namespaceインデントなし,横幅増やす変更追加

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ IndentWidth: 4
 TabWidth: 4
 AllowShortFunctionsOnASingleLine: Empty
 IndentCaseLabels: false
-NamespaceIndentation: All
+NamespaceIndentation: None
 BreakConstructorInitializers: BeforeColon
 AlwaysBreakTemplateDeclarations: Yes
 SpacesInAngles: Leave

--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ NamespaceIndentation: None
 BreakConstructorInitializers: BeforeColon
 AlwaysBreakTemplateDeclarations: Yes
 SpacesInAngles: Leave
-ColumnLimit: 85
+ColumnLimit: 100
 AlignAfterOpenBracket: BlockIndent
 BinPackArguments: false
 BinPackParameters: false

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -17,37 +17,39 @@ Epoll::~Epoll() {
 }
 
 namespace {
-	uint32_t ConvertToEpollEventType(EventType type) {
-		uint32_t ret_type = 0;
 
-		if (type & EVENT_READ) {
-			ret_type |= EPOLLIN;
-		}
-		if (type & EVENT_WRITE) {
-			ret_type |= EPOLLOUT;
-		}
-		return ret_type;
+uint32_t ConvertToEpollEventType(EventType type) {
+	uint32_t ret_type = 0;
+
+	if (type & EVENT_READ) {
+		ret_type |= EPOLLIN;
 	}
-
-	uint32_t ConvertToEventType(uint32_t event) {
-		uint32_t ret_type = EVENT_NONE;
-
-		if (event & EPOLLIN) {
-			ret_type |= EVENT_READ;
-		}
-		if (event & EPOLLOUT) {
-			ret_type |= EVENT_WRITE;
-		}
-		// todo: tmp
-		return ret_type;
+	if (type & EVENT_WRITE) {
+		ret_type |= EPOLLOUT;
 	}
+	return ret_type;
+}
 
-	Event ConvertToEventDto(const struct epoll_event &event) {
-		Event ret_event;
-		ret_event.fd   = event.data.fd;
-		ret_event.type = ConvertToEventType(event.events);
-		return ret_event;
+uint32_t ConvertToEventType(uint32_t event) {
+	uint32_t ret_type = EVENT_NONE;
+
+	if (event & EPOLLIN) {
+		ret_type |= EVENT_READ;
 	}
+	if (event & EPOLLOUT) {
+		ret_type |= EVENT_WRITE;
+	}
+	// todo: tmp
+	return ret_type;
+}
+
+Event ConvertToEventDto(const struct epoll_event &event) {
+	Event ret_event;
+	ret_event.fd   = event.data.fd;
+	ret_event.type = ConvertToEventType(event.events);
+	return ret_event;
+}
+
 } // namespace
 
 void Epoll::AddNewConnection(int socket_fd, EventType type) {

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -11,21 +11,23 @@ Http::Http(const std::string &read_buf) {
 Http::~Http() {}
 
 namespace {
-	std::string FileToString(const std::ifstream &file) {
-		std::stringstream ss;
-		ss << file.rdbuf();
-		return ss.str();
-	}
 
-	std::string ReadFile(const std::string &file_path) {
-		std::ifstream file(file_path.c_str());
-		if (!file) {
-			std::ifstream error_file("html/404.html");
-			Debug("http", "404 file not found");
-			return FileToString(error_file);
-		}
-		return FileToString(file);
+std::string FileToString(const std::ifstream &file) {
+	std::stringstream ss;
+	ss << file.rdbuf();
+	return ss.str();
+}
+
+std::string ReadFile(const std::string &file_path) {
+	std::ifstream file(file_path.c_str());
+	if (!file) {
+		std::ifstream error_file("html/404.html");
+		Debug("http", "404 file not found");
+		return FileToString(error_file);
 	}
+	return FileToString(file);
+}
+
 } // namespace
 
 // todo: tmp content

--- a/srcs/http/request/parse.cpp
+++ b/srcs/http/request/parse.cpp
@@ -4,15 +4,17 @@
 #include <vector>
 
 namespace {
-	// todo: create path (/, /aaa, /aaa/)
-	std::string CreateDefaultPath(const std::string &path) {
-		static const std::string location = "html";
 
-		if (path.size() == 1) {
-			return location + "/index.html";
-		}
-		return location + path + "/index.html";
+// todo: create path (/, /aaa, /aaa/)
+std::string CreateDefaultPath(const std::string &path) {
+	static const std::string location = "html";
+
+	if (path.size() == 1) {
+		return location + "/index.html";
 	}
+	return location + path + "/index.html";
+}
+
 } // namespace
 
 // todo: tmp request_

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -5,27 +5,19 @@
 
 namespace http_response {
 
-void CreateStatusLine(
-	std::ostream &response_stream, const Http::RequestMessage &request
-) {
+void CreateStatusLine(std::ostream &response_stream, const Http::RequestMessage &request) {
 	response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
 					<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
 }
 
 template <typename T>
-void CreateHeaderField(
-	std::ostream &response_stream, const std::string &name, const T &value
-) {
+void CreateHeaderField(std::ostream &response_stream, const std::string &name, const T &value) {
 	response_stream << name << ":" << SP << value << SP << CRLF;
 }
 
-void CreateHeaderFields(
-	std::ostream &response_stream, const Http::RequestMessage &request
-) {
+void CreateHeaderFields(std::ostream &response_stream, const Http::RequestMessage &request) {
 	CreateHeaderField(response_stream, CONNECTION, "close");
-	CreateHeaderField(
-		response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size()
-	);
+	CreateHeaderField(response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size());
 }
 
 void CreateCRLF(std::ostream &response_stream) {

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -4,37 +4,38 @@
 #include <sstream>
 
 namespace http_response {
-	void CreateStatusLine(
-		std::ostream &response_stream, const Http::RequestMessage &request
-	) {
-		response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
-						<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
-	}
 
-	template <typename T>
-	void CreateHeaderField(
-		std::ostream &response_stream, const std::string &name, const T &value
-	) {
-		response_stream << name << ":" << SP << value << SP << CRLF;
-	}
+void CreateStatusLine(
+	std::ostream &response_stream, const Http::RequestMessage &request
+) {
+	response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
+					<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
+}
 
-	void CreateHeaderFields(
-		std::ostream &response_stream, const Http::RequestMessage &request
-	) {
-		CreateHeaderField(response_stream, CONNECTION, "close");
-		CreateHeaderField(
-			response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size()
-		);
-	}
+template <typename T>
+void CreateHeaderField(
+	std::ostream &response_stream, const std::string &name, const T &value
+) {
+	response_stream << name << ":" << SP << value << SP << CRLF;
+}
 
-	void CreateCRLF(std::ostream &response_stream) {
-		response_stream << CRLF;
-	}
+void CreateHeaderFields(
+	std::ostream &response_stream, const Http::RequestMessage &request
+) {
+	CreateHeaderField(response_stream, CONNECTION, "close");
+	CreateHeaderField(
+		response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size()
+	);
+}
 
-	void
-	CreateBody(std::ostream &response_stream, const Http::RequestMessage &request) {
-		response_stream << request.at(Http::HTTP_CONTENT);
-	}
+void CreateCRLF(std::ostream &response_stream) {
+	response_stream << CRLF;
+}
+
+void CreateBody(std::ostream &response_stream, const Http::RequestMessage &request) {
+	response_stream << request.at(Http::HTTP_CONTENT);
+}
+
 } // namespace http_response
 
 std::string Http::CreateResponse() {

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -6,9 +6,11 @@
 #include <string>
 
 namespace {
-	void PrintError(const std::string &s) {
-		std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
-	}
+
+void PrintError(const std::string &s) {
+	std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
+}
+
 } // namespace
 
 // ./webserv [configuration file]

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -7,8 +7,7 @@
 #include <unistd.h>     // close
 
 // todo: set ConfigData -> private variables
-Server::Server(const Config::ConfigData &config)
-	: server_name_("from_config"), port_(8080) {
+Server::Server(const Config::ConfigData &config) : server_name_("from_config"), port_(8080) {
 	(void)config;
 	Init();
 	Debug("server", "init server & listen", server_fd_);
@@ -46,8 +45,7 @@ void Server::HandleEvent(const Event &event) {
 }
 
 void Server::HandleNewConnection() {
-	const int new_socket =
-		accept(server_fd_, (struct sockaddr *)&sock_addr_, &addrlen_);
+	const int new_socket = accept(server_fd_, (struct sockaddr *)&sock_addr_, &addrlen_);
 	if (new_socket == SYSTEM_ERROR) {
 		throw std::runtime_error("accept failed");
 	}
@@ -123,8 +121,7 @@ void Server::Init() {
 	}
 	// set socket option to reuse address
 	int optval = 1;
-	if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) ==
-		SYSTEM_ERROR) {
+	if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == SYSTEM_ERROR) {
 		throw std::runtime_error("setsockopt failed");
 	}
 	sock_addr_.sin_family      = AF_INET;
@@ -132,8 +129,7 @@ void Server::Init() {
 	sock_addr_.sin_port        = htons(port_);
 
 	// bind
-	if (bind(server_fd_, (const struct sockaddr *)&sock_addr_, addrlen_) ==
-		SYSTEM_ERROR) {
+	if (bind(server_fd_, (const struct sockaddr *)&sock_addr_, addrlen_) == SYSTEM_ERROR) {
 		throw std::runtime_error("bind failed");
 	}
 

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -66,15 +66,17 @@ void Server::HandleExistingConnection(const Event &event) {
 }
 
 namespace {
-	std::string CreateHttpResponse(const std::string &read_buf) {
-		Http http(read_buf);
-		return http.CreateResponse();
-	}
 
-	// todo: find "Connection: close"?
-	bool IsRequestReceivedComplete(const std::string &buffer) {
-		return buffer.find("\r\n\r\n") != std::string::npos;
-	}
+std::string CreateHttpResponse(const std::string &read_buf) {
+	Http http(read_buf);
+	return http.CreateResponse();
+}
+
+// todo: find "Connection: close"?
+bool IsRequestReceivedComplete(const std::string &buffer) {
+	return buffer.find("\r\n\r\n") != std::string::npos;
+}
+
 } // namespace
 
 void Server::ReadRequest(const Event &event) {

--- a/srcs/utils/debug.hpp
+++ b/srcs/utils/debug.hpp
@@ -17,8 +17,8 @@ void Debug(const std::string &title, const T &x) {
 
 template <typename T, typename U>
 void Debug(const std::string &title, const T &x, const U &y) {
-	std::cerr << COLOR_GLAY << "[" << title << "] " << x << "(" << y << ")"
-			  << COLOR_RESET << std::endl;
+	std::cerr << COLOR_GLAY << "[" << title << "] " << x << "(" << y << ")" << COLOR_RESET
+			  << std::endl;
 }
 
 #endif /* UTILS_DEBUG_HPP_ */

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -1,26 +1,28 @@
 #include "split.hpp"
 
 namespace utils {
-	std::vector<std::string>
-	SplitStr(const std::string &src, const std::string &substring) {
-		std::vector<std::string> split_str;
-		const std::size_t        src_size    = src.size();
-		const std::size_t        substr_size = substring.size();
 
-		if (substr_size == 0) {
-			split_str.push_back(src);
-			return split_str;
-		}
-		std::size_t start = 0;
-		while (start <= src_size) {
-			const std::string::size_type pos = src.find(substring, start);
-			if (pos == std::string::npos) {
-				split_str.push_back(src.substr(start));
-				break;
-			}
-			split_str.push_back(src.substr(start, pos - start));
-			start = pos + substr_size;
-		}
+std::vector<std::string>
+SplitStr(const std::string &src, const std::string &substring) {
+	std::vector<std::string> split_str;
+	const std::size_t        src_size    = src.size();
+	const std::size_t        substr_size = substring.size();
+
+	if (substr_size == 0) {
+		split_str.push_back(src);
 		return split_str;
 	}
+	std::size_t start = 0;
+	while (start <= src_size) {
+		const std::string::size_type pos = src.find(substring, start);
+		if (pos == std::string::npos) {
+			split_str.push_back(src.substr(start));
+			break;
+		}
+		split_str.push_back(src.substr(start, pos - start));
+		start = pos + substr_size;
+	}
+	return split_str;
+}
+
 } // namespace utils

--- a/srcs/utils/split.cpp
+++ b/srcs/utils/split.cpp
@@ -2,8 +2,7 @@
 
 namespace utils {
 
-std::vector<std::string>
-SplitStr(const std::string &src, const std::string &substring) {
+std::vector<std::string> SplitStr(const std::string &src, const std::string &substring) {
 	std::vector<std::string> split_str;
 	const std::size_t        src_size    = src.size();
 	const std::size_t        substr_size = substring.size();

--- a/srcs/utils/split.hpp
+++ b/srcs/utils/split.hpp
@@ -5,8 +5,10 @@
 #include <vector>
 
 namespace utils {
-	std::vector<std::string>
-	SplitStr(const std::string &src, const std::string &substring);
+
+std::vector<std::string>
+SplitStr(const std::string &src, const std::string &substring);
+
 }
 
 #endif /* UTILS_SPLIT_HPP_ */

--- a/srcs/utils/split.hpp
+++ b/srcs/utils/split.hpp
@@ -6,8 +6,7 @@
 
 namespace utils {
 
-std::vector<std::string>
-SplitStr(const std::string &src, const std::string &substring);
+std::vector<std::string> SplitStr(const std::string &src, const std::string &substring);
 
 }
 

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -58,14 +58,11 @@ void Client::Init() {
 
 	// convert address
 	if (inet_pton(AF_INET, "127.0.0.1", &sock_addr_.sin_addr) <= 0) {
-		throw std::runtime_error(
-			"inet_pton failed. Invalid address / Address not supported"
-		);
+		throw std::runtime_error("inet_pton failed. Invalid address / Address not supported");
 	}
 
 	// connect sock_fd & sock_addr_
-	if (connect(sock_fd_, (struct sockaddr *)&sock_addr_, sizeof(sock_addr_)) ==
-		SYSTEM_ERROR) {
+	if (connect(sock_fd_, (struct sockaddr *)&sock_addr_, sizeof(sock_addr_)) == SYSTEM_ERROR) {
 		throw std::runtime_error("connect failed");
 	}
 }

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -16,12 +16,14 @@ Client::~Client() {
 }
 
 namespace {
-	static const std::string COLOR_GRAY  = "\033[30m";
-	static const std::string COLOR_RESET = "\033[0m";
 
-	void DebugPrint(const std::string &s) {
-		std::cerr << COLOR_GRAY << s << COLOR_RESET << std::endl;
-	}
+static const std::string COLOR_GRAY  = "\033[30m";
+static const std::string COLOR_RESET = "\033[0m";
+
+void DebugPrint(const std::string &s) {
+	std::cerr << COLOR_GRAY << s << COLOR_RESET << std::endl;
+}
+
 } // namespace
 
 void Client::SendRequestAndReceiveResponse(const std::string &message) {

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -6,36 +6,38 @@
 #include <sstream> // stringstream
 
 namespace {
-	static const std::string COLOR_RED   = "\033[31m";
-	static const std::string COLOR_RESET = "\033[0m";
 
-	void PrintError(const std::string &s) {
-		std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
-	}
+static const std::string COLOR_RED   = "\033[31m";
+static const std::string COLOR_RESET = "\033[0m";
 
-	unsigned int ConvertStrToUint(const std::string &str) {
-		std::stringstream ss(str);
-		int               num;
-		ss >> num;
-		if (num < 0 || !ss.eof() || ss.fail()) {
-			throw std::logic_error("invalid port");
-		}
-		return static_cast<unsigned int>(num);
-	}
+void PrintError(const std::string &s) {
+	std::cerr << COLOR_RED << "Error: " << s << COLOR_RESET << std::endl;
+}
 
-	std::string FileToString(const std::ifstream &file) {
-		std::stringstream ss;
-		ss << file.rdbuf();
-		return ss.str();
+unsigned int ConvertStrToUint(const std::string &str) {
+	std::stringstream ss(str);
+	int               num;
+	ss >> num;
+	if (num < 0 || !ss.eof() || ss.fail()) {
+		throw std::logic_error("invalid port");
 	}
+	return static_cast<unsigned int>(num);
+}
 
-	std::string ReadFileStr(const std::string &file_path) {
-		std::ifstream file(file_path.c_str());
-		if (!file) {
-			throw std::runtime_error("error infile");
-		}
-		return FileToString(file);
+std::string FileToString(const std::ifstream &file) {
+	std::stringstream ss;
+	ss << file.rdbuf();
+	return ss.str();
+}
+
+std::string ReadFileStr(const std::string &file_path) {
+	std::ifstream file(file_path.c_str());
+	if (!file) {
+		throw std::runtime_error("error infile");
 	}
+	return FileToString(file);
+}
+
 } // namespace
 
 // ./client PORT INFILE_PATH

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -48,10 +48,9 @@ int main(int argc, char **argv) {
 	}
 
 	try {
-		const unsigned int port = ConvertStrToUint(argv[1]);
-		const std::string  request_message =
-			ReadFileStr(std::string(argv[2], std::strlen(argv[2])));
-		Client client(port);
+		const unsigned int port           = ConvertStrToUint(argv[1]);
+		const std::string request_message = ReadFileStr(std::string(argv[2], std::strlen(argv[2])));
+		Client            client(port);
 		client.SendRequestAndReceiveResponse(request_message);
 	} catch (const std::exception &e) {
 		PrintError(e.what());

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -6,31 +6,34 @@
 #include <string>
 
 namespace {
-	// 比較する型
-	typedef std::vector<std::string> Strs;
 
-	// expectedのStrsを作成
-	// templateのパラメータパックがc++11以降なので使っていない
-	// 手動で正しいsizeをセットする必要有り
-	Strs CreateExpect(const std::string *array, std::size_t size) {
-		return Strs(array, array + size);
+// 比較する型
+typedef std::vector<std::string> Strs;
+
+// expectedのStrsを作成
+// templateのパラメータパックがc++11以降なので使っていない
+// 手動で正しいsizeをセットする必要有り
+Strs CreateExpect(const std::string *array, std::size_t size) {
+	return Strs(array, array + size);
+}
+
+// SplitStr()を実行してexpectedと比較
+void Run(
+	const std::string &src, const std::string &substring, const Strs &expected
+) {
+	static unsigned int test_case = 0;
+	test_case++;
+
+	if (utils::SplitStr(src, substring) == expected) {
+		std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src
+				  << std::endl;
+	} else {
+		std::cerr << COLOR_RED << test_case << ".[NG] " << COLOR_RESET << src
+				  << std::endl;
+		throw std::logic_error("SplitStr()");
 	}
+}
 
-	// SplitStr()を実行してexpectedと比較
-	void
-	Run(const std::string &src, const std::string &substring, const Strs &expected) {
-		static unsigned int test_case = 0;
-		test_case++;
-
-		if (utils::SplitStr(src, substring) == expected) {
-			std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src
-					  << std::endl;
-		} else {
-			std::cerr << COLOR_RED << test_case << ".[NG] " << COLOR_RESET << src
-					  << std::endl;
-			throw std::logic_error("SplitStr()");
-		}
-	}
 } // namespace
 
 int main() {

--- a/test/unit/split/main.cpp
+++ b/test/unit/split/main.cpp
@@ -18,18 +18,14 @@ Strs CreateExpect(const std::string *array, std::size_t size) {
 }
 
 // SplitStr()を実行してexpectedと比較
-void Run(
-	const std::string &src, const std::string &substring, const Strs &expected
-) {
+void Run(const std::string &src, const std::string &substring, const Strs &expected) {
 	static unsigned int test_case = 0;
 	test_case++;
 
 	if (utils::SplitStr(src, substring) == expected) {
-		std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src
-				  << std::endl;
+		std::cerr << COLOR_GREEN << test_case << ".[OK] " << COLOR_RESET << src << std::endl;
 	} else {
-		std::cerr << COLOR_RED << test_case << ".[NG] " << COLOR_RESET << src
-				  << std::endl;
+		std::cerr << COLOR_RED << test_case << ".[NG] " << COLOR_RESET << src << std::endl;
 		throw std::logic_error("SplitStr()");
 	}
 }


### PR DESCRIPTION
コードの内容に変更はなしです

namespace を全体に使用しようとした際に、今までの format では少し改行が増えすぎてしまったので意見を聞いて以下を変更
- [x] namespace で囲った時のインデントをなくす
- [x] 横幅を少し増やす
- [x] 現在の main branch の `srcs`, `test` ディレクトリ以下にあるファイルに適用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **スタイル**
  - コードの整形とインデントの調整を多数のファイルで実施しました。

- **テスト**
  - ユニットテストのコード整形と組織化を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->