### PR TITLE
[fix] ServerInfo, ClientInfo の constructor でのメンバ初期化を修正

### DIFF
--- a/srcs/client_info.cpp
+++ b/srcs/client_info.cpp
@@ -5,7 +5,7 @@
 
 namespace server {
 
-ClientInfo::ClientInfo() {}
+ClientInfo::ClientInfo() : fd_(0) {}
 
 ClientInfo::ClientInfo(int fd, const struct sockaddr_storage &sock_addr) : fd_(fd) {
 	SetSockInfo(sock_addr);

--- a/srcs/server_info.cpp
+++ b/srcs/server_info.cpp
@@ -2,7 +2,7 @@
 
 namespace server {
 
-ServerInfo::ServerInfo() : fd_(0), name_(""), port_(0) {}
+ServerInfo::ServerInfo() : fd_(0), port_(0) {}
 
 ServerInfo::ServerInfo(const std::string &name, unsigned int port)
 	: fd_(0), name_(name), port_(port) {}


### PR DESCRIPTION
SockContext の unit test を書いている際に valgrind で気付いた、クラスのメンバ変数の未初期化・不要な初期化を修正