### PR TITLE
[add] 複数 port 用 socket 対応

### DIFF
--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -1,0 +1,63 @@
+#include "connection.hpp"
+#include "server.hpp"
+#include <netinet/in.h> // struct sockaddr_in
+#include <stdexcept>    // runtime_error
+#include <sys/socket.h> // socket
+
+// todo: tmp
+#include "utils.hpp"
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+namespace server {
+
+// todo: port->uint16_t
+int Connection::Init(unsigned int port) {
+	// socket
+	const int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (server_fd == SYSTEM_ERROR) {
+		throw std::runtime_error("socket failed");
+	}
+	// set socket option to reuse address
+	int optval = 1;
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == SYSTEM_ERROR) {
+		throw std::runtime_error("setsockopt failed");
+	}
+
+	struct sockaddr_in sock_addr;
+	sock_addr.sin_family      = AF_INET;
+	sock_addr.sin_addr.s_addr = INADDR_ANY;
+	sock_addr.sin_port        = htons(port);
+	const socklen_t addr_len  = sizeof(sock_addr);
+	// bind
+	if (bind(server_fd, (const struct sockaddr *)&sock_addr, addr_len) == SYSTEM_ERROR) {
+		throw std::runtime_error("bind failed");
+	}
+
+	// listen
+	if (listen(server_fd, 3) == SYSTEM_ERROR) {
+		throw std::runtime_error("listen failed");
+	}
+	return server_fd;
+}
+
+int Connection::Accept(int server_fd) {
+	struct sockaddr_in client_sock_addr;
+	socklen_t          addrlen = sizeof(client_sock_addr);
+	const int new_socket       = accept(server_fd, (struct sockaddr *)&client_sock_addr, &addrlen);
+	// todo
+	// if (new_socket == SYSTEM_ERROR) {
+	// 	throw std::runtime_error("accept failed");
+	// }
+
+	// clientのIP addressとportを取得できる
+	// todo: getaddrinfo() 使う
+	char client_ip[INET_ADDRSTRLEN];
+	inet_ntop(AF_INET, &(client_sock_addr.sin_addr), client_ip, INET_ADDRSTRLEN);
+	const int client_port = ntohs(client_sock_addr.sin_port);
+	utils::Debug("accept", "client IP: " + std::string(client_ip) + " / port", client_port);
+
+	return new_socket;
+}
+
+} // namespace server

--- a/srcs/connection.hpp
+++ b/srcs/connection.hpp
@@ -1,0 +1,25 @@
+#ifndef CONNECTION_HPP_
+#define CONNECTION_HPP_
+
+#include <string>
+
+namespace server {
+
+class Connection {
+  public:
+	static int Init(unsigned int port);
+	static int Accept(int server_fd);
+
+  private:
+	Connection();
+	~Connection();
+	// prohibit copy
+	Connection(const Connection &other);
+	Connection &operator=(const Connection &other);
+	// const
+	static const int SYSTEM_ERROR = -1;
+};
+
+} // namespace server
+
+#endif /* CONNECTION_HPP_ */

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -2,6 +2,7 @@
 #define EPOLL_HPP_
 
 #include "event.hpp"
+#include "sock_info.hpp"
 #include <cstddef>     // size_t
 #include <sys/epoll.h> // epoll
 
