### PR TITLE
[add] 全 VirtualServer を保持・管理する class 作成

### DIFF
--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -1,0 +1,21 @@
+#include "virtual_server_storage.hpp"
+#include "virtual_server.hpp"
+
+namespace server {
+
+VirtualServerStorage::VirtualServerStorage() {}
+
+VirtualServerStorage::~VirtualServerStorage() {}
+
+VirtualServerStorage::VirtualServerStorage(const VirtualServerStorage &other) {
+	*this = other;
+}
+
+VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage &other) {
+	if (this != &other) {
+		virtual_servers_ = other.virtual_servers_;
+	}
+	return *this;
+}
+
+} // namespace server

--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -1,5 +1,6 @@
 #include "virtual_server_storage.hpp"
 #include "virtual_server.hpp"
+#include <stdexcept> // logic_error
 
 namespace server {
 
@@ -21,6 +22,20 @@ VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage
 
 void VirtualServerStorage::AddVirtualServer(const VirtualServer &virtual_server) {
 	virtual_servers_.push_back(virtual_server);
+}
+
+// ex)
+// - virtual_server1が通信でfd 4,5を使用している場合
+// virtual_server_storage.AddMapping(4, virtual_server1*);
+// virtual_server_storage.AddMapping(5, virtual_server1*);
+// -> mapping_fd_to_virtual_servers_ = {{4, virtual_server1*}, {5, virtual_servers1*}}
+void VirtualServerStorage::AddMapping(int server_fd, const VirtualServer *virtual_server) {
+	typedef std::pair<VirtualServerMapping::const_iterator, bool> InsertResult;
+	InsertResult                                                  result =
+		mapping_fd_to_virtual_servers_.insert(std::make_pair(server_fd, virtual_server));
+	if (result.second == false) {
+		throw std::logic_error("server_fd is already mapped");
+	}
 }
 
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -18,4 +18,8 @@ VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage
 	return *this;
 }
 
+void VirtualServerStorage::AddVirtualServer(const VirtualServer &virtual_server) {
+	virtual_servers_.push_back(virtual_server);
+}
+
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -13,7 +13,8 @@ VirtualServerStorage::VirtualServerStorage(const VirtualServerStorage &other) {
 
 VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage &other) {
 	if (this != &other) {
-		virtual_servers_ = other.virtual_servers_;
+		virtual_servers_               = other.virtual_servers_;
+		mapping_fd_to_virtual_servers_ = other.mapping_fd_to_virtual_servers_;
 	}
 	return *this;
 }

--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -38,4 +38,12 @@ void VirtualServerStorage::AddMapping(int server_fd, const VirtualServer *virtua
 	}
 }
 
