### PR TITLE
[update] addrinfo構造体の list を全部 bind() 試して、1 つでも成功したら listen() する 

### DIFF
--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -26,8 +26,6 @@ void InitHints(Connection::AddrInfo *hints) {
 
 // result: dynamic allocated by getaddrinfo()
 Connection::AddrInfo *Connection::GetAddrInfoList(const SockInfo &server_sock_info) {
-	// todo: use host in getaddrinfo()?
-	// const std::string &host  = server_sock_info.GetName();
 	const std::string &port  = utils::ConvertUintToStr(server_sock_info.GetPort());
 	AddrInfo           hints = {};
 	InitHints(&hints);

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -32,6 +32,7 @@ Connection::AddrInfo *Connection::GetAddrInfoList(const SockInfo &server_sock_in
 
 	AddrInfo *result;
 	const int status = getaddrinfo(NULL, port.c_str(), &hints, &result);
+	// EAI_MEMORY is also included in status != 0
 	if (status != 0) {
 		throw std::runtime_error("getaddrinfo failed: " + std::string(gai_strerror(status)));
 	}

--- a/srcs/connection.hpp
+++ b/srcs/connection.hpp
@@ -24,8 +24,9 @@ class Connection {
 	// prohibit copy
 	Connection(const Connection &other);
 	Connection &operator=(const Connection &other);
-	// function
+	// functions
 	AddrInfo *GetAddrInfoList(const SockInfo &server_sock_info);
+	int       TryBind(AddrInfo *addrinfo) const;
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variable


### PR DESCRIPTION
#140  の後に main merge

man getaddrinfo()
> getaddrinfo() returns a list of address structures.
   Try each address until we successfully [bind](https://ja.manpages.org/bind/2)(2).
    If [socket](https://ja.manpages.org/socket/2)(2) (or [bind](https://ja.manpages.org/bind/2)(2)) fails, we (close the socket and) try the next address.

---

`getaddrinfo()` が作ってくれた `struct sockaddr *` の `list` を for 文で回してる部分の変更です

今まで
- systemcall に失敗したら throw していた
- `bind()` -> `listen()` を同タイミングで試していた

変更点
- man に全て `bind()` を試すと書いてあったので、systemcall に失敗しても取りあえず全部の `list` を for 文で回して `bind()` を試すようにした
- `bind()` に成功して初めてそのソケットを `listen()` する、の方が役割として分かれていて良さそうだったので分割した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<br>
<br>

## Summary by CodeRabbit

- **新機能**
  - 接続の前にソケットのバインドを試みる機能を追加しました。不成功の場合はエラーを返します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->