### PR TITLE
[add] client の IP, port などを保持しておく ClientInfo class 作成

### DIFF
--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -1,0 +1,19 @@
+#include "client_info.hpp"
+
+// todo: tmp
+#include <iostream>
+
+namespace server {
+
+ClientInfo::ClientInfo(int fd, const struct sockaddr_storage &sock_addr) : fd_(fd), port_(0) {
+	(void)sock_addr;
+}
+
+ClientInfo::~ClientInfo() {
+	// todo: close?
+	// if (fd_ != SYSTEM_ERROR) {
+	// 	close(fd_);
+	// }
+}
+
+} // namespace server

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -1,4 +1,5 @@
 #include "client_info.hpp"
+#include <arpa/inet.h>  // ntohs
 #include <netdb.h>      // getnameinfo
 #include <netinet/in.h> // struct sock_addr,INET6_ADDRSTRLEN,ntohs
 #include <stdexcept>
@@ -10,7 +11,7 @@ namespace server {
 
 ClientInfo::ClientInfo(int fd, const struct sockaddr_storage &sock_addr) : fd_(fd), port_(0) {
 	SetSockInfo(sock_addr);
-	std::cout << "client (" << fd << ") " << "ip: " << ip_str_ << std::endl;
+	std::cout << "client (" << fd << ") " << "ip: " << ip_str_ << ", port: " << port_ << std::endl;
 }
 
 ClientInfo::~ClientInfo() {
@@ -19,6 +20,23 @@ ClientInfo::~ClientInfo() {
 	// 	close(fd_);
 	// }
 }
+
+namespace {
+
+unsigned int ConvertPortToHostByteOrder(const struct sockaddr_storage &sock_addr) {
+	// for IPv4
+	if (sock_addr.ss_family == AF_INET) {
+		return ntohs(((struct sockaddr_in *)&sock_addr)->sin_port);
+	}
+	// for IPv6
+	if (sock_addr.ss_family == AF_INET6) {
+		return ntohs(((struct sockaddr_in6 *)&sock_addr)->sin6_port);
+	}
+	// todo: tmp(unreachable?)
+	return -1;
+}
+
+} // namespace
 
 void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	// getnameinfo
@@ -37,8 +55,9 @@ void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 		throw std::runtime_error("getnameinfo failed: " + std::string(gai_strerror(status)));
 	}
 
-	// set IP
+	// set IP,port
 	ip_str_ = ip_str;
+	port_   = ConvertPortToHostByteOrder(sock_addr);
 }
 
 } // namespace server

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -4,14 +4,10 @@
 #include <netinet/in.h> // struct sock_addr,INET6_ADDRSTRLEN,ntohs
 #include <stdexcept>
 