+const VirtualServer &VirtualServerStorage::GetVirtualServer(int server_fd) const {
+	try {
+		return *mapping_fd_to_virtual_servers_.at(server_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("VirtualServer doesn't exists");
+	}
+}
+
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -2,6 +2,7 @@
 #define VIRTUAL_SERVER_STORAGE_HPP_
 
 #include <list>
+#include <map>
 
 namespace server {
 
@@ -10,7 +11,8 @@ class VirtualServer;
 // fdとVirtualServerを紐づけて全VirtualServerを保持・取得する
 class VirtualServerStorage {
   public:
-	typedef std::list<VirtualServer> VirtualServerList;
+	typedef std::list<VirtualServer>             VirtualServerList;
+	typedef std::map<int, const VirtualServer *> VirtualServerMapping;
 	VirtualServerStorage();
 	~VirtualServerStorage();
 	VirtualServerStorage(const VirtualServerStorage &other);
@@ -21,6 +23,8 @@ class VirtualServerStorage {
   private:
 	// 全VirtualServerを保持
 	VirtualServerList virtual_servers_;
+	// VirtualServerと、VirtualServerが通信に使用している複数fdを紐づける
+	VirtualServerMapping mapping_fd_to_virtual_servers_;
 };
 
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -20,6 +20,8 @@ class VirtualServerStorage {
 	// functions
 	void AddVirtualServer(const VirtualServer &virtual_server);
 	void AddMapping(int server_fd, const VirtualServer *virtual_server);
+	// getter
+	const VirtualServer &GetVirtualServer(int server_fd) const;
 
   private:
 	// 全VirtualServerを保持

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -1,0 +1,26 @@
+#ifndef VIRTUAL_SERVER_STORAGE_HPP_
+#define VIRTUAL_SERVER_STORAGE_HPP_
+
+#include <list>
+
+namespace server {
+
+class VirtualServer;
+
+// fdとVirtualServerを紐づけて全VirtualServerを保持・取得する
+class VirtualServerStorage {
+  public:
+	typedef std::list<VirtualServer> VirtualServerList;
+	VirtualServerStorage();
+	~VirtualServerStorage();
+	VirtualServerStorage(const VirtualServerStorage &other);
+	VirtualServerStorage &operator=(const VirtualServerStorage &other);
+
+  private:
+	// 全VirtualServerを保持
+	VirtualServerList virtual_servers_;
+};
+
+} // namespace server
+
+#endif /* VIRTUAL_SERVER_STORAGE_HPP_ */

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -15,6 +15,8 @@ class VirtualServerStorage {
 	~VirtualServerStorage();
 	VirtualServerStorage(const VirtualServerStorage &other);
 	VirtualServerStorage &operator=(const VirtualServerStorage &other);
+	// function
+	void AddVirtualServer(const VirtualServer &virtual_server);
 
   private:
 	// 全VirtualServerを保持

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -17,8 +17,9 @@ class VirtualServerStorage {
 	~VirtualServerStorage();
 	VirtualServerStorage(const VirtualServerStorage &other);
 	VirtualServerStorage &operator=(const VirtualServerStorage &other);
-	// function
+	// functions
 	void AddVirtualServer(const VirtualServer &virtual_server);
+	void AddMapping(int server_fd, const VirtualServer *virtual_server);
 
   private:
 	// 全VirtualServerを保持

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -2,7 +2,8 @@
 # Each directory should have a Makefile with a 'run' target.
 TEST_DIRS	:=	convert_str \
 				split_str \
-				virtual_server
+				virtual_server \
+				virtual_server_storage
 
 .PHONY	: run
 run:

--- a/test/unit/virtual_server_storage/Makefile
+++ b/test/unit/virtual_server_storage/Makefile
@@ -1,0 +1,75 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	virtual_server_storage
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR		:=	../../../srcs
+WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
+SRCS			+=	$(WS_UTILS_DIR)/color.cpp
+WS_VIRTUAL_SERVER_DIR	:=	$(WS_SRCS_DIR)/virtual_server
+SRCS					+=	$(WS_VIRTUAL_SERVER_DIR)/virtual_server_storage.cpp \
+							$(WS_VIRTUAL_SERVER_DIR)/virtual_server.cpp
+
+# 3. Add unit test files
+SRCS	+=	test_virtual_server_storage.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_UTILS_DIR) $(WS_VIRTUAL_SERVER_DIR) 
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -152,6 +152,19 @@ int RunTestVirtualServerStorage() {
 	ret_code |= Test(RunGetVirtualServer(vs_storage, 5, vs1));
 	ret_code |= Test(RunGetVirtualServer(vs_storage, 6, vs2));
 
+	// virtual_server_storageのcopyのテスト
+	// copy constructor
+	server::VirtualServerStorage copy_vs_storage1(vs_storage);
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage1, 4, vs1));
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage1, 5, vs1));
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage1, 6, vs2));
+
+	// copy assignment operator=
+	server::VirtualServerStorage copy_vs_storage2 = vs_storage;
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage2, 4, vs1));
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage2, 5, vs1));
+	ret_code |= Test(RunGetVirtualServer(copy_vs_storage2, 6, vs2));
+
 	return ret_code;
 }
 

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -1,0 +1,48 @@
+#include "virtual_server.hpp"
+#include "virtual_server_storage.hpp"
+#include <cstdlib>
+
+namespace {
+
+typedef server::VirtualServer::LocationList LocationList;
+
+// -----------------------------------------------------------------------------
+// - virtual_serverは以下の想定
+// virtual_server | server_name | locations         | ports
+// ----------------- ----------------------------------------------
+//       vs1      | localhost   | {"/www/"}         | {8080, 12345}
+//       vs2      | localhost2  | {"/", "/static/"} | {9999}
+int RunTestVirtualServerStorage() {
+	int ret_code = EXIT_SUCCESS;
+
+	/* -------------- VirtualServer2個用意 -------------- */
+	std::string  expected_server_name1 = "localhost";
+	LocationList expected_locations1;
+	expected_locations1.push_back("/www/");
+	server::VirtualServer vs1(expected_server_name1, expected_locations1);
+
+	std::string  expected_server_name2 = "localhost2";
+	LocationList expected_locations2;
+	expected_locations2.push_back("/");
+	expected_locations2.push_back("/static/");
+	server::VirtualServer vs2(expected_server_name2, expected_locations2);
+
+	/* -------------- VirtualServerStorage -------------- */
+	server::VirtualServerStorage vs_storage;
+
+	// virtual_server2個をvirtual_server_storageに追加
+	vs_storage.AddVirtualServer(vs1);
+	vs_storage.AddVirtualServer(vs2);
+
+	return ret_code;
+}
+
+} // namespace
+
+int main() {
+	int ret_code = EXIT_SUCCESS;
+
+	ret_code |= RunTestVirtualServerStorage();
+
+	return ret_code;
+}

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -1,10 +1,111 @@
+#include "color.hpp"
 #include "virtual_server.hpp"
 #include "virtual_server_storage.hpp"
 #include <cstdlib>
