### PR TITLE
[sandbox] httpparseクラス ヘッダフィールドの書式をパースする関数作成

### DIFF
--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -28,6 +28,15 @@ bool IsUpper(const std::string &str) {
 	return true;
 }
 
+// OWS (optional whitespace): SP(Space), HTAB(Horizontal Tab)
+void TrimLeadingOptionalWhitespace(std::string &str) {
+	size_t i = 0;
+	while (i < str.size() && (std::isspace(str[i]) || str[i] == '\t')) {
+		++i;
+	}
+	str.erase(0, i);
+}
+
 static std::vector<std::string> CreateBasicMethods() {
 	std::vector<std::string> basic_methods;
 	basic_methods.push_back("GET");
@@ -98,7 +107,8 @@ HeaderFields HttpParse::SetHeaderFields(
 	typedef std::vector<std::string>::const_iterator It;
 	try {
 		for (It it = header_fields_info.begin() + 1; it != header_fields_info.end(); ++it) {
-			std::vector<std::string> header_key_value                 = utils::SplitStr(*it, ": ");
+			std::vector<std::string> header_key_value                 = utils::SplitStr(*it, ":");
+			TrimLeadingOptionalWhitespace(header_key_value[1]);
 			header_fields[CheckHeaderFieldValue(header_key_value[0])] = header_key_value[1];
 		}
 	} catch (const HttpParseException &e) {

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -28,7 +28,9 @@ struct HttpRequest {
 
 enum StatusCode {
 	OK,
-	NOT_FOUND
+	BAD_REQUEST,
+	NOT_FOUND,
+	NOT_IMPLEMENTED
 };
 
 struct HttpRequestResult {
@@ -44,12 +46,19 @@ class HttpParse {
   private:
 	HttpParse();
 	~HttpParse();
-	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
+	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line, StatusCode* status_code);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
 
 	static std::string CheckMethod(const std::string &method);
 	static std::string CheckRequestTarget(const std::string &request_target);
 	static std::string CheckVersion(const std::string &version);
+	class HttpParseException {
+		public:
+			explicit HttpParseException(const StatusCode& status_code);
+			const StatusCode& GetStatusCode() const;
+		private:
+			const StatusCode& status_code_;
+	};
 };
 
 } // namespace http

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -49,18 +49,21 @@ class HttpParse {
 	~HttpParse();
 	static RequestLine
 	SetRequestLine(const std::vector<std::string> &request_line, StatusCode *status_code);
-	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
+	static HeaderFields
+	SetHeaderFields(const std::vector<std::string> &header_fields_info, StatusCode *status_code);
 
 	static std::string CheckMethod(const std::string &method);
 	static std::string CheckRequestTarget(const std::string &request_target);
 	static std::string CheckVersion(const std::string &version);
+
+	static std::string CheckHeaderFieldValue(const std::string &header_field_value);
 	class HttpParseException {
 	  public:
-		explicit HttpParseException(const StatusCode &status_code);
-		const StatusCode &GetStatusCode() const;
+		explicit HttpParseException(StatusCode status_code);
+		StatusCode GetStatusCode() const;
 
 	  private:
-		const StatusCode &status_code_;
+		StatusCode status_code_;
 	};
 };
 

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -17,19 +17,26 @@ int main(void) {
 	assert_request_line(expect1, test1.request.request_line);
 
 	// methodが小文字が含まれてる
-	http::RequestLine       expect2("400", "/", "HTTP/1.1");
+	http::RequestLine       expect2("", "/", "HTTP/1.1");
 	http::HttpRequestResult test2 = http::HttpParse::Run("GEdT / HTTP/1.1");
-	assert_request_line(expect2, test2.request.request_line);
+	assert(http::BAD_REQUEST == test2.status_code);
+	if (http::OK == test2.status_code)
+		assert_request_line(expect2, test2.request.request_line);
+	// assert(http::OK == test2.status_code);
 
 	// methodがUS-ASCII以外の文字が含まれてる
-	http::RequestLine       expect3("400", "/", "HTTP/1.1");
+	http::RequestLine       expect3("", "/", "HTTP/1.1");
 	http::HttpRequestResult test3 = http::HttpParse::Run("GEあ / HTTP/1.1");
-	assert_request_line(expect3, test3.request.request_line);
+	assert(http::BAD_REQUEST == test3.status_code);
+	if (http::OK == test3.status_code)
+		assert_request_line(expect2, test3.request.request_line);
 
 	// 課題要件以外のmethodが含まれてる
-	http::RequestLine       expect4("501", "/", "HTTP/1.1");
+	http::RequestLine       expect4("", "/", "HTTP/1.1");
 	http::HttpRequestResult test4 = http::HttpParse::Run("HEAD / HTTP/1.1");
-	assert_request_line(expect4, test4.request.request_line);
+	assert(http::NOT_IMPLEMENTED == test4.status_code);
+	if (http::OK == test4.status_code)
+		assert_request_line(expect2, test4.request.request_line);
 
 	// // RequestTargetが絶対パスじゃない
 	// http::RequestLine expect5("GET", "400", "HTTP/1.1");

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -31,7 +31,7 @@ int main(void) {
 	http::HttpRequestResult test4 = http::HttpParse::Run("HEAD / HTTP/1.1");
 	assert(http::NOT_IMPLEMENTED == test4.status_code);
 
-	// header_fieldsが設定されてる場合
+	// header_fields: 成功例
 	http::RequestLine       expect5("GET", "/", "HTTP/1.1");
 	http::HttpRequestResult test5 = http::HttpParse::Run(
 		"GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n"
@@ -40,12 +40,21 @@ int main(void) {
 	assert_request_line(expect5, test5.request.request_line);
 	assert("www.example.com" == test5.request.header_fields["Host"]);
 
-	// header_fieldsの書式が間違ってる場合
-	http::RequestLine       expect6("", "/", "HTTP/1.1");
+	// header_fields: セミコロン以降に複数OWS(SpaceとHorizontal Tab)が設定されてる場合
+	http::RequestLine       expect6("GET", "/", "HTTP/1.1");
 	http::HttpRequestResult test6 = http::HttpParse::Run(
+		"GET / HTTP/1.1\r\nHost:    \twww.example.com\r\nConnection: keep-alive\r\n\r\n"
+	);
+	assert(http::OK == test6.status_code);
+	assert_request_line(expect6, test6.request.request_line);
+	assert("www.example.com" == test6.request.header_fields["Host"]);
+
+	// header_fields: 存在しないfield_nameの場合
+	http::RequestLine       expect7("", "/", "HTTP/1.1");
+	http::HttpRequestResult test7 = http::HttpParse::Run(
 		"GET / HTTP/1.1\r\nHosdt: www.example.com\r\nConnection: keep-alive\r\n\r\n"
 	);
-	assert(http::BAD_REQUEST == test6.status_code);
+	assert(http::BAD_REQUEST == test7.status_code);
 
 	// // RequestTargetが絶対パスじゃない
 	// http::RequestLine expect6("GET", "400", "HTTP/1.1");

--- a/sandbox/sawa/http_parse/main.cpp
+++ b/sandbox/sawa/http_parse/main.cpp
@@ -20,26 +20,35 @@ int main(void) {
 	http::RequestLine       expect2("", "/", "HTTP/1.1");
 	http::HttpRequestResult test2 = http::HttpParse::Run("GEdT / HTTP/1.1");
 	assert(http::BAD_REQUEST == test2.status_code);
-	if (http::OK == test2.status_code)
-		assert_request_line(expect2, test2.request.request_line);
-	// assert(http::OK == test2.status_code);
 
 	// methodがUS-ASCII以外の文字が含まれてる
 	http::RequestLine       expect3("", "/", "HTTP/1.1");
 	http::HttpRequestResult test3 = http::HttpParse::Run("GEあ / HTTP/1.1");
 	assert(http::BAD_REQUEST == test3.status_code);
-	if (http::OK == test3.status_code)
-		assert_request_line(expect3, test3.request.request_line);
 
 	// 課題要件以外のmethodが含まれてる
 	http::RequestLine       expect4("", "/", "HTTP/1.1");
 	http::HttpRequestResult test4 = http::HttpParse::Run("HEAD / HTTP/1.1");
 	assert(http::NOT_IMPLEMENTED == test4.status_code);
-	if (http::OK == test4.status_code)
-		assert_request_line(expect4, test4.request.request_line);
+
+	// header_fieldsが設定されてる場合
+	http::RequestLine       expect5("GET", "/", "HTTP/1.1");
+	http::HttpRequestResult test5 = http::HttpParse::Run(
+		"GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: keep-alive\r\n\r\n"
+	);
+	assert(http::OK == test5.status_code);
+	assert_request_line(expect5, test5.request.request_line);
+	assert("www.example.com" == test5.request.header_fields["Host"]);
+
+	// header_fieldsの書式が間違ってる場合
+	http::RequestLine       expect6("", "/", "HTTP/1.1");
+	http::HttpRequestResult test6 = http::HttpParse::Run(
+		"GET / HTTP/1.1\r\nHosdt: www.example.com\r\nConnection: keep-alive\r\n\r\n"
+	);
+	assert(http::BAD_REQUEST == test6.status_code);
 
 	// // RequestTargetが絶対パスじゃない
-	// http::RequestLine expect5("GET", "400", "HTTP/1.1");
+	// http::RequestLine expect6("GET", "400", "HTTP/1.1");
 	// http::HttpRequestResult test5 = a.Run("GET index.html/ HTTP/1.1");
 	// assert_request_line(expect5, test5.request_line);
 

--- a/test/nginx/test.cpp
+++ b/test/nginx/test.cpp
@@ -38,10 +38,33 @@ int main() {
 
 	// HTTP GETリクエストの作成
 	std::string request_body = "key1=value1&key2=value2";
-	std::string http_request = "GET / HTTP/1.1\r\nHost: " + std::string(server_ip) +
-							   "\r\nConnection: close\r\nContent-Type: "
-							   "application/x-www-form-urlencoded\r\nContent-Length: " +
+	std::string http_request = "GET / HTTP/1.1\r\n"
+							   "Host: a\r\n"
+							   "Host: " +
+							   std::string(server_ip) +
+							   "\r\n"
+							   "Connection: close\r\n"
+							   "Content-Type: application/x-www-form-urlencoded\r\n"
+							   "Content-Length: " +
 							   std::to_string(request_body.length()) + "\r\n\r\n" + request_body;
+	// Hostを複数設定した場合　HTTP/1.1 400 Bad Request
+	// std::string http_request = "GET / HTTP/1.1\r\n"
+	// 						   "Host: a\r\n"
+	// 						   "Host: " + std::string(server_ip) + "\r\n"
+	// 						   "Connection: close\r\n"
+	// 						   "Content-Type: application/x-www-form-urlencoded\r\n"
+	// 						   "Content-Length: " +
+	// 						   std::to_string(request_body.length()) + "\r\n\r\n" + request_body;
+
+	// Connectionが複数設定した場合は最後に設定した値が適用: HTTP/1.1 200 OK
+	// std::string http_request = "GET / HTTP/1.1\r\n"
+	// 						   "Host: a\r\n"
+	// 						   "Connection: keep-alive\r\n"
+	// 						   "Connection: keep-alive\r\n"
+	// 						   "Connection: close\r\n"
+	// 						   "Content-Type: application/x-www-form-urlencoded\r\n"
+	// 						   "Content-Length: " +
+	// 						   std::to_string(request_body.length()) + "\r\n\r\n" + request_body;
 
 	// リクエストの送信
 	send(sockfd, http_request.c_str(), http_request.size(), 0);


### PR DESCRIPTION
sanboxとnginxのtest.cpp のみなのでレビューなしで大丈夫です!issue立てて作り直します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTPパース機能にヘッダーフィールドの検証機能を追加しました。

- **バグ修正**
  - ヘッダーフィールドの処理におけるエラー処理を改善し、ステータスコードの設定を追加しました。

- **テスト**
  - HTTPパースのテストケースを追加し、ヘッダーフィールドの異なるシナリオに対応しました。
  - HTTP GETリクエスト作成プロセスのテストを強化し、様々なホスト設定や重複ヘッダーのシナリオを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->