### PR TITLE
[fix] mapの.atがC++11以降のようだったので[]演算子に変更

### DIFF
--- a/srcs/buffer.cpp
+++ b/srcs/buffer.cpp
@@ -26,9 +26,10 @@ void Buffer::Delete(int fd) {
 	buffers_[fd].erase();
 }
 
-std::string Buffer::GetBuffer(int fd) const {
+// In C++98, the map's "at" method is unavailable, not using const qualifiers.
+std::string &Buffer::GetBuffer(int fd) {
 	// todo: fd error handle
-	return buffers_.at(fd);
+	return buffers_[fd];
 }
 
 } // namespace server

--- a/srcs/buffer.hpp
+++ b/srcs/buffer.hpp
@@ -13,9 +13,9 @@ class Buffer {
 	typedef std::map<int, std::string> Buffers;
 	Buffer();
 	~Buffer();
-	ssize_t     Read(int fd);
-	void        Delete(int fd);
-	std::string GetBuffer(int fd) const;
+	ssize_t      Read(int fd);
+	void         Delete(int fd);
+	std::string &GetBuffer(int fd);
 
   private:
 	// prohibit copy

--- a/srcs/http/response/create_response.cpp
+++ b/srcs/http/response/create_response.cpp
@@ -5,9 +5,9 @@
 namespace http {
 namespace {
 
-void CreateStatusLine(std::ostream &response_stream, const Http::RequestMessage &request) {
-	response_stream << HTTP_VERSION << SP << request.at(Http::HTTP_STATUS) << SP
-					<< request.at(Http::HTTP_STATUS_TEXT) << CRLF;
+void CreateStatusLine(std::ostream &response_stream, Http::RequestMessage &request) {
+	response_stream << HTTP_VERSION << SP << request[Http::HTTP_STATUS] << SP
+					<< request[Http::HTTP_STATUS_TEXT] << CRLF;
 }
 
 template <typename T>
@@ -15,17 +15,17 @@ void CreateHeaderField(std::ostream &response_stream, const std::string &name, c
 	response_stream << name << ":" << SP << value << SP << CRLF;
 }
 
-void CreateHeaderFields(std::ostream &response_stream, const Http::RequestMessage &request) {
+void CreateHeaderFields(std::ostream &response_stream, Http::RequestMessage &request) {
 	CreateHeaderField(response_stream, CONNECTION, "close");
-	CreateHeaderField(response_stream, CONTENT_LENGTH, request.at(Http::HTTP_CONTENT).size());
+	CreateHeaderField(response_stream, CONTENT_LENGTH, request[Http::HTTP_CONTENT].size());
 }
 
 void CreateCRLF(std::ostream &response_stream) {
 	response_stream << CRLF;
 }
 
-void CreateBody(std::ostream &response_stream, const Http::RequestMessage &request) {
-	response_stream << request.at(Http::HTTP_CONTENT);
+void CreateBody(std::ostream &response_stream, Http::RequestMessage &request) {
+	response_stream << request[Http::HTTP_CONTENT];
 }
 
 } // namespace

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -28,8 +28,9 @@ void SockContext::DeleteSockInfo(int fd) {
 	context_.erase(fd);
 }
 
+// In C++98, the map's "at" method is unavailable, not using const qualifiers.
 SockInfo &SockContext::GetSockInfo(int fd) {
-	SockInfo &sock_info = context_.at(fd);
+	SockInfo &sock_info = context_[fd];
 	if (context_.count(fd) == 0) {
 		throw std::logic_error("SockInfo doesn't exist");
 	}


### PR DESCRIPTION
#132  の後に merge

map の `.at` が C++11…
https://ja.cppreference.com/w/cpp/container/map/at

map の `[ ]` 演算子は const 参照を返さないため、関数に const がつけられなくなってしまったけど仕方ない…
 https://ja.cppreference.com/w/cpp/container/map/operator_at
 `T& operator[]( const Key& key );`