+#include <iostream>
+#include <sstream> // ostringstream
 
 namespace {
 
 typedef server::VirtualServer::LocationList LocationList;
+
+struct Result {
+	bool        is_ok;
+	std::string error_log;
+};
+
+int GetTestCaseNum() {
+	static int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+void PrintOk() {
+	std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintNg() {
+	std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintError(const std::string &message) {
+	std::cerr << utils::color::RED << message << utils::color::RESET << std::endl;
+}
+
+template <typename T>
+bool IsSame(const T &result, const T &expected) {
+	return result == expected;
+}
+
+int Test(Result result) {
+	if (result.is_ok) {
+		PrintOk();
+		return EXIT_SUCCESS;
+	}
+	PrintNg();
+	PrintError(result.error_log);
+	return EXIT_FAILURE;
+}
+
+// -----------------------------------------------------------------------------
+// テストfail時のlocationsのdebug出力
+// (todo: test_virtual_server.cppと全く同じ関数なのでどうにかしても良いかも)
+std::string PrintLocations(const LocationList &locations) {
+	std::ostringstream oss;
+
+	typedef LocationList::const_iterator It;
+	for (It it = locations.begin(); it != locations.end(); ++it) {
+		oss << *it;
+		if (++LocationList::const_iterator(it) != locations.end()) {
+			oss << std::endl;
+		}
+	}
+	return oss.str();
+}
+
+Result
+TestIsSameVirtualServer(const server::VirtualServer &vs, const server::VirtualServer &expected_vs) {
+	Result result;
+	result.is_ok = true;
+	std::ostringstream oss;
+
+	// server_name
+	const std::string &server_name          = vs.GetServerName();
+	const std::string &expected_server_name = expected_vs.GetServerName();
+	if (!IsSame(server_name, expected_server_name)) {
+		result.is_ok = false;
+		oss << "server_name" << std::endl;
+		oss << "- result   [" << server_name << "]" << std::endl;
+		oss << "- expected [" << expected_server_name << "]" << std::endl;
+	}
+
+	// locations
+	const LocationList &locations          = vs.GetLocations();
+	const LocationList &expected_locations = expected_vs.GetLocations();
+	if (!IsSame(locations, expected_locations)) {
+		result.is_ok = false;
+		oss << "locations" << std::endl;
+		oss << "- result  " << std::endl;
+		oss << "[" << PrintLocations(locations) << "]" << std::endl;
+		oss << "- expected" << std::endl;
+		oss << "[" << PrintLocations(expected_locations) << "]" << std::endl;
+	}
+
+	result.error_log = oss.str();
+	return result;
+}
+
+Result RunGetVirtualServer(
+	const server::VirtualServerStorage &vs_storage,
+	int                                 server_fd,
+	const server::VirtualServer        &expected_vs
+) {
+	const server::VirtualServer &vs = vs_storage.GetVirtualServer(server_fd);
+
+	return TestIsSameVirtualServer(vs, expected_vs);
+}
 
 // -----------------------------------------------------------------------------
 // - virtual_serverは以下の想定
@@ -45,6 +146,11 @@ int RunTestVirtualServerStorage() {
 	vs_storage.AddMapping(4, &vs1);
 	vs_storage.AddMapping(5, &vs1);
 	vs_storage.AddMapping(6, &vs2);
+
+	// getterを使用して期待通りvirtual_serverが追加されてるか・紐づけられているかテスト
+	ret_code |= Test(RunGetVirtualServer(vs_storage, 4, vs1));
+	ret_code |= Test(RunGetVirtualServer(vs_storage, 5, vs1));
+	ret_code |= Test(RunGetVirtualServer(vs_storage, 6, vs2));
 
 	return ret_code;
 }

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -34,6 +34,18 @@ int RunTestVirtualServerStorage() {
 	vs_storage.AddVirtualServer(vs1);
 	vs_storage.AddVirtualServer(vs2);
 
+	// - socket通信した結果のserver_fdとvirtual_serverは以下の想定
+	// fd | virtual_server  | port
+	// ----------------------------
+	//  4 |       vs1       | 8080
+	//  5 |       vs1       | 12345
+	//  6 |       vs2       | 9999
+
+	// server_fdとvirtual_serverの紐づけをvirtual_server_storageに追加
+	vs_storage.AddMapping(4, &vs1);
+	vs_storage.AddMapping(5, &vs1);
+	vs_storage.AddMapping(6, &vs2);
+
 	return ret_code;
 }
 


### PR DESCRIPTION
PR #178 の後、main merge

主に見てほしいメイン実装は `+84 行`です
(unit test `+256 行`)

## 目的
現在は 1 つの仮想サーバのみ対応しているので、複数仮想サーバに対応する

以下の流れで実装していて、この PR は `2` のみの実装です (イメージは miro の全体図の右上の方にあります)
1. ~~`class VirtualServer` 作成~~
(PR #178 )
2. `1` を全て保持する `class VirtualServerStorage` 作成 <-
3. `1`, `2` を Server 内に組み込む
(-> Issue #209 )

## したこと
`VirtualServer` を全て保持しておく `class VirtualServerStorage` を作成しました

使われ方は以下のように想定しています (上記 `3` で実装する)
- `Server class` の最初に、config を基に複数 `VirtualServer` を作る
- 作った `VirtualServer` を全部 `VirtualServerStorage.AddVirtualServer(VirtualServer)` で storage に保存する
- `Server.Init()` で各 VirtualServer の port の socket 通信が完了したら、その fd との紐づけを storage に保存する
`VirtualServerStorage.AddMapping(server_fd, VirtualServer*)`
- getter は CGI で、server_fd から VirtualServer の情報を取得する際に使用する
`VirtualServerStorage.GetVirtualServer(server_fd)`

簡単な unit test 付きです
```sh
make unit
```

- `3` で webserv 内に組み込みたいので、cppcheck で unused のエラーが出ますが、一時的なのでスルーしていただけると🙏
- 型名・変数名がすごく微妙な気がしてるので、何か良い案があればお願いします…


<br>
<br>
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 仮想サーバーの管理を行う新しいクラス「VirtualServerStorage」を導入しました。
	- 新しい仮想サーバーを追加し、ファイルディスクリプタにマッピングする機能を提供します。
	- 仮想サーバーをファイルディスクリプタに基づいて取得する機能を追加しました。
  
- **テスト**
	- 「VirtualServerStorage」クラスの機能を検証するユニットテストを新たに追加しました。
	- テストフレームワークの構成を強化し、仮想サーバーのストレージコンポーネントに関連するビルドプロセスを管理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->