### PR TITLE
141-sandbox-http_parseクラスの作成

### DIFF
--- a/sandbox/sawa/http_parse/Makefile
+++ b/sandbox/sawa/http_parse/Makefile
@@ -1,0 +1,51 @@
+NAME	:=	a.out
+
+# for test main
+SRCS	:=	main.cpp \
+			http_parse.cpp
+
+# 1. add webserv file
+WS_UTILS_DIR	:=	../../../srcs/utils
+SRCS			+=	$(WS_UTILS_DIR)/color.cpp \
+					$(WS_UTILS_DIR)/split.cpp
+
+TARGET_DIR	:=	../../../srcs/http
+SRCS			+=	$(TARGET_DIR)/http_message.cpp
+
+# 3. add new dir
+SRC_DIRS	:=	$(WS_UTILS_DIR) \
+				$(TARGET_DIR)
+
+#--------------------------------------------
+OBJ_DIR	:=	objs
+OBJS	:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRC_DIRS))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+vpath %.cpp $(SRC_DIRS)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all

--- a/sandbox/sawa/http_parse/Makefile
+++ b/sandbox/sawa/http_parse/Makefile
@@ -49,3 +49,7 @@ fclean: clean
 
 .PHONY	: re
 re: fclean all
+
+.PHONY	: run
+run: re
+	./$(NAME)

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -16,18 +16,18 @@ std::string CreateDefaultPath(const std::string &path) {
 	return location + path + "/index.html";
 }
 
-void PrintLines(const std::vector<std::string> &lines) {
-	typedef std::vector<std::string>::const_iterator It;
-	size_t                                           i = 0;
-	for (It it = lines.begin(); it != lines.end(); ++it) {
-		// if (*it == "") {
-		// 	std::cout << "stop!" << std::endl;
-		// 	break;
-		// }
-		std::cout << i << ":" << *it << std::endl;
-		i++;
-	}
-}
+// void PrintLines(const std::vector<std::string> &lines) {
+// 	typedef std::vector<std::string>::const_iterator It;
+// 	size_t                                           i = 0;
+// 	for (It it = lines.begin(); it != lines.end(); ++it) {
+// 		// if (*it == "") {
+// 		// 	std::cout << "stop!" << std::endl;
+// 		// 	break;
+// 		// }
+// 		std::cout << i << ":" << *it << std::endl;
+// 		i++;
+// 	}
+// }
 
 } // namespace
 
@@ -35,20 +35,35 @@ HTTPParse::HTTPParse() {}
 
 HTTPParse::~HTTPParse() {}
 
-StatusLine HTTPParse::SetStatusLine(const std::vector<std::string> &request_line) {
-	StatusLine status_line;
-	status_line.method  = request_line[0];
-	status_line.uri     = CreateDefaultPath(request_line[1]);
-	status_line.version = request_line[2];
-	return status_line;
+RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_line_info) {
+	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
+	RequestLine request_line;
+	request_line.method  = request_line_info[0];
+	request_line.uri     = CreateDefaultPath(request_line_info[1]);
+	request_line.version = request_line_info[2];
+	return request_line;
+}
+
+HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_fields_info) {
+	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
+	HeaderFields                                     header_fields;
+	typedef std::vector<std::string>::const_iterator It;
+	for (It it = header_fields_info.begin() + 1; it != header_fields_info.end(); ++it) {
+		if (*it == "")
+			break;
+		std::vector<std::string> tmp = utils::SplitStr(*it, ": ");
+		header_fields[tmp[0]]        = tmp[1];
+	}
+	return header_fields;
 }
 
 // todo: tmp request_
 HTTPRequest HTTPParse::Run(const std::string &read_buf) {
-	HTTPRequest                    request;
-	const std::vector<std::string> lines = utils::SplitStr(read_buf, CRLF);
-	PrintLines(lines);
-	request.status_line = SetStatusLine(utils::SplitStr(lines[0], SP));
+	HTTPRequest              request;
+	std::vector<std::string> lines = utils::SplitStr(read_buf, CRLF);
+	request.status_line            = SetRequestLine(utils::SplitStr(lines[0], SP));
+	request.header_fields          = SetHeaderFields(lines);
+	// PrintLines(lines);
 	return request;
 }
 

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -51,10 +51,17 @@ HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_f
 	for (It it = header_fields_info.begin() + 1; it != header_fields_info.end(); ++it) {
 		if (*it == "")
 			break;
-		std::vector<std::string> tmp = utils::SplitStr(*it, ": ");
-		header_fields[tmp[0]]        = tmp[1];
+		std::vector<std::string> header_key_value = utils::SplitStr(*it, ": ");
+		header_fields[header_key_value[0]]        = header_key_value[1];
 	}
 	return header_fields;
