### PR TITLE
[add] `SockContext` が、client_fd とその client の request を受信した server 情報を紐づけて保持する

### DIFF
--- a/srcs/buffer.cpp
+++ b/srcs/buffer.cpp
@@ -26,10 +26,9 @@ void Buffer::Delete(int fd) {
 	buffers_[fd].erase();
 }
 
-// In C++98, the map's "at" method is unavailable, not using const qualifiers.
-std::string &Buffer::GetBuffer(int fd) {
+const std::string &Buffer::GetBuffer(int fd) const {
 	// todo: fd error handle
-	return buffers_[fd];
+	return buffers_.at(fd);
 }
 
 } // namespace server

--- a/srcs/buffer.hpp
+++ b/srcs/buffer.hpp
@@ -13,9 +13,10 @@ class Buffer {
 	typedef std::map<int, std::string> Buffers;
 	Buffer();
 	~Buffer();
-	ssize_t      Read(int fd);
-	void         Delete(int fd);
-	std::string &GetBuffer(int fd);
+	ssize_t Read(int fd);
+	void    Delete(int fd);
+	// getter
+	const std::string &GetBuffer(int fd) const;
 
   private:
 	// prohibit copy

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -83,7 +83,7 @@ void Server::HandleNewConnection(int server_fd) {
 	}
 
 	// add to context
-	context_.AddClientInfo(client_fd, new_client_info);
+	context_.AddClientInfo(client_fd, new_client_info, server_fd);
 	event_monitor_.Add(client_fd, event::EVENT_READ);
 	utils::Debug("server", "add new client", client_fd);
 }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -135,7 +135,7 @@ std::string Server::CreateHttpResponse(int client_fd) const {
 	// todo: tmp
 	const bool is_cgi = true;
 	if (is_cgi) {
-		ClientInfo client_info = context_.GetClientInfo(client_fd);
+		const ClientInfo &client_info = context_.GetClientInfo(client_fd);
 		const ServerInfo &server_info = context_.GetConnectedServerInfo(client_fd);
 		utils::Debug(
 			"server",

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -136,7 +136,7 @@ std::string Server::CreateHttpResponse(int client_fd) const {
 	const bool is_cgi = true;
 	if (is_cgi) {
 		ClientInfo client_info = context_.GetClientInfo(client_fd);
-		ServerInfo server_info = context_.GetConnectedServerInfo(client_fd);
+		const ServerInfo &server_info = context_.GetConnectedServerInfo(client_fd);
 		utils::Debug(
 			"server",
 			"ClientInfo - IP: " + client_info.GetIp() +

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -23,13 +23,14 @@ class Server {
 	Server();
 	// prohibit copy
 	Server(const Server &other);
-	Server &operator=(const Server &other);
-	void    Init(const ServerInfoVec &server_infos);
-	void    HandleEvent(const event::Event &event);
-	void    HandleNewConnection(int server_fd);
-	void    HandleExistingConnection(const event::Event &event);
-	void    ReadRequest(const event::Event &event);
-	void    SendResponse(int client_fd);
+	Server     &operator=(const Server &other);
+	void        Init(const ServerInfoVec &server_infos);
+	void        HandleEvent(const event::Event &event);
+	void        HandleNewConnection(int server_fd);
+	void        HandleExistingConnection(const event::Event &event);
+	void        ReadRequest(const event::Event &event);
+	std::string CreateHttpResponse(int client_fd) const;
+	void        SendResponse(int client_fd);
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// connection

--- a/srcs/server_info.cpp
+++ b/srcs/server_info.cpp
@@ -26,6 +26,10 @@ int ServerInfo::GetFd() const {
 	return fd_;
 }
 
+const std::string &ServerInfo::GetName() const {
+	return name_;
+}
+
 unsigned int ServerInfo::GetPort() const {
 	return port_;
 }

--- a/srcs/server_info.hpp
+++ b/srcs/server_info.hpp
@@ -14,8 +14,9 @@ class ServerInfo {
 	ServerInfo(const ServerInfo &other);
 	ServerInfo &operator=(const ServerInfo &other);
 	// getter
-	int          GetFd() const;
-	unsigned int GetPort() const;
+	int                GetFd() const;
+	const std::string &GetName() const;
+	unsigned int       GetPort() const;
 	// setter
 	void SetSockFd(int fd);
 

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -49,9 +49,9 @@ void SockContext::DeleteClientInfo(int fd) {
 	host_servers_.erase(fd);
 }
 
-const ServerInfo &SockContext::GetServerInfo(int fd) const {
+const ServerInfo *SockContext::GetServerInfo(int fd) const {
 	try {
-		return server_context_.at(fd);
+		return &server_context_.at(fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("ServerInfo doesn't exist");
 	}
@@ -67,7 +67,7 @@ const ClientInfo &SockContext::GetClientInfo(int fd) const {
 
 const ServerInfo &SockContext::GetConnectedServerInfo(int client_fd) const {
 	try {
-		return host_servers_.at(client_fd);
+		return *host_servers_.at(client_fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("associated ServerInfo doesn't exist");
 	}

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -65,4 +65,12 @@ const ClientInfo &SockContext::GetClientInfo(int fd) const {
 	}
 }
 
+const ServerInfo &SockContext::GetConnectedServerInfo(int client_fd) const {
+	try {
+		return host_servers_.at(client_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("associated ServerInfo doesn't exist");
+	}
+}
+
 } // namespace server

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -36,7 +36,7 @@ void SockContext::AddClientInfo(int client_fd, const ClientInfo &client_info, in
 	}
 
 	// add the connected host server_info associated with client_fd to host_servers
-	typedef std::pair<ClientsHostServerMap::const_iterator, bool> ResultInsertToHost;
+	typedef std::pair<HostServerInfoMap::const_iterator, bool> ResultInsertToHost;
 	ResultInsertToHost                                            result_host =
 		host_servers_.insert(std::make_pair(client_fd, GetServerInfo(server_fd)));
 	if (result_host.second == false) {

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -49,14 +49,6 @@ void SockContext::DeleteClientInfo(int fd) {
 	host_servers_.erase(fd);
 }
 
-const ServerInfo *SockContext::GetServerInfo(int fd) const {
-	try {
-		return &server_context_.at(fd);
-	} catch (const std::exception &e) {
-		throw std::logic_error("ServerInfo doesn't exist");
-	}
-}
-
 const ClientInfo &SockContext::GetClientInfo(int fd) const {
 	try {
 		return client_context_.at(fd);
@@ -70,6 +62,14 @@ const ServerInfo &SockContext::GetConnectedServerInfo(int client_fd) const {
 		return *host_servers_.at(client_fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("associated ServerInfo doesn't exist");
+	}
+}
+
+const ServerInfo *SockContext::GetServerInfo(int fd) const {
+	try {
+		return &server_context_.at(fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("ServerInfo doesn't exist");
 	}
 }
 

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -57,4 +57,12 @@ const ServerInfo &SockContext::GetServerInfo(int fd) const {
 	}
 }
 
+const ClientInfo &SockContext::GetClientInfo(int fd) const {
+	try {
+		return client_context_.at(fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("ClientInfo doesn't exist");
+	}
+}
+
 } // namespace server

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -28,18 +28,18 @@ void SockContext::AddServerInfo(int server_fd, const ServerInfo &server_info) {
 
 void SockContext::AddClientInfo(int client_fd, const ClientInfo &client_info, int server_fd) {
 	// add client_info to client_context
-	typedef std::pair<ClientInfoMap::const_iterator, bool> ResultInsertToContext;
-	ResultInsertToContext                                  result_context =
+	typedef std::pair<ClientInfoMap::const_iterator, bool> ResultInsertToClientContext;
+	ResultInsertToClientContext                            result_client_context =
 		client_context_.insert(std::make_pair(client_fd, client_info));
-	if (result_context.second == false) {
+	if (result_client_context.second == false) {
 		throw std::logic_error("ClientInfo already exists");
 	}
 
 	// add the connected host server_info associated with client_fd to host_servers
-	typedef std::pair<HostServerInfoMap::const_iterator, bool> ResultInsertToHost;
-	ResultInsertToHost                                            result_host =
+	typedef std::pair<HostServerInfoMap::const_iterator, bool> ResultInsertToHostServers;
+	ResultInsertToHostServers                                  result_host_servers =
 		host_servers_.insert(std::make_pair(client_fd, GetServerInfo(server_fd)));
-	if (result_host.second == false) {
+	if (result_host_servers.second == false) {
 		throw std::logic_error("ClientInfo already exists");
 	}
 }

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -18,9 +18,9 @@ SockContext::~SockContext() {
 	}
 }
 
-void SockContext::AddServerInfo(int fd, const ServerInfo &server_info) {
+void SockContext::AddServerInfo(int server_fd, const ServerInfo &server_info) {
 	typedef std::pair<ServerInfoMap::const_iterator, bool> InsertResult;
-	InsertResult result = server_context_.insert(std::make_pair(fd, server_info));
+	InsertResult result = server_context_.insert(std::make_pair(server_fd, server_info));
 	if (result.second == false) {
 		throw std::logic_error("ServerInfo already exists");
 	}
@@ -44,14 +44,14 @@ void SockContext::AddClientInfo(int client_fd, const ClientInfo &client_info, in
 	}
 }
 
-void SockContext::DeleteClientInfo(int fd) {
-	client_context_.erase(fd);
-	host_servers_.erase(fd);
+void SockContext::DeleteClientInfo(int client_fd) {
+	client_context_.erase(client_fd);
+	host_servers_.erase(client_fd);
 }
 
-const ClientInfo &SockContext::GetClientInfo(int fd) const {
+const ClientInfo &SockContext::GetClientInfo(int client_fd) const {
 	try {
-		return client_context_.at(fd);
+		return client_context_.at(client_fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("ClientInfo doesn't exist");
 	}
@@ -65,9 +65,9 @@ const ServerInfo &SockContext::GetConnectedServerInfo(int client_fd) const {
 	}
 }
 
-const ServerInfo *SockContext::GetServerInfo(int fd) const {
+const ServerInfo *SockContext::GetServerInfo(int server_fd) const {
 	try {
-		return &server_context_.at(fd);
+		return &server_context_.at(server_fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("ServerInfo doesn't exist");
 	}

--- a/srcs/sock_context.cpp
+++ b/srcs/sock_context.cpp
@@ -38,4 +38,12 @@ void SockContext::DeleteClientInfo(int fd) {
 	client_context_.erase(fd);
 }
 
+const ServerInfo &SockContext::GetServerInfo(int fd) const {
+	try {
+		return server_context_.at(fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("ServerInfo doesn't exist");
+	}
+}
+
 } // namespace server

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -13,6 +13,7 @@ class SockContext {
   public:
 	typedef std::map<int, ServerInfo> ServerInfoMap;
 	typedef std::map<int, ClientInfo> ClientInfoMap;
+	typedef std::map<int, ServerInfo> ClientsHostServerMap; // todo: naming
 	SockContext();
 	~SockContext();
 	// functions
@@ -30,8 +31,9 @@ class SockContext {
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variables
-	ServerInfoMap server_context_;
-	ClientInfoMap client_context_;
+	ServerInfoMap        server_context_;
+	ClientInfoMap        client_context_;
+	ClientsHostServerMap host_servers_;
 };
 
 } // namespace server

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -18,11 +18,11 @@ class SockContext {
 	~SockContext();
 	// functions
 	// todo: overload?
-	void AddServerInfo(int fd, const ServerInfo &server_info);
-	void AddClientInfo(int fd, const ClientInfo &client_info, int server_fd);
-	void DeleteClientInfo(int fd);
+	void AddServerInfo(int server_fd, const ServerInfo &server_info);
+	void AddClientInfo(int client_fd, const ClientInfo &client_info, int server_fd);
+	void DeleteClientInfo(int client_fd);
 	// getter
-	const ClientInfo &GetClientInfo(int fd) const;
+	const ClientInfo &GetClientInfo(int client_fd) const;
 	const ServerInfo &GetConnectedServerInfo(int client_fd) const;
 
   private:
@@ -30,7 +30,7 @@ class SockContext {
 	SockContext(const SockContext &other);
 	SockContext &operator=(const SockContext &other);
 	// function
-	const ServerInfo *GetServerInfo(int fd) const;
+	const ServerInfo *GetServerInfo(int server_fd) const;
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variables

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -19,7 +19,7 @@ class SockContext {
 	// functions
 	// todo: overload?
 	void AddServerInfo(int fd, const ServerInfo &server_info);
-	void AddClientInfo(int fd, const ClientInfo &client_info);
+	void AddClientInfo(int fd, const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int fd);
 	// getter
 	const ServerInfo &GetServerInfo(int fd) const;

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -22,7 +22,6 @@ class SockContext {
 	void AddClientInfo(int fd, const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int fd);
 	// getter
-	const ServerInfo *GetServerInfo(int fd) const;
 	const ClientInfo &GetClientInfo(int fd) const;
 	const ServerInfo &GetConnectedServerInfo(int client_fd) const;
 
@@ -30,6 +29,8 @@ class SockContext {
 	// prohibit copy
 	SockContext(const SockContext &other);
 	SockContext &operator=(const SockContext &other);
+	// function
+	const ServerInfo *GetServerInfo(int fd) const;
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variables

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -13,7 +13,7 @@ class SockContext {
   public:
 	typedef std::map<int, ServerInfo>         ServerInfoMap;
 	typedef std::map<int, ClientInfo>         ClientInfoMap;
-	typedef std::map<int, const ServerInfo *> ClientsHostServerMap; // todo: naming
+	typedef std::map<int, const ServerInfo *> HostServerInfoMap;
 	SockContext();
 	~SockContext();
 	// functions
@@ -34,9 +34,9 @@ class SockContext {
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variables
-	ServerInfoMap        server_context_;
-	ClientInfoMap        client_context_;
-	ClientsHostServerMap host_servers_;
+	ServerInfoMap     server_context_;
+	ClientInfoMap     client_context_;
+	HostServerInfoMap host_servers_;
 };
 
 } // namespace server

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -20,6 +20,8 @@ class SockContext {
 	void AddServerInfo(int fd, const ServerInfo &server_info);
 	void AddClientInfo(int fd, const ClientInfo &client_info);
 	void DeleteClientInfo(int fd);
+	// getter
+	const ServerInfo &GetServerInfo(int fd) const;
 
   private:
 	// prohibit copy

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -23,6 +23,7 @@ class SockContext {
 	void DeleteClientInfo(int fd);
 	// getter
 	const ServerInfo &GetServerInfo(int fd) const;
+	const ClientInfo &GetClientInfo(int fd) const;
 
   private:
 	// prohibit copy

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -11,9 +11,9 @@ class ClientInfo;
 // Store socket informations for each fd
 class SockContext {
   public:
-	typedef std::map<int, ServerInfo> ServerInfoMap;
-	typedef std::map<int, ClientInfo> ClientInfoMap;
-	typedef std::map<int, ServerInfo> ClientsHostServerMap; // todo: naming
+	typedef std::map<int, ServerInfo>         ServerInfoMap;
+	typedef std::map<int, ClientInfo>         ClientInfoMap;
+	typedef std::map<int, const ServerInfo *> ClientsHostServerMap; // todo: naming
 	SockContext();
 	~SockContext();
 	// functions
@@ -22,7 +22,7 @@ class SockContext {
 	void AddClientInfo(int fd, const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int fd);
 	// getter
-	const ServerInfo &GetServerInfo(int fd) const;
+	const ServerInfo *GetServerInfo(int fd) const;
 	const ClientInfo &GetClientInfo(int fd) const;
 	const ServerInfo &GetConnectedServerInfo(int client_fd) const;
 

--- a/srcs/sock_context.hpp
+++ b/srcs/sock_context.hpp
@@ -24,6 +24,7 @@ class SockContext {
 	// getter
 	const ServerInfo &GetServerInfo(int fd) const;
 	const ClientInfo &GetClientInfo(int fd) const;
+	const ServerInfo &GetConnectedServerInfo(int client_fd) const;
 
   private:
 	// prohibit copy


### PR DESCRIPTION
## したこと
### 機能追加
- `class SockContext`
- [x] client_fd と、その client と接続している server 情報を紐づける map を、SockContext class 内にもつようにした
(`ClientsHostServerMap`, `host_servers_` などの命名はより良いのがあればなと思ってます)
```cpp
typedef std::map<int, const ServerInfo *> ClientsHostServerMap;
```
- [x] `AddClientInfo()`, `DeleteClientInfo()` で client 情報を登録・削除する際に、同時に接続先の server 情報も map に登録・削除するようにした


### 機能追加ではない、実装上の変更点
- [x] [`srcs/server.cpp` 137 行目くらい](https://github.com/s1-haya/webserv/pull/184/files#diff-4d09ec0b514aa793727b6cabc4c1ddc1e22c0d74190f219bbaf62f40c4d96101R130-R151) : もし CGI だったら client 情報と接続先 server 情報を取得する、という分岐を仮作成。(今は必ず実行される)
```sh
# 以下のような行が debug 出力で確認できる
[server] ClientInfo - IP: 127.0.0.1 / ServerInfo - name: localhost, port: 8080, fd(4)
```
- [x] map へのアクセス時に、存在しなかったら追加する、という書き方だと余計なアクセスが起きていたので、1 回で済むように `insert()` を使用

### 実行確認
`make e2e` が動いていれば今のところ挙動大丈夫だと思います
unit test は別で作成中です… (-> #186 )
```sh
# devcontainer
make run
make test
```


### 今後
- VirtualServer class がいるか？いるならどう class 内で保持したり、検索に使うか考える -> 相談済
- SockContext は色々役割が多い気もするので、段々更に class 分けしそう

<br>
<br>

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
	- `Buffer` クラスの `GetBuffer` メソッドが、読み取り専用の参照を返すように変更され、データの安全性が向上しました。
	- `Server` クラスに新しい `CreateHttpResponse` メソッドが追加され、HTTPレスポンスの生成がよりオブジェクト指向のアプローチで扱えるようになりました。
	- `ServerInfo` クラスに `GetName` メソッドが追加され、サーバー名の取得が可能になりました。
	- `SockContext` クラスに新しいクライアントとサーバー情報を管理する機能が追加されました。

- **バグ修正**
	- クライアント情報の追加および削除時に、適切な管理とエラーハンドリングが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->