### PR TITLE
[sandbox] HTTPParseクラス　ステータスラインが正常系かどうか確認する関数

### DIFF
--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -27,14 +27,14 @@ bool IsUpper(const std::string &str) {
 }
 
 // todo: create path (/, /aaa, /aaa/)
-std::string CreateDefaultPath(const std::string &path) {
-	static const std::string location = "html";
+// std::string CreateDefaultPath(const std::string &path) {
+// 	static const std::string location = "html";
 
-	if (path.size() == 1) {
-		return location + "/index.html";
-	}
-	return location + path + "/index.html";
-}
+// 	if (path.size() == 1) {
+// 		return location + "/index.html";
+// 	}
+// 	return location + path + "/index.html";
+// }
 
 // void PrintLines(const std::vector<std::string> &lines) {
 // 	typedef std::vector<std::string>::const_iterator It;
@@ -67,7 +67,7 @@ std::string HTTPParse::CheckMethod(const std::string &method) {
 	basic_methods.push_back("POST");
 	basic_methods.push_back("DELETE");
 	if (std::find(basic_methods.begin(), basic_methods.end(), method) == basic_methods.end()) {
-		return "501 Not Implemented";
+		return "501";
 	}
 	// 設定ファイルでメソッドが許可されてるかどうか -> 405
 	// どの仮想サーバーのどのリソースがメソッド許可されてるかどうか？がリソースパースしていない段階ではわからないからこの関数で判定しないかも
@@ -77,16 +77,16 @@ std::string HTTPParse::CheckMethod(const std::string &method) {
 	return (method);
 }
 
-std::string HTTPParse::CheckUri(const std::string &uri) {
-	// US-ASCIIかまたは大文字かどうか -> 400
-	if ("HTTP/1.1" == version)
-		return ("400");
-	return (version);
+std::string HTTPParse::CheckRequestTarget(const std::string &reqest_target) {
+	// /が先頭になかったら場合 -> 400
+	if (reqest_target.empty() || reqest_target[0] != '/')
+		return "400";
+	return reqest_target;
 }
 
 std::string HTTPParse::CheckVersion(const std::string &version) {
-	// US-ASCIIかまたは大文字かどうか -> 400
-	if ("HTTP/1.1" == version)
+	// HTTP/1.1かどうか -> 400
+	if ("HTTP/1.1" != version)
 		return ("400");
 	return (version);
 }
@@ -95,7 +95,7 @@ RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_li
 	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	RequestLine request_line(
 		CheckMethod(request_line_info[0]),
-		CreateDefaultPath(CheckUri(request_line_info[1])),
+		CheckRequestTarget(request_line_info[1]),
 		CheckVersion(request_line_info[2])
 	);
 	return request_line;

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -6,6 +6,26 @@
 namespace http {
 namespace {
 
+bool isUSASCII(const std::string &str) {
+	typedef std::string::const_iterator It;
+	for (It it = str.begin(); it != str.end(); it++) {
+		if (static_cast<unsigned char>(*it) > 127) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool isUpper(const std::string &str) {
+	typedef std::string::const_iterator It;
+	for (It it = str.begin(); it != str.end(); it++) {
+		if (!std::isupper(static_cast<unsigned char>(*it))) {
+			return false;
+		}
+	}
+	return true;
+}
+
 // todo: create path (/, /aaa, /aaa/)
 std::string CreateDefaultPath(const std::string &path) {
 	static const std::string location = "html";
@@ -35,12 +55,34 @@ HTTPParse::HTTPParse() {}
 
 HTTPParse::~HTTPParse() {}
 
+// メソッドを拡張する視点で作成する
+std::string HTTPParse::CheckMethod(const std::string &method) {
+	// US-ASCIIかまたは大文字かどうか -> 400
+	if (isUSASCII(method) == false || isUpper(method) == false)
+		return "400";
+	// GET, POST, DELETEかどうか ->　501
+	std::vector<std::string> basic_methods;
+	basic_methods.push_back("GET");
+	basic_methods.push_back("POST");
+	basic_methods.push_back("DELETE");
+	if (std::find(basic_methods.begin(), basic_methods.end(), method) == basic_methods.end()) {
+		return "501 Not Implemented";
+	}
+	// 設定ファイルでメソッドが許可されてるかどうか -> 405
+	// どの仮想サーバーのどのリソースがメソッド許可されてるかどうか？がリソースパースしていない段階ではわからないからこの関数で判定しないかも
+	// if (allowed_methods.find(method) == allowed_methods.end()) {
+	// 	return "405";
+	// }
+	return (method);
+}
+
 RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_line_info) {
 	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
-	RequestLine request_line;
-	request_line.method  = request_line_info[0];
-	request_line.uri     = CreateDefaultPath(request_line_info[1]);
-	request_line.version = request_line_info[2];
+	RequestLine request_line(
+		CheckMethod(request_line_info[0]),
+		CreateDefaultPath(request_line_info[1]),
+		request_line_info[2]
+	);
 	return request_line;
 }
 
@@ -67,16 +109,16 @@ HTTPRequest HTTPParse::Run(const std::string &read_buf) {
 	HTTPRequest              request;
 	std::vector<std::string> a = utils::SplitStr(read_buf, CRLF + CRLF);
 	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
-	request.status_line        = SetRequestLine(utils::SplitStr(b[0], SP));
+	request.request_line       = SetRequestLine(utils::SplitStr(b[0], SP));
 	request.header_fields      = SetHeaderFields(b);
 	// 調査: bodymessageの取得方法（ヘッダーによって仕様が変わる）
-	if ("POST" == request.status_line.method)
+	if ("POST" == request.request_line.method)
 		request.message_body = SetMessageBody(utils::SplitStr(a[1], ""));
 	// PrintLines(b);
 	return request;
 }
 
-// status_line && header
+// request_line && header
 // messagebody
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -6,7 +6,7 @@
 namespace http {
 namespace {
 
-bool isUSASCII(const std::string &str) {
+bool IsUSASCII(const std::string &str) {
 	typedef std::string::const_iterator It;
 	for (It it = str.begin(); it != str.end(); it++) {
 		if (static_cast<unsigned char>(*it) > 127) {
@@ -16,7 +16,7 @@ bool isUSASCII(const std::string &str) {
 	return true;
 }
 
-bool isUpper(const std::string &str) {
+bool IsUpper(const std::string &str) {
 	typedef std::string::const_iterator It;
 	for (It it = str.begin(); it != str.end(); it++) {
 		if (!std::isupper(static_cast<unsigned char>(*it))) {
@@ -58,9 +58,10 @@ HTTPParse::~HTTPParse() {}
 // メソッドを拡張する視点で作成する
 std::string HTTPParse::CheckMethod(const std::string &method) {
 	// US-ASCIIかまたは大文字かどうか -> 400
-	if (isUSASCII(method) == false || isUpper(method) == false)
+	if (IsUSASCII(method) == false || IsUpper(method) == false)
 		return "400";
 	// GET, POST, DELETEかどうか ->　501
+	// メソッドはstaticで持たせた方がいいのかな？
 	std::vector<std::string> basic_methods;
 	basic_methods.push_back("GET");
 	basic_methods.push_back("POST");
@@ -76,12 +77,26 @@ std::string HTTPParse::CheckMethod(const std::string &method) {
 	return (method);
 }
 
+std::string HTTPParse::CheckUri(const std::string &uri) {
+	// US-ASCIIかまたは大文字かどうか -> 400
+	if ("HTTP/1.1" == version)
+		return ("400");
+	return (version);
+}
+
+std::string HTTPParse::CheckVersion(const std::string &version) {
+	// US-ASCIIかまたは大文字かどうか -> 400
+	if ("HTTP/1.1" == version)
+		return ("400");
+	return (version);
+}
+
 RequestLine HTTPParse::SetRequestLine(const std::vector<std::string> &request_line_info) {
 	// 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	RequestLine request_line(
 		CheckMethod(request_line_info[0]),
-		CreateDefaultPath(request_line_info[1]),
-		request_line_info[2]
+		CreateDefaultPath(CheckUri(request_line_info[1])),
+		CheckVersion(request_line_info[2])
 	);
 	return request_line;
 }

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -35,6 +35,8 @@ class HTTPParse {
 	std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
 
 	std::string CheckMethod(const std::string &method);
+	std::string CheckUri(const std::string &uri);
+	std::string CheckVersion(const std::string &version);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -8,11 +8,13 @@ namespace http {
 
 struct RequestLine {
 	std::string method;
-	std::string uri;
+	std::string request_target;
 	std::string version;
-	RequestLine() : method(""), uri(""), version("") {}
-	RequestLine(const std::string &method, const std::string &uri, const std::string &version)
-		: method(method), uri(uri), version(version) {}
+	RequestLine() : method(""), request_target(""), version("") {}
+	RequestLine(
+		const std::string &method, const std::string &request_target, const std::string &version
+	)
+		: method(method), request_target(request_target), version(version) {}
 };
 
 typedef std::map<std::string, std::string> HeaderFields;
@@ -35,7 +37,7 @@ class HTTPParse {
 	std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
 
 	std::string CheckMethod(const std::string &method);
-	std::string CheckUri(const std::string &uri);
+	std::string CheckRequestTarget(const std::string &request_target);
 	std::string CheckVersion(const std::string &version);
 };
 

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -10,12 +10,15 @@ struct RequestLine {
 	std::string method;
 	std::string uri;
 	std::string version;
+	RequestLine() : method(""), uri(""), version("") {}
+	RequestLine(const std::string &method, const std::string &uri, const std::string &version)
+		: method(method), uri(uri), version(version) {}
 };
 
 typedef std::map<std::string, std::string> HeaderFields;
 
 struct HTTPRequest {
-	RequestLine  status_line;
+	RequestLine  request_line;
 	HeaderFields header_fields;
 	std::string  message_body;
 };
@@ -30,6 +33,8 @@ class HTTPParse {
 	RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
 	std::string  SetMessageBody(const std::vector<std::string> &message_body_info);
+
+	std::string CheckMethod(const std::string &method);
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -2,30 +2,40 @@
 #include <cassert>
 #include <iostream>
 
+void assert_request_line(const http::RequestLine &expect, const http::RequestLine &res) {
+	assert(expect.method == res.method);
+	assert(expect.uri == res.uri);
+	assert(expect.version == res.version);
+}
+
 int main(void) {
 	http::HTTPParse a;
 
 	// StatusLineのみのHTTPリクエスト
+	http::RequestLine expect1("GET", "html/index.html", "HTTP/1.1");
 	http::HTTPRequest test1 = a.Run("GET / HTTP/1.1");
-	assert("GET" == test1.status_line.method);
-	assert("html/index.html" == test1.status_line.uri);
-	assert("HTTP/1.1" == test1.status_line.version);
+	assert_request_line(expect1, test1.request_line);
+
+	// methodが小文字
+	http::RequestLine expect5("400", "html/index.html", "HTTP/1.1");
+	http::HTTPRequest test5 = a.Run("GEdT / HTTP/1.1");
+	assert_request_line(expect5, test5.request_line);
 
 	// StatusLineとHeadersを含むHTTPリクエスト
 	http::HTTPRequest test2 =
 		a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
-	assert("GET" == test2.status_line.method);
-	assert("html/sub/index.html" == test2.status_line.uri);
-	assert("HTTP/1.1" == test2.status_line.version);
+	assert("GET" == test2.request_line.method);
+	assert("html/sub/index.html" == test2.request_line.uri);
+	assert("HTTP/1.1" == test2.request_line.version);
 	assert("www.example.com" == test2.header_fields["Host"]);
 	assert("keep-alive" == test2.header_fields["Connection"]);
 
 	// StatusLineとHeader、Bodyを含むHTTPリクエスト
 	http::HTTPRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
 									"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
-	assert("POST" == test3.status_line.method);
-	assert("html/index.html/index.html" == test3.status_line.uri);
-	assert("HTTP/1.1" == test3.status_line.version);
+	assert("POST" == test3.request_line.method);
+	assert("html/index.html/index.html" == test3.request_line.uri);
+	assert("HTTP/1.1" == test3.request_line.version);
 	assert("www.example.com" == test3.header_fields["Host"]);
 	assert("keep-alive" == test3.header_fields["Connection"]);
 	assert("bodymessage" == test3.message_body);
@@ -34,8 +44,8 @@ int main(void) {
 	http::HTTPRequest test4 =
 		a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
 			  "keep-alive\r\n\r\naa\r\naa\naa");
-	// std::cout << "Method: " << test4.status_line.method << std::endl;
-	// std::cout << "uri: " << test4.status_line.uri << std::endl;
-	// std::cout << "version: " << test4.status_line.version << std::endl;
+	// std::cout << "Method: " << test4.request_line.method << std::endl;
+	// std::cout << "uri: " << test4.request_line.uri << std::endl;
+	// std::cout << "version: " << test4.request_line.version << std::endl;
 	return 0;
 }

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -4,48 +4,69 @@
 
 void assert_request_line(const http::RequestLine &expect, const http::RequestLine &res) {
 	assert(expect.method == res.method);
-	assert(expect.uri == res.uri);
+	assert(expect.request_target == res.request_target);
 	assert(expect.version == res.version);
 }
 
 int main(void) {
 	http::HTTPParse a;
+	// expectはエラーの場合はエラーのステータスコードを入れてます。enumを作成したら削除する
 
 	// StatusLineのみのHTTPリクエスト
-	http::RequestLine expect1("GET", "html/index.html", "HTTP/1.1");
+	http::RequestLine expect1("GET", "/", "HTTP/1.1");
 	http::HTTPRequest test1 = a.Run("GET / HTTP/1.1");
 	assert_request_line(expect1, test1.request_line);
 
-	// methodが小文字
-	http::RequestLine expect5("400", "html/index.html", "HTTP/1.1");
-	http::HTTPRequest test5 = a.Run("GEdT / HTTP/1.1");
+	// methodが小文字が含まれてる
+	http::RequestLine expect2("400", "/", "HTTP/1.1");
+	http::HTTPRequest test2 = a.Run("GEdT / HTTP/1.1");
+	assert_request_line(expect2, test2.request_line);
+
+	// methodがUS-ASCII以外の文字が含まれてる
+	http::RequestLine expect3("400", "/", "HTTP/1.1");
+	http::HTTPRequest test3 = a.Run("GEあ / HTTP/1.1");
+	assert_request_line(expect3, test3.request_line);
+
+	// 課題要件以外のmethodが含まれてる
+	http::RequestLine expect4("501", "/", "HTTP/1.1");
+	http::HTTPRequest test4 = a.Run("HEAD / HTTP/1.1");
+	assert_request_line(expect4, test4.request_line);
+
+	// RequestTargetが絶対パスじゃない
+	http::RequestLine expect5("GET", "400", "HTTP/1.1");
+	http::HTTPRequest test5 = a.Run("GET index.html/ HTTP/1.1");
 	assert_request_line(expect5, test5.request_line);
 
+	// HTTPバージョンが異なる
+	http::RequestLine expect6("GET", "/", "400");
+	http::HTTPRequest test6 = a.Run("GET / HTTP/1.0");
+	assert_request_line(expect6, test6.request_line);
+
 	// StatusLineとHeadersを含むHTTPリクエスト
-	http::HTTPRequest test2 =
-		a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
-	assert("GET" == test2.request_line.method);
-	assert("html/sub/index.html" == test2.request_line.uri);
-	assert("HTTP/1.1" == test2.request_line.version);
-	assert("www.example.com" == test2.header_fields["Host"]);
-	assert("keep-alive" == test2.header_fields["Connection"]);
+	// http::HTTPRequest test2 =
+	// 	a.Run("GET /sub HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n");
+	// assert("GET" == test2.request_line.method);
+	// assert("/sub" == test2.request_line.request_target);
+	// assert("HTTP/1.1" == test2.request_line.version);
+	// assert("www.example.com" == test2.header_fields["Host"]);
+	// assert("keep-alive" == test2.header_fields["Connection"]);
 
-	// StatusLineとHeader、Bodyを含むHTTPリクエスト
-	http::HTTPRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
-									"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
-	assert("POST" == test3.request_line.method);
-	assert("html/index.html/index.html" == test3.request_line.uri);
-	assert("HTTP/1.1" == test3.request_line.version);
-	assert("www.example.com" == test3.header_fields["Host"]);
-	assert("keep-alive" == test3.header_fields["Connection"]);
-	assert("bodymessage" == test3.message_body);
+	// // StatusLineとHeader、Bodyを含むHTTPリクエスト
+	// http::HTTPRequest test3 = a.Run("POST /index.html HTTP/1.1\r\nHost: "
+	// 								"www.example.com\r\nConnection: keep-alive\r\n\r\nbodymessage");
+	// assert("POST" == test3.request_line.method);
+	// assert("/index.html" == test3.request_line.request_target);
+	// assert("HTTP/1.1" == test3.request_line.version);
+	// assert("www.example.com" == test3.header_fields["Host"]);
+	// assert("keep-alive" == test3.header_fields["Connection"]);
+	// assert("bodymessage" == test3.message_body);
 
-	// StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
-	http::HTTPRequest test4 =
-		a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
-			  "keep-alive\r\n\r\naa\r\naa\naa");
+	// // StatusLineとHeader、Body(改行バージョン)を含むHTTPリクエスト
+	// http::HTTPRequest test4 =
+	// 	a.Run("POST /index.html HTTP/1.1\r\nHost: www.example.com\r\nConnection: "
+	// 		  "keep-alive\r\n\r\naa\r\naa\naa");
 	// std::cout << "Method: " << test4.request_line.method << std::endl;
-	// std::cout << "uri: " << test4.request_line.uri << std::endl;
+	// std::cout << "request_target: " << test4.request_line.request_target << std::endl;
 	// std::cout << "version: " << test4.request_line.version << std::endl;
 	return 0;
 }

--- a/test/nginx/Dockerfile
+++ b/test/nginx/Dockerfile
@@ -1,3 +1,7 @@
 FROM nginx:1.26.1
 
+RUN apt-get update && apt-get install -y vim
+
+COPY /test/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80

--- a/test/nginx/nginx.conf
+++ b/test/nginx/nginx.conf
@@ -1,0 +1,45 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+	access_log  /var/log/nginx/access.log main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/test/nginx/test.cpp
+++ b/test/nginx/test.cpp
@@ -1,0 +1,61 @@
+#include <arpa/inet.h>
+#include <cstring>
+#include <iostream>
+#include <netinet/in.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main() {
+	const char *server_ip = "127.0.0.1"; // NginxサーバのIPアドレス
+	int         port      = 80;          // Nginxサーバのポート番号
+
+	// ソケットの作成
+	int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (sockfd < 0) {
+		std::cerr << "Error creating socket" << std::endl;
+		return 1;
+	}
+
+	// サーバのアドレス情報の設定
+	struct sockaddr_in server_addr;
+	std::memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port   = htons(port);
+	if (inet_pton(AF_INET, server_ip, &server_addr.sin_addr) <= 0) {
+		std::cerr << "Invalid address / Address not supported" << std::endl;
+		close(sockfd);
+		return 1;
+	}
+
+	// サーバに接続
+	if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+		std::cerr << "Connection failed" << std::endl;
+		close(sockfd);
+		return 1;
+	}
+
+	// HTTP GETリクエストの作成
+	std::string request_body = "key1=value1&key2=value2";
+	std::string http_request = "GET / HTTP/1.1\r\nHost: " + std::string(server_ip) +
+							   "\r\nConnection: close\r\nContent-Type: "
+							   "application/x-www-form-urlencoded\r\nContent-Length: " +
+							   std::to_string(request_body.length()) + "\r\n\r\n" + request_body;
+
+	// リクエストの送信
+	send(sockfd, http_request.c_str(), http_request.size(), 0);
+
+	// レスポンスの受信
+	char buffer[4096];
+	int  bytes_received;
+	while ((bytes_received = recv(sockfd, buffer, sizeof(buffer) - 1, 0)) > 0) {
+		buffer[bytes_received] = '\0'; // 受信データを文字列として終端
+		std::cout << buffer;
+	}
+
+	// ソケットを閉じる
+	close(sockfd);
+
+	return 0;
+}


### PR DESCRIPTION
### したこと
- ステータスラインの書式が正しいかどうか確認する関数作成
  - CheckMethod
      - USASCIIかどうか -> 400
      - 大文字かどうか -> 400
      - GET, DELETE, POSTかどうか -> 501
  - CheckRequestTarget
      - 絶対パスかどうか -> 400
  - CheckVersion
      - HTTP/1.1かどうか -> 400
  - [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1) を参考
- main.cppに簡易的なテスト作成
  - 今は成功したら各値を返すが、失敗したらエラーのステータスコードを返すようになってる（今後はenumでやる）
  
### 今後
- ステータスコードを格納するenum作成
- ヘッダーフィールドの書式が正しいかどうか確認する関数

### 質問
- CheckMethod関数で課題要件を満たすメソッドを作成しているのですが、他でもメソッドの文字列を使う場面ってありますか？？
```
	// ? メソッドはstaticで持たせた方がいいのかな？
	std::vector<std::string> basic_methods;
	basic_methods.push_back("GET");
	basic_methods.push_back("POST");
	basic_methods.push_back("DELETE");
	if (std::find(basic_methods.begin(), basic_methods.end(), method) == basic_methods.end()) {
		return "501";
	}
```

### 追記
https://github.com/s1-haya/webserv/pull/166 の方でCheckMethodがよばれるたびにbasic_methodsを作成されるのを防ぐためstaticにしました