+}
+
+// 　懸念点：MessageBodyにCRLFが含まれていた場合 std::vectorはLineごとに持ってる
+std::string HTTPParse::SetMessageBody(const std::vector<std::string> &message_body_info) {
+	std::vector<std::string>::const_iterator it           = message_body_info.end() - 1;
+	std::string                              message_body = *it;
+	return message_body;
 }
 
 // todo: tmp request_
@@ -63,6 +70,8 @@ HTTPRequest HTTPParse::Run(const std::string &read_buf) {
 	std::vector<std::string> lines = utils::SplitStr(read_buf, CRLF);
 	request.status_line            = SetRequestLine(utils::SplitStr(lines[0], SP));
 	request.header_fields          = SetHeaderFields(lines);
+	if ("POST" == request.status_line.method)
+		request.message_body = SetMessageBody(lines);
 	// PrintLines(lines);
 	return request;
 }

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -6,16 +6,7 @@
 namespace http {
 namespace {
 
-// todo: create path (/, /aaa, /aaa/)
-std::string CreateDefaultPath(const std::string &path) {
-	static const std::string location = "html";
-
-	if (path.size() == 1) {
-		return location + "/index.html";
-	}
-	return location + path + "/index.html";
-}
-
+// debug:
 // void PrintLines(const std::vector<std::string> &lines) {
 // 	typedef std::vector<std::string>::const_iterator It;
 // 	size_t                                           i = 0;
@@ -39,7 +30,7 @@ RequestLine HttpParse::SetRequestLine(const std::vector<std::string> &request_li
 	// todo 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	RequestLine request_line;
 	request_line.method  = request_line_info[0];
-	request_line.uri     = CreateDefaultPath(request_line_info[1]);
+	request_line.uri     = request_line_info[1];
 	request_line.version = request_line_info[2];
 	return request_line;
 }
@@ -55,27 +46,17 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 	return header_fields;
 }
 
-std::string HttpParse::SetMessageBody(const std::vector<std::string> &message_body_info) {
-	std::vector<std::string>::const_iterator it           = message_body_info.begin();
-	std::string                              message_body = *it;
-	return message_body;
-}
-
 // todo: tmp request_
 HttpRequest HttpParse::Run(const std::string &read_buf) {
 	HttpRequest              request;
+	// a: [request_line header_fields, messagebody]
+	// b: [request_line, header_fields]
 	std::vector<std::string> a = utils::SplitStr(read_buf, CRLF + CRLF);
 	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
 	request.status_line        = SetRequestLine(utils::SplitStr(b[0], SP));
 	request.header_fields      = SetHeaderFields(b);
-	// todo bodymessageの取得方法（ヘッダーによって仕様が変わる）
-	if ("POST" == request.status_line.method)
-		request.message_body = SetMessageBody(utils::SplitStr(a[1], ""));
 	// PrintLines(b);
 	return request;
 }
-
-// status_line && header
-// messagebody
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -1,0 +1,39 @@
+#include "http_parse.hpp"
+#include "http_message.hpp"
+#include "utils.hpp"
+#include <vector>
+
+namespace http {
+namespace {
+
+// todo: create path (/, /aaa, /aaa/)
+std::string CreateDefaultPath(const std::string &path) {
+	static const std::string location = "html";
+
+	if (path.size() == 1) {
+		return location + "/index.html";
+	}
+	return location + path + "/index.html";
+}
+
+} // namespace
+
+HTTPParse::HTTPParse() {}
+
+HTTPParse::~HTTPParse() {}
+
+// todo: tmp request_
+HTTPRequest HTTPParse::Run(const std::string &read_buf) {
+	HTTPRequest                    request;
+	const std::vector<std::string> lines      = utils::SplitStr(read_buf, CRLF);
+	const std::string              start_line = lines[0];
+
+	const std::vector<std::string> request_line = utils::SplitStr(start_line, SP);
+	// set request-line(method, request-target, HTTP-version)
+	request.status_line.method  = request_line[0];
+	request.status_line.uri     = CreateDefaultPath(request_line[1]);
+	request.status_line.version = request_line[2];
+	return request;
+}
+
+} // namespace http

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -31,12 +31,12 @@ std::string CreateDefaultPath(const std::string &path) {
 
 } // namespace
 
-HTTPParse::HTTPParse() {}
+HttpParse::HttpParse() {}
 
-HTTPParse::~HTTPParse() {}
+HttpParse::~HttpParse() {}
 
-RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_line_info) {
-	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
+RequestLine HttpParse::SetRequestLine(const std::vector<std::string> &request_line_info) {
+	// todo 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	RequestLine request_line;
 	request_line.method  = request_line_info[0];
 	request_line.uri     = CreateDefaultPath(request_line_info[1]);
@@ -44,8 +44,8 @@ RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_li
 	return request_line;
 }
 
-HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_fields_info) {
-	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
+HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_fields_info) {
+	// todo 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	HeaderFields                                     header_fields;
 	typedef std::vector<std::string>::const_iterator It;
 	for (It it = header_fields_info.begin() + 1; it != header_fields_info.end(); ++it) {
@@ -55,21 +55,20 @@ HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_f
 	return header_fields;
 }
 
-// 　懸念点：MessageBodyにCRLFが含まれていた場合 std::vectorはLineごとに持ってる
-std::string HTTPParse::SetMessageBody(const std::vector<std::string> &message_body_info) {
+std::string HttpParse::SetMessageBody(const std::vector<std::string> &message_body_info) {
 	std::vector<std::string>::const_iterator it           = message_body_info.begin();
 	std::string                              message_body = *it;
 	return message_body;
 }
 
 // todo: tmp request_
-HTTPRequest HTTPParse::Run(const std::string &read_buf) {
-	HTTPRequest              request;
+HttpRequest HttpParse::Run(const std::string &read_buf) {
+	HttpRequest              request;
 	std::vector<std::string> a = utils::SplitStr(read_buf, CRLF + CRLF);
 	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
 	request.status_line        = SetRequestLine(utils::SplitStr(b[0], SP));
 	request.header_fields      = SetHeaderFields(b);
-	// 調査: bodymessageの取得方法（ヘッダーによって仕様が変わる）
+	// todo bodymessageの取得方法（ヘッダーによって仕様が変わる）
 	if ("POST" == request.status_line.method)
 		request.message_body = SetMessageBody(utils::SplitStr(a[1], ""));
 	// PrintLines(b);

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -16,23 +16,39 @@ std::string CreateDefaultPath(const std::string &path) {
 	return location + path + "/index.html";
 }
 
+void PrintLines(const std::vector<std::string> &lines) {
+	typedef std::vector<std::string>::const_iterator It;
+	size_t                                           i = 0;
+	for (It it = lines.begin(); it != lines.end(); ++it) {
+		// if (*it == "") {
+		// 	std::cout << "stop!" << std::endl;
+		// 	break;
+		// }
+		std::cout << i << ":" << *it << std::endl;
+		i++;
+	}
+}
+
 } // namespace
 
 HTTPParse::HTTPParse() {}
 
 HTTPParse::~HTTPParse() {}
 
+StatusLine HTTPParse::SetStatusLine(const std::vector<std::string> &request_line) {
+	StatusLine status_line;
+	status_line.method  = request_line[0];
+	status_line.uri     = CreateDefaultPath(request_line[1]);
+	status_line.version = request_line[2];
+	return status_line;
+}
+
 // todo: tmp request_
 HTTPRequest HTTPParse::Run(const std::string &read_buf) {
 	HTTPRequest                    request;
-	const std::vector<std::string> lines      = utils::SplitStr(read_buf, CRLF);
-	const std::string              start_line = lines[0];
-
-	const std::vector<std::string> request_line = utils::SplitStr(start_line, SP);
-	// set request-line(method, request-target, HTTP-version)
-	request.status_line.method  = request_line[0];
-	request.status_line.uri     = CreateDefaultPath(request_line[1]);
-	request.status_line.version = request_line[2];
+	const std::vector<std::string> lines = utils::SplitStr(read_buf, CRLF);
+	PrintLines(lines);
+	request.status_line = SetStatusLine(utils::SplitStr(lines[0], SP));
 	return request;
 }
 

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -49,8 +49,6 @@ HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_f
 	HeaderFields                                     header_fields;
 	typedef std::vector<std::string>::const_iterator It;
 	for (It it = header_fields_info.begin() + 1; it != header_fields_info.end(); ++it) {
-		if (*it == "")
-			break;
 		std::vector<std::string> header_key_value = utils::SplitStr(*it, ": ");
 		header_fields[header_key_value[0]]        = header_key_value[1];
 	}
@@ -59,7 +57,7 @@ HeaderFields HTTPParse::SetHeaderFields(const std::vector<std::string> &header_f
 
 // 　懸念点：MessageBodyにCRLFが含まれていた場合 std::vectorはLineごとに持ってる
 std::string HTTPParse::SetMessageBody(const std::vector<std::string> &message_body_info) {
-	std::vector<std::string>::const_iterator it           = message_body_info.end() - 1;
+	std::vector<std::string>::const_iterator it           = message_body_info.begin();
 	std::string                              message_body = *it;
 	return message_body;
 }
@@ -67,13 +65,18 @@ std::string HTTPParse::SetMessageBody(const std::vector<std::string> &message_bo
 // todo: tmp request_
 HTTPRequest HTTPParse::Run(const std::string &read_buf) {
 	HTTPRequest              request;
-	std::vector<std::string> lines = utils::SplitStr(read_buf, CRLF);
-	request.status_line            = SetRequestLine(utils::SplitStr(lines[0], SP));
-	request.header_fields          = SetHeaderFields(lines);
+	std::vector<std::string> a = utils::SplitStr(read_buf, CRLF + CRLF);
+	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
+	request.status_line        = SetRequestLine(utils::SplitStr(b[0], SP));
+	request.header_fields      = SetHeaderFields(b);
+	// 調査: bodymessageの取得方法（ヘッダーによって仕様が変わる）
 	if ("POST" == request.status_line.method)
-		request.message_body = SetMessageBody(lines);
-	// PrintLines(lines);
+		request.message_body = SetMessageBody(utils::SplitStr(a[1], ""));
+	// PrintLines(b);
 	return request;
 }
+
+// status_line && header
+// messagebody
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -1,0 +1,32 @@
+#ifndef HTTP_PARSE_HPP_
+#define HTTP_PARSE_HPP_
+
+#include <map>
+#include <string>
+
+namespace http {
+
+struct StatusLine {
+	std::string method;
+	std::string uri;
+	std::string version;
+};
+
+typedef std::map<std::string, std::string> HeaderField;
+
+struct HTTPRequest {
+	StatusLine  status_line;
+	HeaderField header_fields;
+	std::string message_body;
+};
+
+class HTTPParse {
+  public:
+	HTTPParse();
+	~HTTPParse();
+	HTTPRequest Run(const std::string &buf);
+};
+
+} // namespace http
+
+#endif

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -23,14 +23,13 @@ struct HttpRequest {
 
 class HttpParse {
   public:
-	HttpParse();
-	~HttpParse();
 	static HttpRequest Run(const std::string &buf);
 
   private:
+	HttpParse();
+	~HttpParse();
 	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
-	static std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -25,6 +25,9 @@ class HTTPParse {
 	HTTPParse();
 	~HTTPParse();
 	HTTPRequest Run(const std::string &buf);
+
+  private:
+	StatusLine SetStatusLine(const std::vector<std::string> &request_line);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -29,6 +29,7 @@ class HTTPParse {
   private:
 	RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
+	std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace http {
 
@@ -14,22 +15,22 @@ struct RequestLine {
 
 typedef std::map<std::string, std::string> HeaderFields;
 
-struct HTTPRequest {
+struct HttpRequest {
 	RequestLine  status_line;
 	HeaderFields header_fields;
 	std::string  message_body;
 };
 
-class HTTPParse {
+class HttpParse {
   public:
-	HTTPParse();
-	~HTTPParse();
-	HTTPRequest Run(const std::string &buf);
+	HttpParse();
+	~HttpParse();
+	static HttpRequest Run(const std::string &buf);
 
   private:
-	RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
-	HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
-	std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
+	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
+	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
+	static std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -6,18 +6,18 @@
 
 namespace http {
 
-struct StatusLine {
+struct RequestLine {
 	std::string method;
 	std::string uri;
 	std::string version;
 };
 
-typedef std::map<std::string, std::string> HeaderField;
+typedef std::map<std::string, std::string> HeaderFields;
 
 struct HTTPRequest {
-	StatusLine  status_line;
-	HeaderField header_fields;
-	std::string message_body;
+	RequestLine  status_line;
+	HeaderFields header_fields;
+	std::string  message_body;
 };
 
 class HTTPParse {
@@ -27,7 +27,8 @@ class HTTPParse {
 	HTTPRequest Run(const std::string &buf);
 
   private:
-	StatusLine SetStatusLine(const std::vector<std::string> &request_line);
+	RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
+	HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -28,7 +28,7 @@ int main(void) {
 	assert("HTTP/1.1" == test3.status_line.version);
 	assert("www.example.com" == test3.header_fields["Host"]);
 	assert("keep-alive" == test3.header_fields["Connection"]);
-	// assert("bodymessage" == test3.message_body);
+	assert("bodymessage" == test3.message_body);
 
 	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
 	http::HTTPRequest test4 =

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -1,34 +1,38 @@
 #include "http_parse.hpp"
+#include <cassert>
 #include <iostream>
 
 int main(void) {
 	http::HTTPParse a;
 
 	// StatusLineのみのHTTPリクエスト
-	http::HTTPRequest test1 = a.Run("GET / HTTP1.1");
-	// std::cout << "Method: " << test1.status_line.method << std::endl;
-	// std::cout << "uri: " << test1.status_line.uri << std::endl;
-	// std::cout << "version: " << test1.status_line.version << std::endl;
+	http::HTTPRequest test1 = a.Run("GET / HTTP/1.1");
+	assert("GET" == test1.status_line.method);
+	assert("html/index.html" == test1.status_line.uri);
+	assert("HTTP/1.1" == test1.status_line.version);
 
 	// StatusLineとHeadersを含むHTTPリクエスト
 	http::HTTPRequest test2 =
-		a.Run("GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n"
-		);
-	// std::cout << "Method: " << test2.status_line.method << std::endl;
-	// std::cout << "uri: " << test2.status_line.uri << std::endl;
-	// std::cout << "version: " << test2.status_line.version << std::endl;
+		a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
+	assert("GET" == test2.status_line.method);
+	assert("html/sub/index.html" == test2.status_line.uri);
+	assert("HTTP/1.1" == test2.status_line.version);
+	assert("www.example.com" == test2.header_fields["Host"]);
+	assert("keep-alive" == test2.header_fields["Connection"]);
 
 	// StatusLineとHeader、Bodyを含むHTTPリクエスト
-	http::HTTPRequest test3 = a.Run(
-		"GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\naaaaaa"
-	);
-	// std::cout << "Method: " << test3.status_line.method << std::endl;
-	// std::cout << "uri: " << test3.status_line.uri << std::endl;
-	// std::cout << "version: " << test3.status_line.version << std::endl;
+	http::HTTPRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
+									"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
+	assert("POST" == test3.status_line.method);
+	assert("html/index.html/index.html" == test3.status_line.uri);
+	assert("HTTP/1.1" == test3.status_line.version);
+	assert("www.example.com" == test3.header_fields["Host"]);
+	assert("keep-alive" == test3.header_fields["Connection"]);
+	// assert("bodymessage" == test3.message_body);
 
 	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
 	http::HTTPRequest test4 =
-		a.Run("GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
+		a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
 			  "keep-alive\r\n\r\naa\r\naa\naa");
 	// std::cout << "Method: " << test4.status_line.method << std::endl;
 	// std::cout << "uri: " << test4.status_line.uri << std::endl;

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -3,16 +3,16 @@
 #include <iostream>
 
 int main(void) {
-	http::HTTPParse a;
+	http::HttpParse a;
 
 	// StatusLineのみのHTTPリクエスト
-	http::HTTPRequest test1 = a.Run("GET / HTTP/1.1");
+	http::HttpRequest test1 = a.Run("GET / HTTP/1.1");
 	assert("GET" == test1.status_line.method);
 	assert("html/index.html" == test1.status_line.uri);
 	assert("HTTP/1.1" == test1.status_line.version);
 
 	// StatusLineとHeadersを含むHTTPリクエスト
-	http::HTTPRequest test2 =
+	http::HttpRequest test2 =
 		a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
 	assert("GET" == test2.status_line.method);
 	assert("html/sub/index.html" == test2.status_line.uri);
@@ -21,7 +21,7 @@ int main(void) {
 	assert("keep-alive" == test2.header_fields["Connection"]);
 
 	// StatusLineとHeader、Bodyを含むHTTPリクエスト
-	http::HTTPRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
+	http::HttpRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
 									"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
 	assert("POST" == test3.status_line.method);
 	assert("html/index.html/index.html" == test3.status_line.uri);
@@ -31,7 +31,7 @@ int main(void) {
 	assert("bodymessage" == test3.message_body);
 
 	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
-	http::HTTPRequest test4 =
+	http::HttpRequest test4 =
 		a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
 			  "keep-alive\r\n\r\naa\r\naa\naa");
 	// std::cout << "Method: " << test4.status_line.method << std::endl;

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -1,0 +1,11 @@
+#include "http_parse.hpp"
+#include <iostream>
+
+int main(void) {
+	http::HTTPParse   a;
+	http::HTTPRequest request = a.Run("GET / HTTP1.1");
+	std::cout << "Method: " << request.status_line.method << std::endl;
+	std::cout << "uri: " << request.status_line.uri << std::endl;
+	std::cout << "version: " << request.status_line.version << std::endl;
+	return 0;
+}

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -3,36 +3,33 @@
 #include <iostream>
 
 int main(void) {
-	http::HttpParse a;
-
 	// StatusLineのみのHTTPリクエスト
-	http::HttpRequest test1 = a.Run("GET / HTTP/1.1");
+	http::HttpRequest test1 = http::HttpParse::Run("GET / HTTP/1.1");
 	assert("GET" == test1.status_line.method);
-	assert("html/index.html" == test1.status_line.uri);
+	assert("/" == test1.status_line.uri);
 	assert("HTTP/1.1" == test1.status_line.version);
 
 	// StatusLineとHeadersを含むHTTPリクエスト
 	http::HttpRequest test2 =
-		a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
+		 http::HttpParse::Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
 	assert("GET" == test2.status_line.method);
-	assert("html/sub/index.html" == test2.status_line.uri);
+	assert("/sub" == test2.status_line.uri);
 	assert("HTTP/1.1" == test2.status_line.version);
 	assert("www.example.com" == test2.header_fields["Host"]);
 	assert("keep-alive" == test2.header_fields["Connection"]);
 
 	// StatusLineとHeader、Bodyを含むHTTPリクエスト
-	http::HttpRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
+	http::HttpRequest test3 =  http::HttpParse::Run("POST /index.html HTTP/1.1\r\nHost: "
 									"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
 	assert("POST" == test3.status_line.method);
-	assert("html/index.html/index.html" == test3.status_line.uri);
+	assert("/index.html" == test3.status_line.uri);
 	assert("HTTP/1.1" == test3.status_line.version);
 	assert("www.example.com" == test3.header_fields["Host"]);
 	assert("keep-alive" == test3.header_fields["Connection"]);
-	assert("bodymessage" == test3.message_body);
 
 	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
 	http::HttpRequest test4 =
-		a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
+		 http::HttpParse::Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
 			  "keep-alive\r\n\r\naa\r\naa\naa");
 	// std::cout << "Method: " << test4.status_line.method << std::endl;
 	// std::cout << "uri: " << test4.status_line.uri << std::endl;

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -2,10 +2,36 @@
 #include <iostream>
 
 int main(void) {
-	http::HTTPParse   a;
-	http::HTTPRequest request = a.Run("GET / HTTP1.1");
-	std::cout << "Method: " << request.status_line.method << std::endl;
-	std::cout << "uri: " << request.status_line.uri << std::endl;
-	std::cout << "version: " << request.status_line.version << std::endl;
+	http::HTTPParse a;
+
+	// StatusLineのみのHTTPリクエスト
+	http::HTTPRequest test1 = a.Run("GET / HTTP1.1");
+	// std::cout << "Method: " << test1.status_line.method << std::endl;
+	// std::cout << "uri: " << test1.status_line.uri << std::endl;
+	// std::cout << "version: " << test1.status_line.version << std::endl;
+
+	// StatusLineとHeadersを含むHTTPリクエスト
+	http::HTTPRequest test2 =
+		a.Run("GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n"
+		);
+	// std::cout << "Method: " << test2.status_line.method << std::endl;
+	// std::cout << "uri: " << test2.status_line.uri << std::endl;
+	// std::cout << "version: " << test2.status_line.version << std::endl;
+
+	// StatusLineとHeader、Bodyを含むHTTPリクエスト
+	http::HTTPRequest test3 = a.Run(
+		"GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\naaaaaa"
+	);
+	// std::cout << "Method: " << test3.status_line.method << std::endl;
+	// std::cout << "uri: " << test3.status_line.uri << std::endl;
+	// std::cout << "version: " << test3.status_line.version << std::endl;
+
+	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
+	http::HTTPRequest test4 =
+		a.Run("GET /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
+			  "keep-alive\r\n\r\naa\r\naa\naa");
+	// std::cout << "Method: " << test4.status_line.method << std::endl;
+	// std::cout << "uri: " << test4.status_line.uri << std::endl;
+	// std::cout << "version: " << test4.status_line.version << std::endl;
 	return 0;
 }


### PR DESCRIPTION
### したこと
- [x] HTTPParse: HTTPリクエスト情報をパースするクラス作成
- [x] main.cpp: 各書式通りに値が入ってるかどうかテスト

### 目的 
- HTTPメッセージの書式の情報を構造体にまとめる

```
   HTTP-message   = start-line
                      *( header-field CRLF )
                      CRLF
                      [ message-body ]
```

```
struct HTTPRequest{
    StatusLine status_line;
    HeaderField header_fields;
    std::string message-body;
}
```

```
struct StatusLine{
    std::string method;
    std::string uri;
    std::string version;
}
```
```
typedef std::map<HeaderType, std::string> HeaderField;
    enum HeaderType {
        CONTENT_LENGTH,
        CONTENT_TYPE,
        ...
    };
```

### 今後
- 各書式のパラメータが正常系かどうか判定する関数作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - HTTPリクエスト解析機能を追加しました。
  - C++ファイルのコンパイルと実行ファイルのビルドを行うMakefileを追加しました。

- **その他**
  - HTTPリクエスト解析のための構造体とメソッドを定義しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->