@@ -11,9 +12,9 @@ class Epoll {
   public:
 	Epoll();
 	~Epoll();
-	void AddNewConnection(int socket_fd, event::Type type);
-	void DeleteConnection(int socket_fd);
-	void UpdateEventType(const event::Event &event, event::Type new_type);
+	void AddNewConnection(server::SockInfo *server, event::Type type);
+	void DeleteConnection(server::SockInfo *server);
+	void UpdateEventType(int socket_fd, server::SockInfo *server, event::Type new_type);
 	int  CreateReadyList();
 	// getter
 	event::Event GetEvent(std::size_t index) const;

--- a/srcs/event.hpp
+++ b/srcs/event.hpp
@@ -1,6 +1,7 @@
 #ifndef EVENT_HPP_
 #define EVENT_HPP_
 
+#include "sock_info.hpp"
 #include <stdint.h> // uint32_t
 
 namespace event {
@@ -14,8 +15,8 @@ enum Type {
 };
 
 struct Event {
-	int     fd;
-	int32_t type;
+	int32_t           type;
+	server::SockInfo *sock_info;
 };
 
 } // namespace event

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -1,31 +1,30 @@
 #include "server.hpp"
+#include "connection.hpp"
 #include "event.hpp"
 #include "http.hpp"
 #include "utils.hpp"
-#include <arpa/inet.h> // htons
 #include <errno.h>
-#include <sys/socket.h> // socket
+#include <sys/socket.h> // send
 #include <unistd.h>     // close
 
 namespace server {
 
 // todo: set ConfigData -> private variables
-Server::Server(const _config::Config::ConfigData &config)
-	: server_name_("from_config"), port_(8080) {
+Server::Server(const _config::Config::ConfigData &config) {
 	(void)config;
-	Init();
-	utils::Debug("server", "init server & listen", server_fd_);
+
+	std::vector<TempConfig> servers;
+	servers.push_back(std::make_pair("localhost", 8080));
+	servers.push_back(std::make_pair("abcde", 12345));
+	Init(servers);
 }
 
 Server::~Server() {
-	// todo: close() error handle
-	if (server_fd_ != SYSTEM_ERROR) {
-		close(server_fd_);
-	}
+	sock_infos_.clear();
 }
 
 void Server::Run() {
-	utils::Debug("server", "run server", server_fd_);
+	utils::Debug("server", "run server");
 
 	while (true) {
 		errno           = 0;
@@ -40,21 +39,36 @@ void Server::Run() {
 	}
 }
 
+namespace {
+
+bool IsServerFd(int sock_fd, const Server::SockInfos &sock_infos) {
+	return sock_infos.count(sock_fd) == 1;
+}
+
+} // namespace
+
 void Server::HandleEvent(const event::Event &event) {
-	if (event.fd == server_fd_) {
-		HandleNewConnection();
+	SockInfo *sock_info = static_cast<SockInfo *>(event.sock_info);
+	if (IsServerFd(sock_info->fd, sock_infos_)) {
+		HandleNewConnection(event);
 	} else {
 		HandleExistingConnection(event);
 	}
 }
 
-void Server::HandleNewConnection() {
-	const int new_socket = accept(server_fd_, (struct sockaddr *)&sock_addr_, &addrlen_);
-	if (new_socket == SYSTEM_ERROR) {
+void Server::HandleNewConnection(const event::Event &event) {
+	SockInfo *sock_info = static_cast<SockInfo *>(event.sock_info);
+
+	const int client_fd = Connection::Accept(sock_info->fd);
+	if (client_fd == SYSTEM_ERROR) {
 		throw std::runtime_error("accept failed");
 	}
-	monitor_.AddNewConnection(new_socket, event::EVENT_READ);
-	utils::Debug("server", "add new client", new_socket);
+	// todo: new なくせないか
+	// SockInfo client        = SockInfo(sock_info->name, client_fd);
+	// sock_infos_[client_fd] = client;
+	// monitor_.AddNewConnection(&sock_infos_[client_fd], event::EVENT_READ);
+	monitor_.AddNewConnection(new SockInfo(sock_info->name, client_fd), event::EVENT_READ);
+	utils::Debug("server", "add new client", client_fd);
 }
 
 void Server::HandleExistingConnection(const event::Event &event) {
@@ -62,7 +76,7 @@ void Server::HandleExistingConnection(const event::Event &event) {
 		ReadRequest(event);
 	}
 	if (event.type & event::EVENT_WRITE) {
-		SendResponse(event.fd);
+		SendResponse(event);
 	}
 	// todo: handle other EventType
 }
@@ -82,7 +96,8 @@ bool IsRequestReceivedComplete(const std::string &buffer) {
 } // namespace
 
 void Server::ReadRequest(const event::Event &event) {
-	const int client_fd = event.fd;
+	SockInfo *sock_info = static_cast<SockInfo *>(event.sock_info);
+	const int client_fd = sock_info->fd;
 
 	ssize_t read_ret = buffers_.Read(client_fd);
 	if (read_ret <= 0) {
@@ -97,11 +112,14 @@ void Server::ReadRequest(const event::Event &event) {
 	if (IsRequestReceivedComplete(buffers_.GetBuffer(client_fd))) {
 		utils::Debug("server", "received all request from client", client_fd);
 		std::cerr << buffers_.GetBuffer(client_fd) << std::endl;
-		monitor_.UpdateEventType(event, event::EVENT_WRITE);
+		monitor_.UpdateEventType(client_fd, sock_info, event::EVENT_WRITE);
 	}
 }
 
-void Server::SendResponse(int client_fd) {
+void Server::SendResponse(const event::Event &event) {
+	SockInfo *sock_info = static_cast<SockInfo *>(event.sock_info);
+	const int client_fd = sock_info->fd;
+
 	// todo: check if it's ready to start write/send
 	const std::string response = CreateHttpResponse(buffers_.GetBuffer(client_fd));
 	send(client_fd, response.c_str(), response.size(), 0);
@@ -110,40 +128,25 @@ void Server::SendResponse(int client_fd) {
 	// disconnect
 	buffers_.Delete(client_fd);
 	close(client_fd);
-	monitor_.DeleteConnection(client_fd);
+	monitor_.DeleteConnection(sock_info);
+	sock_infos_.erase(client_fd);
 	utils::Debug("server", "disconnected client", client_fd);
 	utils::Debug("------------------------------------------");
 }
 
-void Server::Init() {
-	addrlen_ = sizeof(sock_addr_);
+void Server::Init(const std::vector<TempConfig> &servers) {
+	typedef std::vector<TempConfig>::const_iterator Itr;
+	for (Itr it = servers.begin(); it != servers.end(); ++it) {
+		const std::string  server_name = it->first;
+		const unsigned int port        = it->second;
 
-	// socket
-	server_fd_ = socket(AF_INET, SOCK_STREAM, 0);
-	if (server_fd_ == SYSTEM_ERROR) {
-		throw std::runtime_error("socket failed");
+		const unsigned int fd     = Connection::Init(port);
+		SockInfo           server = SockInfo(server_name, fd);
+		sock_infos_[server.fd]    = server;
+		// add to epoll's interest list
+		monitor_.AddNewConnection(&sock_infos_[server.fd], event::EVENT_READ);
+		utils::Debug("server", "init server & listen", server.fd);
 	}
-	// set socket option to reuse address
-	int optval = 1;
-	if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == SYSTEM_ERROR) {
-		throw std::runtime_error("setsockopt failed");
-	}
-	sock_addr_.sin_family      = AF_INET;
-	sock_addr_.sin_addr.s_addr = INADDR_ANY;
-	sock_addr_.sin_port        = htons(port_);
-
-	// bind
-	if (bind(server_fd_, (const struct sockaddr *)&sock_addr_, addrlen_) == SYSTEM_ERROR) {
-		throw std::runtime_error("bind failed");
-	}
-
-	// listen
-	if (listen(server_fd_, 3) == SYSTEM_ERROR) {
-		throw std::runtime_error("listen failed");
-	}
-
-	// add to epoll's interest list
-	monitor_.AddNewConnection(server_fd_, event::EVENT_READ);
 }
 
 } // namespace server

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -4,8 +4,9 @@
 #include "_config.hpp"
 #include "buffer.hpp"
 #include "epoll.hpp"
-#include <netinet/in.h> // struct sockaddr_in
+#include <map>
 #include <string>
+#include <vector>
 
 namespace server {
 
@@ -14,27 +15,25 @@ class Server {
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
+	// todo: tmp
+	typedef std::pair<std::string, int>      TempConfig;
+	typedef std::map<unsigned int, SockInfo> SockInfos;
 
   private:
 	Server();
 	// prohibit copy
 	Server(const Server &other);
 	Server &operator=(const Server &other);
-	void    Init();
+	void    Init(const std::vector<TempConfig> &servers);
 	void    HandleEvent(const event::Event &event);
-	void    HandleNewConnection();
+	void    HandleNewConnection(const event::Event &event);
 	void    HandleExistingConnection(const event::Event &event);
 	void    ReadRequest(const event::Event &event);
-	void    SendResponse(int client_fd);
-	// const variables (todo: tmp)
-	const std::string  server_name_;
-	const unsigned int port_;
+	void    SendResponse(const event::Event &event);
 	// const
 	static const int SYSTEM_ERROR = -1;
-	// socket
-	struct sockaddr_in sock_addr_;
-	socklen_t          addrlen_;
-	int                server_fd_;
+	// SockInfo instances
+	SockInfos sock_infos_;
 	// event poll
 	epoll::Epoll monitor_;
 	// request buffers

--- a/srcs/sock_info.hpp
+++ b/srcs/sock_info.hpp
@@ -1,0 +1,27 @@
+#ifndef SOCK_INFO_HPP_
+#define SOCK_INFO_HPP_
+
+#include <string>
+
+namespace server {
+
+struct SockInfo {
+	// default constructor: necessary for map's operator[]
+	SockInfo() : name(""), fd(0) {}
+	SockInfo(const std::string &server_name, unsigned int fd) : name(server_name), fd(fd) {}
+	SockInfo(const SockInfo &other) : name(other.name), fd(other.fd) {}
+	SockInfo &operator=(const SockInfo &other) {
+		if (this != &other) {
+			name = other.name;
+			fd   = other.fd;
+		}
+		return *this;
+	}
+	// variables
+	std::string name;
+	int         fd;
+};
+
+} // namespace server
+
+#endif /* SOCK_INFO_HPP_ */


### PR DESCRIPTION
仮。
一旦 server が map で保持して、epoll_event 構造体の ptr に渡す方式

相談したりして決めたい
- socket 情報の持ち方
- epoll の ptr に渡すのか
- server 側が map などで保持するのか

-> server 側が map などで fd 毎の socket 情報を保持し、epoll には fd だけ渡すような構造で一旦作ることに (-> Issue #130 )