-// todo: tmp
-#include <iostream>
-
 namespace server {
 
 ClientInfo::ClientInfo(int fd, const struct sockaddr_storage &sock_addr) : fd_(fd), port_(0) {
 	SetSockInfo(sock_addr);
-	std::cout << "client (" << fd << ") " << "ip: " << ip_str_ << ", port: " << port_ << std::endl;
 }
 
 ClientInfo::~ClientInfo() {

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -18,13 +18,13 @@ ClientInfo::~ClientInfo() {
 
 void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	// getnameinfo
-	char      ip_str[INET6_ADDRSTRLEN];
+	char      ip[INET6_ADDRSTRLEN];
 	char      port[NI_MAXSERV];
 	const int status = getnameinfo(
 		(struct sockaddr *)&sock_addr,
 		sizeof(sock_addr),
-		ip_str,
-		sizeof(ip_str),
+		ip,
+		sizeof(ip),
 		port,
 		sizeof(port),
 		NI_NUMERICHOST | NI_NUMERICSERV
@@ -35,12 +35,12 @@ void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	}
 
 	// set IP,port
-	ip_str_ = ip_str;
-	port_   = port;
+	ip_   = ip;
+	port_ = port;
 }
 
 std::string ClientInfo::GetIp() const {
-	return ip_str_;
+	return ip_;
 }
 
 std::string ClientInfo::GetPort() const {

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -39,11 +39,11 @@ void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	port_ = port;
 }
 
-std::string ClientInfo::GetIp() const {
+const std::string &ClientInfo::GetIp() const {
 	return ip_;
 }
 
-std::string ClientInfo::GetPort() const {
+const std::string &ClientInfo::GetPort() const {
 	return port_;
 }
 

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -19,32 +19,24 @@ ClientInfo::~ClientInfo() {
 void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	// getnameinfo
 	char      ip[INET6_ADDRSTRLEN];
-	char      port[NI_MAXSERV];
 	const int status = getnameinfo(
 		(struct sockaddr *)&sock_addr,
 		sizeof(sock_addr),
 		ip,
 		sizeof(ip),
-		port,
-		sizeof(port),
+		NULL,
+		0,
 		NI_NUMERICHOST | NI_NUMERICSERV
 	);
 	if (status != 0) {
 		// todo: tmp
 		throw std::runtime_error("getnameinfo failed: " + std::string(gai_strerror(status)));
 	}
-
-	// set IP,port
-	ip_   = ip;
-	port_ = port;
+	ip_ = ip;
 }
 
 const std::string &ClientInfo::GetIp() const {
 	return ip_;
-}
-
-const std::string &ClientInfo::GetPort() const {
-	return port_;
 }
 
 } // namespace server

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -1,4 +1,7 @@
 #include "client_info.hpp"
+#include <netdb.h>      // getnameinfo
+#include <netinet/in.h> // struct sock_addr,INET6_ADDRSTRLEN,ntohs
+#include <stdexcept>
 
 // todo: tmp
 #include <iostream>
@@ -6,7 +9,8 @@
 namespace server {
 
 ClientInfo::ClientInfo(int fd, const struct sockaddr_storage &sock_addr) : fd_(fd), port_(0) {
-	(void)sock_addr;
+	SetSockInfo(sock_addr);
+	std::cout << "client (" << fd << ") " << "ip: " << ip_str_ << std::endl;
 }
 
 ClientInfo::~ClientInfo() {
@@ -14,6 +18,27 @@ ClientInfo::~ClientInfo() {
 	// if (fd_ != SYSTEM_ERROR) {
 	// 	close(fd_);
 	// }
+}
+
+void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
+	// getnameinfo
+	char      ip_str[INET6_ADDRSTRLEN];
+	const int status = getnameinfo(
+		(struct sockaddr *)&sock_addr,
+		sizeof(sock_addr),
+		ip_str,
+		sizeof(ip_str),
+		NULL,
+		0,
+		NI_NUMERICHOST
+	);
+	if (status != 0) {
+		// todo: tmp
+		throw std::runtime_error("getnameinfo failed: " + std::string(gai_strerror(status)));
+	}
+
+	// set IP
+	ip_str_ = ip_str;
 }
 
 } // namespace server

--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -60,4 +60,12 @@ void ClientInfo::SetSockInfo(const struct sockaddr_storage &sock_addr) {
 	port_   = ConvertPortToHostByteOrder(sock_addr);
 }
 
+std::string ClientInfo::GetIp() const {
+	return ip_str_;
+}
+
+unsigned int ClientInfo::GetPort() const {
+	return port_;
+}
+
 } // namespace server

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -23,7 +23,7 @@ class ClientInfo {
 	void SetSockInfo(const struct sockaddr_storage &sock_addr);
 	// variables
 	int         fd_;
-	std::string ip_str_;
+	std::string ip_;
 	std::string port_;
 };
 

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -11,8 +11,8 @@ class ClientInfo {
 	ClientInfo(int fd, const struct sockaddr_storage &sock_addr);
 	~ClientInfo();
 	// getter
-	std::string  GetIp() const;
-	unsigned int GetPort() const;
+	std::string GetIp() const;
+	std::string GetPort() const;
 
   private:
 	ClientInfo();
@@ -22,9 +22,9 @@ class ClientInfo {
 	// function
 	void SetSockInfo(const struct sockaddr_storage &sock_addr);
 	// variables
-	int          fd_;
-	std::string  ip_str_;
-	unsigned int port_;
+	int         fd_;
+	std::string ip_str_;
+	std::string port_;
 };
 
 } // namespace server

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -12,7 +12,6 @@ class ClientInfo {
 	~ClientInfo();
 	// getter
 	const std::string &GetIp() const;
-	const std::string &GetPort() const;
 
   private:
 	ClientInfo();
@@ -24,7 +23,6 @@ class ClientInfo {
 	// variables
 	int         fd_;
 	std::string ip_;
-	std::string port_;
 };
 
 } // namespace server

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -10,6 +10,9 @@ class ClientInfo {
   public:
 	ClientInfo(int fd, const struct sockaddr_storage &sock_addr);
 	~ClientInfo();
+	// getter
+	std::string  GetIp() const;
+	unsigned int GetPort() const;
 
   private:
 	ClientInfo();

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -1,0 +1,27 @@
+#ifndef CLIENT_INFO_HPP_
+#define CLIENT_INFO_HPP_
+
+#include <string>
+#include <sys/socket.h> // struct sockaddr_storage,socklen_t
+
+namespace server {
+
+class ClientInfo {
+  public:
+	ClientInfo(int fd, const struct sockaddr_storage &sock_addr);
+	~ClientInfo();
+
+  private:
+	ClientInfo();
+	// prohibit copy
+	ClientInfo(const ClientInfo &other);
+	ClientInfo &operator=(const ClientInfo &other);
+	// variables
+	int          fd_;
+	std::string  ip_str_;
+	unsigned int port_;
+};
+
+} // namespace server
+
+#endif /* CLIENT_INFO_HPP_ */

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -11,8 +11,8 @@ class ClientInfo {
 	ClientInfo(int fd, const struct sockaddr_storage &sock_addr);
 	~ClientInfo();
 	// getter
-	std::string GetIp() const;
-	std::string GetPort() const;
+	const std::string &GetIp() const;
+	const std::string &GetPort() const;
 
   private:
 	ClientInfo();

--- a/srcs/client_info.hpp
+++ b/srcs/client_info.hpp
@@ -16,6 +16,8 @@ class ClientInfo {
 	// prohibit copy
 	ClientInfo(const ClientInfo &other);
 	ClientInfo &operator=(const ClientInfo &other);
+	// function
+	void SetSockInfo(const struct sockaddr_storage &sock_addr);
 	// variables
 	int          fd_;
 	std::string  ip_str_;

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -98,6 +98,12 @@ int Connection::Accept(int server_fd) {
 
 	// create new client struct
 	ClientInfo client_info(client_fd, client_sock_addr);
+	utils::Debug(
+		"server",
+		"new ClientInfo created. IP: " + client_info.GetIp() +
+			", PORT: " + utils::ConvertUintToStr(client_info.GetPort()) + ", fd",
+		client_fd
+	);
 
 	// todo: need?
 	// if (client_fd == SYSTEM_ERROR) {

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -93,7 +93,7 @@ int Connection::Connect(SockInfo &server_sock_info) {
 int Connection::Accept(int server_fd) {
 	struct sockaddr sock_addr;
 	socklen_t       addrlen   = sizeof(sock_addr);
-	const socklen_t client_fd = accept(server_fd, (struct sockaddr *)&sock_addr, &addrlen);
+	const int       client_fd = accept(server_fd, (struct sockaddr *)&sock_addr, &addrlen);
 	// retrieve the client's IP address, port, etc.
 
 	// todo: need?

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -1,4 +1,5 @@
 #include "connection.hpp"
+#include "client_info.hpp"
 #include "server.hpp"
 #include "sock_info.hpp"
 #include "utils.hpp"    // ConvertUintToStr
@@ -91,10 +92,12 @@ int Connection::Connect(SockInfo &server_sock_info) {
 }
 
 int Connection::Accept(int server_fd) {
-	struct sockaddr sock_addr;
-	socklen_t       addrlen   = sizeof(sock_addr);
-	const int       client_fd = accept(server_fd, (struct sockaddr *)&sock_addr, &addrlen);
-	// retrieve the client's IP address, port, etc.
+	struct sockaddr_storage client_sock_addr;
+	socklen_t               addrlen = sizeof(client_sock_addr);
+	const int client_fd = accept(server_fd, (struct sockaddr *)&client_sock_addr, &addrlen);
+
+	// create new client struct
+	ClientInfo client_info(client_fd, client_sock_addr);
 
 	// todo: need?
 	// if (client_fd == SYSTEM_ERROR) {

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -100,8 +100,8 @@ int Connection::Accept(int server_fd) {
 	ClientInfo client_info(client_fd, client_sock_addr);
 	utils::Debug(
 		"server",
-		"new ClientInfo created. IP: " + client_info.GetIp() +
-			", PORT: " + utils::ConvertUintToStr(client_info.GetPort()) + ", fd",
+		"new ClientInfo created. IP: " + client_info.GetIp() + ", PORT: " + client_info.GetPort() +
+			", fd",
 		client_fd
 	);
 

--- a/srcs/connection.cpp
+++ b/srcs/connection.cpp
@@ -99,10 +99,7 @@ int Connection::Accept(int server_fd) {
 	// create new client struct
 	ClientInfo client_info(client_fd, client_sock_addr);
 	utils::Debug(
-		"server",
-		"new ClientInfo created. IP: " + client_info.GetIp() + ", PORT: " + client_info.GetPort() +
-			", fd",
-		client_fd
+		"server", "new ClientInfo created. IP: " + client_info.GetIp() + ", fd", client_fd
 	);
 
 	// todo: need?


### PR DESCRIPTION
一旦以下の 2 つの class を分けて作ってみることにし、この PR では `ClientInfo class` のみ実装をしています
- `ClientInfo class` :  client の socket 情報 (IP, port 等) を保持する
- `ServerInfo class` : server の socket 情報 (server_name, location 等) を保持する -> 別 Issue

---

### したこと
- [x] fd, IP, port をメンバにもつ client 用の `ClientInfo class` 作成 (fd はメンバにいらないかも？-> 後で必要そうだったのでこのままで。)
- [x] コンストラクタで IP, port を設定 (コンストラクト時に取得して良いものか？ちょっと疑問)

### してないこと
- エラー処理
- "fd 毎の client のインスタンスを全部保持しておく map" を server 側がもつこと -> 別 Issue

### 実行確認
現段階では e2e が通れば取りあえず挙動に問題はないと思います
```sh
# devcontainer
make run
make test

# request を送ると client の IP, port, fd が debug 出力される
           :
[server] run server
[server] new ClientInfo created. IP: 127.0.0.1, PORT: 46254, fd(6) <-
[server] add new client(6)
           :
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - クライアント情報を管理する `ClientInfo` クラスを追加しました。これにより、ソケットファイルディスクリプタ、IPアドレス、ポートの情報を含むクライアント情報を扱うことができます。

- **改善**
  - `Connection` クラスの `Accept` メソッドが更新され、クライアントソケット情報を使用して `ClientInfo` オブジェクトを作成するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->