### PR TITLE
[add] 複数 port 用 socket 対応

### DIFF
--- a/srcs/buffer.cpp
+++ b/srcs/buffer.cpp
@@ -26,9 +26,10 @@ void Buffer::Delete(int fd) {
 	buffers_[fd].erase();
 }
 
-std::string Buffer::GetBuffer(int fd) const {
+// In C++98, the map's "at" method is unavailable, not using const qualifiers.
+std::string &Buffer::GetBuffer(int fd) {
 	// todo: fd error handle
-	return buffers_.at(fd);
+	return buffers_[fd];
 }
 
 } // namespace server

--- a/srcs/buffer.hpp
+++ b/srcs/buffer.hpp
@@ -13,9 +13,9 @@ class Buffer {
 	typedef std::map<int, std::string> Buffers;
 	Buffer();
 	~Buffer();
-	ssize_t     Read(int fd);
-	void        Delete(int fd);
-	std::string GetBuffer(int fd) const;
+	ssize_t      Read(int fd);
+	void         Delete(int fd);
+	std::string &GetBuffer(int fd);
 
   private:
 	// prohibit copy

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -6,7 +6,11 @@
 
 namespace server {
 
-int Connection::Init(SockInfo &server_sock_info) {
+Connection::Connection() {}
+
+Connection::~Connection() {}
+
+int Connection::Connect(SockInfo &server_sock_info) {
 	// socket
 	const int server_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (server_fd == SYSTEM_ERROR) {
@@ -30,6 +34,8 @@ int Connection::Init(SockInfo &server_sock_info) {
 	if (listen(server_fd, 3) == SYSTEM_ERROR) {
 		throw std::runtime_error("listen failed");
 	}
+	listen_server_fds_.insert(server_fd);
+
 	return server_fd;
 }
 
@@ -46,6 +52,10 @@ int Connection::Accept(SockInfo &sock_info) {
 	// 	throw std::runtime_error("accept failed");
 	// }
 	return new_socket;
+}
+
+bool Connection::IsListenServerFd(int sock_fd) const {
+	return listen_server_fds_.count(sock_fd) == 1;
 }
 
 } // namespace server

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -1,0 +1,42 @@
+#include "connection.hpp"
+#include "server.hpp"
+#include <stdexcept>    // runtime_error
+#include <sys/socket.h> // socket,setsockopt,bind,listen,accept
+
+namespace server {
+
+int Connection::Init(struct sockaddr_in &sock_addr, socklen_t addrlen) {
+	// socket
+	const int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (server_fd == SYSTEM_ERROR) {
+		throw std::runtime_error("socket failed");
+	}
+	// set socket option to reuse address
+	// optval : Specify a non-zero value to enable the boolean option, or zero to disable it
+	int optval = 1;
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == SYSTEM_ERROR) {
+		throw std::runtime_error("setsockopt failed");
+	}
+
+	// bind
+	if (bind(server_fd, (const struct sockaddr *)&sock_addr, addrlen) == SYSTEM_ERROR) {
+		throw std::runtime_error("bind failed");
+	}
+
+	// listen
+	if (listen(server_fd, 3) == SYSTEM_ERROR) {
+		throw std::runtime_error("listen failed");
+	}
+	return server_fd;
+}
+
+int Connection::Accept(int server_fd, struct sockaddr_in &sock_addr, socklen_t *addrlen) {
+	const int new_socket = accept(server_fd, (struct sockaddr *)&sock_addr, addrlen);
+	// todo: need?
+	// if (new_socket == SYSTEM_ERROR) {
+	// 	throw std::runtime_error("accept failed");
+	// }
+	return new_socket;
+}
+
+} // namespace server

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -30,6 +30,7 @@ int Connection::Connect(SockInfo &server_sock_info) {
 		throw std::runtime_error("bind failed");
 	}
 
+	// todo / listen() : set an appropriate backlog value
 	// listen
 	if (listen(server_fd, 3) == SYSTEM_ERROR) {
 		throw std::runtime_error("listen failed");

--- a/srcs/connection.hpp
+++ b/srcs/connection.hpp
@@ -6,10 +6,12 @@
 
 namespace server {
 
+class SockInfo;
+
 class Connection {
   public:
-	static int Init(struct sockaddr_in &sock_addr, socklen_t addrlen);
-	static int Accept(int server_fd, struct sockaddr_in &sock_addr, socklen_t *addrlen);
+	static int Init(SockInfo &server_sock_info);
+	static int Accept(SockInfo &sock_info);
 
   private:
 	Connection();

--- a/srcs/connection.hpp
+++ b/srcs/connection.hpp
@@ -2,6 +2,7 @@
 #define CONNECTION_HPP_
 
 #include <netinet/in.h> // struct sockaddr_in
+#include <set>
 #include <string>
 
 namespace server {
@@ -10,17 +11,22 @@ class SockInfo;
 
 class Connection {
   public:
-	static int Init(SockInfo &server_sock_info);
-	static int Accept(SockInfo &sock_info);
-
-  private:
+	typedef std::set<int> FdSet;
 	Connection();
 	~Connection();
+	// function
+	int        Connect(SockInfo &server_sock_info);
+	static int Accept(SockInfo &sock_info);
+	bool       IsListenServerFd(int sock_fd) const;
+
+  private:
 	// prohibit copy
 	Connection(const Connection &other);
 	Connection &operator=(const Connection &other);
 	// const
 	static const int SYSTEM_ERROR = -1;
+	// variable
+	FdSet listen_server_fds_;
 };
 
 } // namespace server

--- a/srcs/connection.hpp
+++ b/srcs/connection.hpp
@@ -1,0 +1,26 @@
+#ifndef CONNECTION_HPP_
+#define CONNECTION_HPP_
+
+#include <netinet/in.h> // struct sockaddr_in
+#include <string>
+
+namespace server {
+
+class Connection {
+  public:
+	static int Init(struct sockaddr_in &sock_addr, socklen_t addrlen);
+	static int Accept(int server_fd, struct sockaddr_in &sock_addr, socklen_t *addrlen);
+
+  private:
+	Connection();
+	~Connection();
+	// prohibit copy
+	Connection(const Connection &other);
+	Connection &operator=(const Connection &other);
+	// const
+	static const int SYSTEM_ERROR = -1;
+};
+
+} // namespace server
+
+#endif /* CONNECTION_HPP_ */

--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -55,7 +55,8 @@ event::Event ConvertToEventDto(const struct epoll_event &event) {
 
 } // namespace
 
-void Epoll::AddNewConnection(int socket_fd, event::Type type) {
+// add socket_fd to epoll's interest list
+void Epoll::Add(int socket_fd, event::Type type) {
 	struct epoll_event ev;
 	ev.events  = ConvertToEpollEventType(type);
 	ev.data.fd = socket_fd;
@@ -64,8 +65,9 @@ void Epoll::AddNewConnection(int socket_fd, event::Type type) {
 	}
 }
 
-// todo: error?
-void Epoll::DeleteConnection(int socket_fd) {
+// remove socket_fd from epoll's interest list
+void Epoll::Delete(int socket_fd) {
+	// todo: error?
 	epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, socket_fd, NULL);
 }
 
@@ -82,8 +84,8 @@ int Epoll::CreateReadyList() {
 	return ready;
 }
 
-// override with new_type
-void Epoll::UpdateEventType(const event::Event &event, const event::Type new_type) {
+// update epoll's interest list with new_type
+void Epoll::Update(const event::Event &event, const event::Type new_type) {
 	const int socket_fd = event.fd;
 
 	struct epoll_event ev;

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -11,9 +11,9 @@ class Epoll {
   public:
 	Epoll();
 	~Epoll();
-	void AddNewConnection(int socket_fd, event::Type type);
-	void DeleteConnection(int socket_fd);
-	void UpdateEventType(const event::Event &event, event::Type new_type);
+	void Add(int socket_fd, event::Type type);
+	void Delete(int socket_fd);
+	void Update(const event::Event &event, event::Type new_type);
 	int  CreateReadyList();
 	// getter
 	event::Event GetEvent(std::size_t index) const;

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -5,9 +5,9 @@
 namespace http {
 namespace {
 
-void CreateStatusLine(std::ostream &response_stream, const Http::RequestMessage &request) {
-	response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
-					<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
+void CreateStatusLine(std::ostream &response_stream, Http::RequestMessage &request) {
+	response_stream << HTTP_VERSION << SP << request[Http::HTTP_STATUS] << SP
+					<< request[Http::HTTP_STATUS_TEXT] << CRLF;
 }
 
 template <typename T>
@@ -15,17 +15,17 @@ void CreateHeaderField(std::ostream &response_stream, const std::string &name, c
 	response_stream << name << ":" << SP << value << SP << CRLF;
 }
 
-void CreateHeaderFields(std::ostream &response_stream, const Http::RequestMessage &request) {
+void CreateHeaderFields(std::ostream &response_stream, Http::RequestMessage &request) {
 	CreateHeaderField(response_stream, CONNECTION, "close");
-	CreateHeaderField(response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size());
+	CreateHeaderField(response_stream, CONTENT_LENGTH, request[Http::HTTP_CONTENT].size());
 }
 
 void CreateCRLF(std::ostream &response_stream) {
 	response_stream << CRLF;
 }
 
-void CreateBody(std::ostream &response_stream, const Http::RequestMessage &request) {
-	response_stream << request.at(Http::HTTP_CONTENT);
+void CreateBody(std::ostream &response_stream, Http::RequestMessage &request) {
+	response_stream << request[Http::HTTP_CONTENT];
 }
 
 } // namespace

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -41,8 +41,17 @@ void Server::Run() {
 	}
 }
 
+namespace {
+
+bool IsListenServerFd(int sock_fd, const Server::FdSet &listen_server_fds) {
+	return listen_server_fds.count(sock_fd) == 1;
+}
+
+} // namespace
+
 void Server::HandleEvent(const event::Event &event) {
-	if (event.fd == server_fd_) {
+	const int sock_fd = event.fd;
+	if (IsListenServerFd(sock_fd, listen_server_fds_)) {
 		HandleNewConnection();
 	} else {
 		HandleExistingConnection(event);
@@ -124,6 +133,7 @@ void Server::Init() {
 	addrlen_                   = sizeof(sock_addr_);
 
 	server_fd_ = Connection::Init(sock_addr_, addrlen_);
+	listen_server_fds_.insert(server_fd_);
 	// add to epoll's interest list
 	monitor_.AddNewConnection(server_fd_, event::EVENT_READ);
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -10,8 +10,8 @@
 namespace server {
 namespace {
 
-Server::SockInfos ConvertConfigToSockInfos(std::vector<Server::TempConfig> server_configs) {
-	Server::SockInfos sock_infos;
+Server::SockInfoVec ConvertConfigToSockInfoVec(std::vector<Server::TempConfig> server_configs) {
+	Server::SockInfoVec sock_infos;
 
 	typedef std::vector<Server::TempConfig>::const_iterator Itr;
 	for (Itr it = server_configs.begin(); it != server_configs.end(); ++it) {
@@ -35,7 +35,7 @@ Server::Server(const _config::Config::ConfigData &config) {
 	server_configs.push_back(std::make_pair("localhost", 8080));
 	server_configs.push_back(std::make_pair("tmp_server_name", 12345));
 
-	SockInfos sock_infos = ConvertConfigToSockInfos(server_configs);
+	SockInfoVec sock_infos = ConvertConfigToSockInfoVec(server_configs);
 	Init(sock_infos);
 }
 Server::~Server() {}
@@ -142,8 +142,8 @@ void Server::SendResponse(int client_fd) {
 	utils::Debug("------------------------------------------");
 }
 
-void Server::Init(const SockInfos &sock_infos) {
-	typedef SockInfos::const_iterator Itr;
+void Server::Init(const SockInfoVec &sock_infos) {
+	typedef SockInfoVec::const_iterator Itr;
 	for (Itr it = sock_infos.begin(); it != sock_infos.end(); ++it) {
 		SockInfo server_sock_info = *it;
 		// connect & listen

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -9,13 +9,36 @@
 #include <unistd.h>     // close
 
 namespace server {
+namespace {
+
+Server::SockInfos ConvertConfigToSockInfos(std::vector<Server::TempConfig> server_configs) {
+	Server::SockInfos sock_infos;
+
+	typedef std::vector<Server::TempConfig>::const_iterator Itr;
+	for (Itr it = server_configs.begin(); it != server_configs.end(); ++it) {
+		const std::string  server_name = it->first;
+		const unsigned int port        = it->second;
+
+		SockInfo server_sock_info(server_name, port);
+		sock_infos.push_back(server_sock_info);
+	}
+	return sock_infos;
+}
+
+} // namespace
 
 // todo: set ConfigData -> private variables
 Server::Server(const _config::Config::ConfigData &config) {
 	(void)config;
-	Init("localhost", 8080);
-}
 
+	// todo: tmp
+	std::vector<TempConfig> server_configs;
+	server_configs.push_back(std::make_pair("localhost", 8080));
+	server_configs.push_back(std::make_pair("tmp_server_name", 12345));
+
+	SockInfos sock_infos = ConvertConfigToSockInfos(server_configs);
+	Init(sock_infos);
+}
 Server::~Server() {}
 
 void Server::Run() {
@@ -128,18 +151,21 @@ void Server::SendResponse(int client_fd) {
 	utils::Debug("------------------------------------------");
 }
 
-void Server::Init(const std::string &server_name, unsigned int port) {
-	SockInfo server_sock_info(server_name, port);
-	// connect & listen
-	const int server_fd = Connection::Init(server_sock_info);
-	server_sock_info.SetSockFd(server_fd);
+void Server::Init(const SockInfos &sock_infos) {
+	typedef SockInfos::const_iterator Itr;
+	for (Itr it = sock_infos.begin(); it != sock_infos.end(); ++it) {
+		SockInfo server_sock_info = *it;
+		// connect & listen
+		const int server_fd = Connection::Init(server_sock_info);
+		server_sock_info.SetSockFd(server_fd);
 
-	listen_server_fds_.insert(server_fd);
-	// add to context
-	context_.AddSockInfo(server_fd, server_sock_info);
-	// add to epoll's interest list
-	monitor_.AddNewConnection(server_fd, event::EVENT_READ);
-	utils::Debug("server", "init server & listen", server_fd);
+		listen_server_fds_.insert(server_fd);
+		// add to context
+		context_.AddSockInfo(server_fd, server_sock_info);
+		// add to epoll's interest list
+		monitor_.AddNewConnection(server_fd, event::EVENT_READ);
+		utils::Debug("server", "init server & listen", server_fd);
+	}
 }
 
 } // namespace server

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -78,8 +78,7 @@ void Server::HandleNewConnection(int sock_fd) {
 	new_sock_info.SetPeerSockFd(new_sock_fd);
 	// add to context
 	context_.AddSockInfo(new_sock_fd, new_sock_info);
-	// add to epoll's interest list
-	event_monitor_.AddNewConnection(new_sock_fd, event::EVENT_READ);
+	event_monitor_.Add(new_sock_fd, event::EVENT_READ);
 	utils::Debug("server", "add new client", new_sock_fd);
 }
 
@@ -117,13 +116,13 @@ void Server::ReadRequest(const event::Event &event) {
 		}
 		// todo: need?
 		// buffers_.Delete(client_fd);
-		// event_monitor_.DeleteConnection(client_fd);
+		// event_monitor_.Delete(client_fd);
 		return;
 	}
 	if (IsRequestReceivedComplete(buffers_.GetBuffer(client_fd))) {
 		utils::Debug("server", "received all request from client", client_fd);
 		std::cerr << buffers_.GetBuffer(client_fd) << std::endl;
-		event_monitor_.UpdateEventType(event, event::EVENT_WRITE);
+		event_monitor_.Update(event, event::EVENT_WRITE);
 	}
 }
 
@@ -136,7 +135,7 @@ void Server::SendResponse(int client_fd) {
 	// disconnect
 	buffers_.Delete(client_fd);
 	context_.DeleteSockInfo(client_fd);
-	event_monitor_.DeleteConnection(client_fd);
+	event_monitor_.Delete(client_fd);
 	close(client_fd);
 	utils::Debug("server", "disconnected client", client_fd);
 	utils::Debug("------------------------------------------");
@@ -152,8 +151,7 @@ void Server::Init(const SockInfoVec &sock_infos) {
 
 		// add to context
 		context_.AddSockInfo(server_fd, server_sock_info);
-		// add to epoll's interest list
-		event_monitor_.AddNewConnection(server_fd, event::EVENT_READ);
+		event_monitor_.Add(server_fd, event::EVENT_READ);
 		utils::Debug("server", "init server & listen", server_fd);
 	}
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -65,21 +65,21 @@ void Server::HandleEvent(const event::Event &event) {
 	}
 }
 
-void Server::HandleNewConnection(int sock_fd) {
-	SockInfo &sock_info = context_.GetSockInfo(sock_fd);
+void Server::HandleNewConnection(int server_fd) {
+	SockInfo &tmp_server_sock_info = context_.GetSockInfo(server_fd);
 
 	// A new socket that has established a connection with the peer socket.
-	const int new_sock_fd = Connection::Accept(sock_info);
-	if (new_sock_fd == SYSTEM_ERROR) {
+	const int client_fd = Connection::Accept(tmp_server_sock_info);
+	if (client_fd == SYSTEM_ERROR) {
 		throw std::runtime_error("accept failed");
 	}
 
-	SockInfo new_sock_info = sock_info;
-	new_sock_info.SetPeerSockFd(new_sock_fd);
+	SockInfo new_sock_info = tmp_server_sock_info;
+	new_sock_info.SetPeerSockFd(client_fd);
 	// add to context
-	context_.AddSockInfo(new_sock_fd, new_sock_info);
-	event_monitor_.Add(new_sock_fd, event::EVENT_READ);
-	utils::Debug("server", "add new client", new_sock_fd);
+	context_.AddSockInfo(client_fd, new_sock_info);
+	event_monitor_.Add(client_fd, event::EVENT_READ);
+	utils::Debug("server", "add new client", client_fd);
 }
 
 void Server::HandleExistingConnection(const event::Event &event) {

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -37,7 +37,7 @@ class Server {
 	// context
 	SockContext context_;
 	// event poll
-	epoll::Epoll monitor_;
+	epoll::Epoll event_monitor_;
 	// request buffers
 	Buffer buffers_;
 };

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -7,12 +7,15 @@
 #include "sock_context.hpp"
 #include <set>
 #include <string>
+#include <vector>
 
 namespace server {
 
 class Server {
   public:
-	typedef std::set<int> FdSet;
+	typedef std::pair<std::string, int> TempConfig; // todo: tmp
+	typedef std::vector<SockInfo>       SockInfos;
+	typedef std::set<int>               FdSet;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
@@ -22,7 +25,7 @@ class Server {
 	// prohibit copy
 	Server(const Server &other);
 	Server &operator=(const Server &other);
-	void    Init(const std::string &server_name, unsigned int port);
+	void    Init(const SockInfos &sock_infos);
 	void    HandleEvent(const event::Event &event);
 	void    HandleNewConnection(int sock_fd);
 	void    HandleExistingConnection(const event::Event &event);

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -4,7 +4,7 @@
 #include "_config.hpp"
 #include "buffer.hpp"
 #include "epoll.hpp"
-#include <netinet/in.h> // struct sockaddr_in
+#include "sock_context.hpp"
 #include <set>
 #include <string>
 
@@ -22,22 +22,17 @@ class Server {
 	// prohibit copy
 	Server(const Server &other);
 	Server &operator=(const Server &other);
-	void    Init();
+	void    Init(const std::string &server_name, unsigned int port);
 	void    HandleEvent(const event::Event &event);
-	void    HandleNewConnection();
+	void    HandleNewConnection(int sock_fd);
 	void    HandleExistingConnection(const event::Event &event);
 	void    ReadRequest(const event::Event &event);
 	void    SendResponse(int client_fd);
-	// const variables (todo: tmp)
-	const std::string  server_name_;
-	const unsigned int port_;
 	// const
 	static const int SYSTEM_ERROR = -1;
-	// socket
-	struct sockaddr_in sock_addr_;
-	socklen_t          addrlen_;
-	int                server_fd_;
-	FdSet              listen_server_fds_;
+	// context
+	SockContext context_;
+	FdSet       listen_server_fds_;
 	// event poll
 	epoll::Epoll monitor_;
 	// request buffers

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -14,7 +14,7 @@ namespace server {
 class Server {
   public:
 	typedef std::pair<std::string, int> TempConfig; // todo: tmp
-	typedef std::vector<SockInfo>       SockInfos;
+	typedef std::vector<SockInfo>       SockInfoVec;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
@@ -24,7 +24,7 @@ class Server {
 	// prohibit copy
 	Server(const Server &other);
 	Server &operator=(const Server &other);
-	void    Init(const SockInfos &sock_infos);
+	void    Init(const SockInfoVec &sock_infos);
 	void    HandleEvent(const event::Event &event);
 	void    HandleNewConnection(int sock_fd);
 	void    HandleExistingConnection(const event::Event &event);

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -3,9 +3,9 @@
 
 #include "_config.hpp"
 #include "buffer.hpp"
+#include "connection.hpp"
 #include "epoll.hpp"
 #include "sock_context.hpp"
-#include <set>
 #include <string>
 #include <vector>
 
@@ -15,7 +15,6 @@ class Server {
   public:
 	typedef std::pair<std::string, int> TempConfig; // todo: tmp
 	typedef std::vector<SockInfo>       SockInfos;
-	typedef std::set<int>               FdSet;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
@@ -33,9 +32,10 @@ class Server {
 	void    SendResponse(int client_fd);
 	// const
 	static const int SYSTEM_ERROR = -1;
+	// connection
+	Connection connection_;
 	// context
 	SockContext context_;
-	FdSet       listen_server_fds_;
 	// event poll
 	epoll::Epoll monitor_;
 	// request buffers

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -26,7 +26,7 @@ class Server {
 	Server &operator=(const Server &other);
 	void    Init(const SockInfoVec &sock_infos);
 	void    HandleEvent(const event::Event &event);
-	void    HandleNewConnection(int sock_fd);
+	void    HandleNewConnection(int server_fd);
 	void    HandleExistingConnection(const event::Event &event);
 	void    ReadRequest(const event::Event &event);
 	void    SendResponse(int client_fd);

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -5,12 +5,14 @@
 #include "buffer.hpp"
 #include "epoll.hpp"
 #include <netinet/in.h> // struct sockaddr_in
+#include <set>
 #include <string>
 
 namespace server {
 
 class Server {
   public:
+	typedef std::set<int> FdSet;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
@@ -35,6 +37,7 @@ class Server {
 	struct sockaddr_in sock_addr_;
 	socklen_t          addrlen_;
 	int                server_fd_;
+	FdSet              listen_server_fds_;
 	// event poll
 	epoll::Epoll monitor_;
 	// request buffers

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -1,1 +1,12 @@
 #include "sock_context.hpp"
+#include "sock_info.hpp"
+
+namespace server {
+
+SockInfo &SockContext::GetSockInfo(int fd) {
+	SockInfo &sock_info = context_.at(fd);
+	// todo: fd doesn't exist, throw logic_error
+	return sock_info;
+}
+
+} // namespace server

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -1,7 +1,20 @@
 #include "sock_context.hpp"
 #include "sock_info.hpp"
+#include <unistd.h> // close
 
 namespace server {
+
+SockContext::SockContext() {}
+
+SockContext::~SockContext() {
+	typedef std::map<int, SockInfo>::iterator Itr;
+	for (Itr it = context_.begin(); it != context_.end(); ++it) {
+		const int fd = it->first;
+		if (fd != SYSTEM_ERROR) {
+			close(fd);
+		}
+	}
+}
 
 SockInfo &SockContext::GetSockInfo(int fd) {
 	SockInfo &sock_info = context_.at(fd);

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -1,0 +1,1 @@
+#include "sock_context.hpp"

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -16,6 +16,15 @@ SockContext::~SockContext() {
 	}
 }
 
+void SockContext::AddSockInfo(int fd, const SockInfo &sock_info) {
+	// todo: fd already exist, throw logic_error
+	context_[fd] = sock_info;
+}
+
+void SockContext::DeleteSockInfo(int fd) {
+	context_.erase(fd);
+}
+
 SockInfo &SockContext::GetSockInfo(int fd) {
 	SockInfo &sock_info = context_.at(fd);
 	// todo: fd doesn't exist, throw logic_error

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -28,8 +28,9 @@ void SockContext::DeleteSockInfo(int fd) {
 	context_.erase(fd);
 }
 
+// In C++98, the map's "at" method is unavailable, not using const qualifiers.
 SockInfo &SockContext::GetSockInfo(int fd) {
-	SockInfo &sock_info = context_.at(fd);
+	SockInfo &sock_info = context_[fd];
 	if (context_.count(fd) == 0) {
 		throw std::logic_error("SockInfo doesn't exist");
 	}

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -1,6 +1,7 @@
 #include "sock_context.hpp"
 #include "sock_info.hpp"
-#include <unistd.h> // close
+#include <stdexcept> // logic_error
+#include <unistd.h>  // close
 
 namespace server {
 
@@ -17,7 +18,9 @@ SockContext::~SockContext() {
 }
 
 void SockContext::AddSockInfo(int fd, const SockInfo &sock_info) {
-	// todo: fd already exist, throw logic_error
+	if (context_.count(fd) > 0) {
+		throw std::logic_error("SockInfo already exists");
+	}
 	context_[fd] = sock_info;
 }
 
@@ -27,7 +30,9 @@ void SockContext::DeleteSockInfo(int fd) {
 
 SockInfo &SockContext::GetSockInfo(int fd) {
 	SockInfo &sock_info = context_.at(fd);
-	// todo: fd doesn't exist, throw logic_error
+	if (context_.count(fd) == 0) {
+		throw std::logic_error("SockInfo doesn't exist");
+	}
 	return sock_info;
 }
 

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -1,0 +1,29 @@
+#ifndef SOCK_CONTEXT_HPP_
+#define SOCK_CONTEXT_HPP_
+
+#include <map>
+
+namespace server {
+
+class SockInfo;
+
+// Store socket informations for each fd
+class SockContext {
+  public:
+	typedef std::map<int, SockInfo> SockInfos;
+
+  private:
+	SockContext();
+	~SockContext();
+	// prohibit copy
+	SockContext(const SockContext &other);
+	SockContext &operator=(const SockContext &other);
+	// const
+	static const int SYSTEM_ERROR = -1;
+	// variables
+	SockInfos context_;
+};
+
+} // namespace server
+
+#endif /* SOCK_CONTEXT_HPP_ */

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -11,12 +11,12 @@ class SockInfo;
 class SockContext {
   public:
 	typedef std::map<int, SockInfo> SockInfos;
+	SockContext();
+	~SockContext();
 	// getter
 	SockInfo &GetSockInfo(int fd);
 
   private:
-	SockContext();
-	~SockContext();
 	// prohibit copy
 	SockContext(const SockContext &other);
 	SockContext &operator=(const SockContext &other);

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -13,6 +13,9 @@ class SockContext {
 	typedef std::map<int, SockInfo> SockInfos;
 	SockContext();
 	~SockContext();
+	// functions
+	void AddSockInfo(int fd, const SockInfo &sock_info);
+	void DeleteSockInfo(int fd);
 	// getter
 	SockInfo &GetSockInfo(int fd);
 

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -10,7 +10,7 @@ class SockInfo;
 // Store socket informations for each fd
 class SockContext {
   public:
-	typedef std::map<int, SockInfo> SockInfos;
+	typedef std::map<int, SockInfo> SockInfoMap;
 	SockContext();
 	~SockContext();
 	// functions
@@ -26,7 +26,7 @@ class SockContext {
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variables
-	SockInfos context_;
+	SockInfoMap context_;
 };
 
 } // namespace server

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -11,6 +11,8 @@ class SockInfo;
 class SockContext {
   public:
 	typedef std::map<int, SockInfo> SockInfos;
+	// getter
+	SockInfo &GetSockInfo(int fd);
 
   private:
 	SockContext();

--- a/srcs/sock_info.cpp
+++ b/srcs/sock_info.cpp
@@ -1,6 +1,36 @@
 #include "sock_info.hpp"
+#include <arpa/inet.h> // htons
+#include <cstring>     // memset
 
 namespace server {
+
+SockInfo::SockInfo() : fd_(0), name_(""), port_(0), addrlen_(sizeof(sock_addr_)) {
+	std::memset(&sock_addr_, 0, addrlen_);
+}
+
+SockInfo::SockInfo(const std::string &name, unsigned int port)
+	: fd_(0), name_(name), port_(port), addrlen_(sizeof(sock_addr_)) {
+	sock_addr_.sin_family      = AF_INET;
+	sock_addr_.sin_addr.s_addr = INADDR_ANY;
+	sock_addr_.sin_port        = htons(port);
+}
+
+SockInfo::~SockInfo() {}
+
+SockInfo::SockInfo(const SockInfo &other) {
+	*this = other;
+}
+
+SockInfo &SockInfo::operator=(const SockInfo &other) {
+	if (this != &other) {
+		fd_        = other.fd_;
+		name_      = other.name_;
+		port_      = other.port_;
+		sock_addr_ = other.sock_addr_;
+		addrlen_   = other.addrlen_;
+	}
+	return *this;
+}
 
 int SockInfo::GetFd() const {
 	return fd_;

--- a/srcs/sock_info.cpp
+++ b/srcs/sock_info.cpp
@@ -1,3 +1,21 @@
 #include "sock_info.hpp"
 
-namespace server {}
+namespace server {
+
+int SockInfo::GetFd() const {
+	return fd_;
+}
+
+struct sockaddr_in &SockInfo::GetSockAddr() {
+	return sock_addr_;
+}
+
+socklen_t SockInfo::GetAddrlen() const {
+	return addrlen_;
+}
+
+void SockInfo::SetSockFd(int fd) {
+	fd_ = fd;
+}
+
+} // namespace server

--- a/srcs/sock_info.cpp
+++ b/srcs/sock_info.cpp
@@ -1,0 +1,3 @@
+#include "sock_info.hpp"
+
+namespace server {}

--- a/srcs/sock_info.cpp
+++ b/srcs/sock_info.cpp
@@ -4,12 +4,12 @@
 
 namespace server {
 
-SockInfo::SockInfo() : fd_(0), name_(""), port_(0), addrlen_(sizeof(sock_addr_)) {
+SockInfo::SockInfo() : fd_(0), name_(""), port_(0), addrlen_(sizeof(sock_addr_)), peer_fd_(0) {
 	std::memset(&sock_addr_, 0, addrlen_);
 }
 
 SockInfo::SockInfo(const std::string &name, unsigned int port)
-	: fd_(0), name_(name), port_(port), addrlen_(sizeof(sock_addr_)) {
+	: fd_(0), name_(name), port_(port), addrlen_(sizeof(sock_addr_)), peer_fd_(0) {
 	sock_addr_.sin_family      = AF_INET;
 	sock_addr_.sin_addr.s_addr = INADDR_ANY;
 	sock_addr_.sin_port        = htons(port);
@@ -28,6 +28,7 @@ SockInfo &SockInfo::operator=(const SockInfo &other) {
 		port_      = other.port_;
 		sock_addr_ = other.sock_addr_;
 		addrlen_   = other.addrlen_;
+		peer_fd_   = other.peer_fd_;
 	}
 	return *this;
 }
@@ -46,6 +47,10 @@ socklen_t SockInfo::GetAddrlen() const {
 
 void SockInfo::SetSockFd(int fd) {
 	fd_ = fd;
+}
+
+void SockInfo::SetPeerSockFd(int fd) {
+	peer_fd_ = fd;
 }
 
 } // namespace server

--- a/srcs/sock_info.hpp
+++ b/srcs/sock_info.hpp
@@ -29,6 +29,8 @@ class SockInfo {
 	// todo: use struct sockaddr
 	struct sockaddr_in sock_addr_;
 	socklen_t          addrlen_;
+	// peer socket info(client)
+	int peer_fd_;
 };
 
 } // namespace server

--- a/srcs/sock_info.hpp
+++ b/srcs/sock_info.hpp
@@ -8,6 +8,12 @@ namespace server {
 
 class SockInfo {
   public:
+	// default constructor: necessary for map's insert/[]
+	SockInfo();
+	SockInfo(const std::string &name, unsigned int port);
+	~SockInfo();
+	SockInfo(const SockInfo &other);
+	SockInfo &operator=(const SockInfo &other);
 	// getter
 	int                 GetFd() const;
 	struct sockaddr_in &GetSockAddr();
@@ -17,15 +23,10 @@ class SockInfo {
 	void SetPeerSockFd(int fd);
 
   private:
-	SockInfo();
-	~SockInfo();
-	// prohibit copy
-	SockInfo(const SockInfo &other);
-	SockInfo &operator=(const SockInfo &other);
-	// variables
-	int                fd_;
-	std::string        name_;
-	unsigned int       port_;
+	int          fd_;
+	std::string  name_;
+	unsigned int port_;
+	// todo: use struct sockaddr
 	struct sockaddr_in sock_addr_;
 	socklen_t          addrlen_;
 };

--- a/srcs/sock_info.hpp
+++ b/srcs/sock_info.hpp
@@ -1,0 +1,26 @@
+#ifndef SOCK_INFO_HPP_
+#define SOCK_INFO_HPP_
+
+#include <netinet/in.h> // struct sockaddr_in
+#include <string>
+
+namespace server {
+
+class SockInfo {
+  private:
+	SockInfo();
+	~SockInfo();
+	// prohibit copy
+	SockInfo(const SockInfo &other);
+	SockInfo &operator=(const SockInfo &other);
+	// variables
+	int                fd_;
+	std::string        name_;
+	unsigned int       port_;
+	struct sockaddr_in sock_addr_;
+	socklen_t          addrlen_;
+};
+
+} // namespace server
+
+#endif /* SOCK_INFO_HPP_ */

--- a/srcs/sock_info.hpp
+++ b/srcs/sock_info.hpp
@@ -7,6 +7,15 @@
 namespace server {
 
 class SockInfo {
+  public:
+	// getter
+	int                 GetFd() const;
+	struct sockaddr_in &GetSockAddr();
+	socklen_t           GetAddrlen() const;
+	// setter
+	void SetSockFd(int fd);
+	void SetPeerSockFd(int fd);
+
   private:
 	SockInfo();
 	~SockInfo();


### PR DESCRIPTION
## したこと
- config に複数 port があった場合に全部 listen するように変更・追加
- 試しに 8080, 12345 の port が listen するようにコード内にベタ書きしています…

複数 class に跨る変更だったのでちょっと多めになってしまいました…

## 詳細
- `Server class`
今まで 1 つの仮想サーバ用に作ってたので `Server class` が port, server_fd, sockaddr 等の情報を全て保持していた
- [x] → これらの情報を `SockInfo class` が保持するように変更 (1 つの仮想サーバにつき 1 つの SockInfo instance)
- [x] fd 毎に SockInfo を作成するため、全部の SockInfo を `SockContext class` が map で保持
`std::map<int fd, SockInfo sock_info>`

<br>

- `Connection class` 
- [x] 複数 port の接続に対応するため、socket 通信部分を `Server class` から分離して `Connection class` に移動
- [x] 外からは listen 中の fd なのかそうでないかだけ知れれば良いので (`HandleEvent()`)、listen 中の server fd をこのクラス内で保持
- [x] `Connect()` : 新規接続する (`socket()` から `listen()` まで)
- [x] `Accept()` : listen 中 fd への新規接続 (client) を受け付ける


## 実行確認
```shell
# server 
make run

# test/client
make run INFILE_PATH=request_messages/200_get_root.txt PORT=8080
make run INFILE_PATH=request_messages/200_get_sub.txt PORT=12345
make run INFILE_PATH=request_messages/404_get_not_exist_path.txt PORT=12345

# browser (Host はまだ見てないので両方 localhost)
localhost:8080
localhost:12345
```

## してないこと・今後する
- 複数 host 名
- port の範囲・上限設定
- エラー処理
- 全部の port について `socket()` から `bind()` まで成功したら、`listen()` するとかでも良いかも
- `SockInfo` を継承した `ServerInfo`, `ClientInfo` とかに分けると良いのかも？

<br>
<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - アプリに接続管理機能を追加しました。
  - サーバーコンテキストでのソケット操作機能を強化しました。

- **バグ修正**
  - バッファの取得方法を改善し、パフォーマンスを向上させました。

- **リファクタリング**
  - サーバーとソケットハンドリングのコードをリファクタし、メンテナンス性を向上させました。

- **スタイル**
  - コードのスタイルとアクセシビリティを微調整しました。

- **ドキュメント**
  - 新しい接続管理機能に関するドキュメントを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->