### PR TITLE
[add] 簡易的にリクエストを試せる html の提案

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true
     },
-    "isort.args":["--profile", "black"]
+    "isort.args":["--profile", "black"],
+	"[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+	}
 }

--- a/html/404.html
+++ b/html/404.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Web Server</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>404 Bad request... (tmp)</h1>
-</body>
+  </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -8,13 +8,13 @@
     <h1>Hello from webserv! (tmp)</h1>
 
     <h2>GET</h2>
-    <div><a href="/sub">link to /sub</a></div>
-    <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
+    <div><a href="sub/">link to sub/</a></div>
+    <div><a href="non-existent-path/">link to non-existent-path/ (404)</a></div>
     <br />
 
     <h2>POST</h2>
-    <div>post to /post?</div>
-    <form action="/post" method="POST">
+    <div>post to post/?</div>
+    <form action="post/" method="POST">
       <label for="text-input">Enter text</label>
       <input type="text" name="user_text" />
       <button type="submit">Submit</button>
@@ -22,16 +22,16 @@
     <br />
 
     <h2>DELETE</h2>
-    <div><a href="/delete">link to /delete?</a></div>
+    <div><a href="delete/">link to delete/?</a></div>
     <br />
 
     <h2>GET(CGI)</h2>
-    <div><a href="/cgi/print_env.pl">link to /cgi/print_env.pl</a></div>
+    <div><a href="cgi/print_env.pl">link to cgi/print_env.pl</a></div>
     <br />
 
     <h2>POST(CGI)</h2>
     <div>post to cgi/print_stdin.pl?</div>
-    <form action="/cgi/print_stdin.pl" method="POST">
+    <form action="cgi/print_stdin.pl" method="POST">
       <label for="text-input">Enter text</label>
       <input type="text" name="user_text" />
       <button type="submit">Submit</button>

--- a/html/index.html
+++ b/html/index.html
@@ -1,40 +1,40 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Web Server</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Hello from webserv! (tmp)</h1>
 
     <h2>GET</h2>
     <div><a href="/sub">link to /sub</a></div>
     <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
-    <br>
+    <br />
 
     <h2>POST</h2>
     <div>post to /post?</div>
     <form action="/post" method="POST">
-        <label for="text-input">Enter text</label>
-        <input type="text" name="user_text">
-        <button type="submit">Submit</button>
+      <label for="text-input">Enter text</label>
+      <input type="text" name="user_text" />
+      <button type="submit">Submit</button>
     </form>
-    <br>
+    <br />
 
     <h2>DELETE</h2>
     <div><a href="/delete">link to /delete?</a></div>
-    <br>
+    <br />
 
     <h2>GET(CGI)</h2>
     <div><a href="/cgi/print_env.pl">link to /cgi/print_env.pl</a></div>
-    <br>
+    <br />
 
     <h2>POST(CGI)</h2>
     <div>post to cgi/print_stdin.pl?</div>
     <form action="/cgi/print_stdin.pl" method="POST">
-        <label for="text-input">Enter text</label>
-        <input type="text" name="user_text">
-        <button type="submit">Submit</button>
+      <label for="text-input">Enter text</label>
+      <input type="text" name="user_text" />
+      <button type="submit">Submit</button>
     </form>
-</body>
+  </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -7,34 +7,44 @@
   <body>
     <h1>Hello from webserv! (tmp)</h1>
 
-    <h2>GET</h2>
-    <div><a href="sub/">link to sub/</a></div>
-    <div><a href="non-existent-path/">link to non-existent-path/ (404)</a></div>
-    <br />
+    <div class="method">
+      <h2>GET</h2>
+      <ul>
+        <li><a href="sub/">link to sub/</a></li>
+        <li>
+          <a href="non-existent-path/">link to non-existent-path/ (404)</a>
+        </li>
+      </ul>
+    </div>
 
-    <h2>POST</h2>
-    <div>post to post/?</div>
-    <form action="post/" method="POST">
-      <label for="text-input">Enter text</label>
-      <input type="text" name="user_text" />
-      <button type="submit">Submit</button>
-    </form>
-    <br />
+    <div class="method">
+      <h2>POST</h2>
+      <p>post to post/?</p>
+      <form action="post/" method="POST">
+        <label for="text-input">Enter text</label>
+        <input type="text" name="user_text" />
+        <button type="submit">Submit</button>
+      </form>
+    </div>
 
-    <h2>DELETE</h2>
-    <div><a href="delete/">link to delete/?</a></div>
-    <br />
+    <div class="method">
+      <h2>DELETE</h2>
+      <p><a href="delete/">link to delete/?</a></p>
+    </div>
 
-    <h2>GET(CGI)</h2>
-    <div><a href="cgi/print_env.pl">link to cgi/print_env.pl</a></div>
-    <br />
+    <div class="method">
+      <h2>GET(CGI)</h2>
+      <p><a href="cgi/print_env.pl">link to cgi/print_env.pl</a></p>
+    </div>
 
-    <h2>POST(CGI)</h2>
-    <div>post to cgi/print_stdin.pl?</div>
-    <form action="cgi/print_stdin.pl" method="POST">
-      <label for="text-input">Enter text</label>
-      <input type="text" name="user_text" />
-      <button type="submit">Submit</button>
-    </form>
+    <div class="method">
+      <h2>POST(CGI)</h2>
+      <p>post to cgi/print_stdin.pl?</p>
+      <form action="cgi/print_stdin.pl" method="POST">
+        <label for="text-input">Enter text</label>
+        <input type="text" name="user_text" />
+        <button type="submit">Submit</button>
+      </form>
+    </div>
   </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -6,7 +6,35 @@
 </head>
 <body>
     <h1>Hello from webserv! (tmp)</h1>
+
+    <h2>GET</h2>
     <div><a href="/sub">link to /sub</a></div>
     <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
+    <br>
+
+    <h2>POST</h2>
+    <div>post to /post?</div>
+    <form action="/post" method="POST">
+        <label for="text-input">Enter text</label>
+        <input type="text" name="user_text">
+        <button type="submit">Submit</button>
+    </form>
+    <br>
+
+    <h2>DELETE</h2>
+    <div><a href="/delete">link to /delete?</a></div>
+    <br>
+
+    <h2>GET(CGI)</h2>
+    <div><a href="/cgi/print_env.pl">link to /cgi/print_env.pl</a></div>
+    <br>
+
+    <h2>POST(CGI)</h2>
+    <div>post to cgi/print_stdin.pl?</div>
+    <form action="/cgi/print_stdin.pl" method="POST">
+        <label for="text-input">Enter text</label>
+        <input type="text" name="user_text">
+        <button type="submit">Submit</button>
+    </form>
 </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -6,5 +6,7 @@
 </head>
 <body>
     <h1>Hello from webserv! (tmp)</h1>
+    <div><a href="/sub">link to /sub</a></div>
+    <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
 </body>
 </html>

--- a/html/sub/index.html
+++ b/html/sub/index.html
@@ -7,6 +7,6 @@
   <body>
     <h1>Sub page (tmp)</h1>
     <div><a href="/">link to / (Home)</a></div>
-    <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
+    <div><a href="non-existent-path/">link to non-existent-path/ (404)</a></div>
   </body>
 </html>

--- a/html/sub/index.html
+++ b/html/sub/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Web Server</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Sub page (tmp)</h1>
     <div><a href="/">link to / (Home)</a></div>
     <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
-</body>
+  </body>
 </html>

--- a/html/sub/index.html
+++ b/html/sub/index.html
@@ -6,5 +6,7 @@
 </head>
 <body>
     <h1>Sub page (tmp)</h1>
+    <div><a href="/">link to / (Home)</a></div>
+    <div><a href="/non-existent-path">link to non-existent-path (404)</a></div>
 </body>
 </html>

--- a/html/sub/index.html
+++ b/html/sub/index.html
@@ -6,7 +6,15 @@
   </head>
   <body>
     <h1>Sub page (tmp)</h1>
-    <div><a href="/">link to / (Home)</a></div>
-    <div><a href="non-existent-path/">link to non-existent-path/ (404)</a></div>
+
+    <div class="method">
+      <h2>GET</h2>
+      <ul>
+        <li><a href="/">link to / (Home)</a></li>
+        <li>
+          <a href="non-existent-path/">link to non-existent-path/ (404)</a>
+        </li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -38,6 +38,7 @@ Server::Server(const _config::Config::ConfigData &config) {
 	SockInfoVec sock_infos = ConvertConfigToSockInfoVec(server_configs);
 	Init(sock_infos);
 }
+
 Server::~Server() {}
 
 void Server::Run() {

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -1,4 +1,5 @@
 #include "client.hpp"
+#include "color.hpp"
 #include "utils.hpp"
 #include <arpa/inet.h> // inet_pton,htons
 #include <iostream>

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -1,4 +1,5 @@
 #include "client.hpp"
+#include "color.hpp"
 #include "utils.hpp"
 #include <cstdlib>
 #include <cstring> // strlen

--- a/test/unit/srcs/split/test_split.cpp
+++ b/test/unit/srcs/split/test_split.cpp
@@ -1,3 +1,4 @@
+#include "color.hpp"
 #include "utils.hpp"
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
HTML こんな感じでどうでしょう…？というベースの提案です
最低限のみ。今後、適宜追加

実行
```sh
# devcontainer
make run

# local browser で localhost:8080 にアクセス
```

### したこと
メイン (`/html`)
- top page (`html/index.html`)
  - sub page の URL を送る (sub page に移動する)
  - form 入力して POST としてリクエストを送る。CGI の場合はその URL を送る (webserv の内部で POST の処理がまだなので 404 に移動する。入力された text はリクエストの body に入っていて内部で受け取れている)

- sub page (`html/sub/index.html`)
  - top page に移動

- html ファイルの formatter として `Prettier` というのを入れてみました
それで自動フォーマットしてみてます
拘りがあるわけではないので、他が良いとかあれば教えてください

<br>

サブ (`/html` 以外)
- 関係ないのですが、少しだけだったのでついでに header の include 修正・改行の追加しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `html/index.html` に新しい HTML 要素（リンク、フォーム、ヘッダーなど）を追加し、さまざまなサーバーエンドポイントとやり取りできるようになりました。

- **スタイル**
  - `html/404.html` および `html/sub/index.html` のインデントとフォーマットを改善しました。

- **ドキュメント**
  - 一部の HTML 要素に自己終了タグを追加しました。

- **雑務**
  - HTML ファイルの保存時に `Prettier` フォーマッタを使用するよう設定を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->