### PR TITLE
[add] VirtualServerをServer classに組み込む

### DIFF
--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char **argv) {
 
 	try {
 		server::Server server(config);
+		server.Init();
 		server.Run();
 	} catch (const std::exception &e) {
 		PrintError(e.what());

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -38,8 +38,8 @@ std::list<TempConfig> CreateTempConfig() {
 VirtualServer::PortList ConvertPorts(const std::list<std::string> &ports_str) {
 	VirtualServer::PortList port_list;
 
-	typedef std::list<std::string>::const_iterator It;
-	for (It it = ports_str.begin(); it != ports_str.end(); ++it) {
+	typedef std::list<std::string>::const_iterator Itr;
+	for (Itr it = ports_str.begin(); it != ports_str.end(); ++it) {
 		unsigned int port;
 		if (!utils::ConvertStrToUint(*it, port)) {
 			// todo: original exception

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -154,24 +154,6 @@ void Server::ReadRequest(const event::Event &event) {
 	}
 }
 
-namespace {
-
-// todo: tmp for debug
-std::string OutputLocations(const VirtualServer::LocationList &locations) {
-	std::ostringstream oss;
-
-	typedef VirtualServer::LocationList::const_iterator It;
-	for (It it = locations.begin(); it != locations.end(); ++it) {
-		oss << *it;
-		if (++It(it) != locations.end()) {
-			oss << ", ";
-		}
-	}
-	return oss.str();
-}
-
-} // namespace
-
 std::string Server::CreateHttpResponse(int client_fd) const {
 	const std::string &request_buf = buffers_.GetBuffer(client_fd);
 
@@ -196,7 +178,8 @@ std::string Server::CreateHttpResponse(int client_fd) const {
 		utils::Debug(
 			"server",
 			"ClientInfo - IP: " + client_ip + " / ServerInfo - name: " + server_name +
-				", location: " + OutputLocations(locations) + ", port: " + server_port + ", fd",
+				", location: " + utils::FormatListToStr(locations) + ", port: " + server_port +
+				", fd",
 			server_fd
 		);
 		// todo: call cgi(client_info, server_info)?

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -9,10 +9,40 @@
 #include <unistd.h>     // close
 
 namespace server {
+namespace {
+
+// todo: tmp
+std::list<TempConfig> CreateTempConfig() {
+	std::list<TempConfig> all_configs;
+
+	// virtual server 1
+	TempConfig config1;
+	config1.server_name = "localhost";
+	config1.locations.push_back("/www/");
+	config1.ports.push_back("8080");
+	config1.ports.push_back("12345");
+	all_configs.push_back(config1);
+
+	// virtual server 2
+	TempConfig config2;
+	config2.server_name = "test_serv";
+	config2.locations.push_back("/");
+	config2.locations.push_back("/static/");
+	config2.ports.push_back("9999");
+	all_configs.push_back(config2);
+
+	return all_configs;
+}
+
+} // namespace
 
 // todo: set ConfigData -> private variables
 Server::Server(const _config::Config::ConfigData &config) {
 	(void)config;
+
+	// todo: tmp
+	TempAllConfig all_configs = CreateTempConfig();
+	(void)all_configs;
 
 	ServerInfoVec server_infos;
 	Init(server_infos);

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -9,40 +9,12 @@
 #include <unistd.h>     // close
 
 namespace server {
-namespace {
-
-Server::ServerInfoVec ConvertConfigToSockInfoVec(std::vector<Server::TempConfig> server_configs) {
-	Server::ServerInfoVec server_infos;
-
-	typedef std::vector<Server::TempConfig>::const_iterator Itr;
-	for (Itr it = server_configs.begin(); it != server_configs.end(); ++it) {
-		const std::string &server_name = it->first;
-		unsigned int       port;
-		if (!utils::ConvertStrToUint(it->second, port)) {
-			// todo: original exception
-			throw std::logic_error("wrong port number");
-		}
-
-		// todo: validate server_name, port, etc?
-		ServerInfo server_info(server_name, port);
-		server_infos.push_back(server_info);
-	}
-	return server_infos;
-}
-
-} // namespace
 
 // todo: set ConfigData -> private variables
 Server::Server(const _config::Config::ConfigData &config) {
 	(void)config;
 
-	// todo: tmp
-	std::vector<TempConfig> server_configs;
-	server_configs.push_back(std::make_pair("localhost", "8080"));
-	server_configs.push_back(std::make_pair("localhost", "12345"));
-	// server_configs.push_back(std::make_pair("::1", "8080"));
-
-	ServerInfoVec server_infos = ConvertConfigToSockInfoVec(server_configs);
+	ServerInfoVec server_infos;
 	Init(server_infos);
 }
 

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -71,7 +71,6 @@ Server::Server(const _config::Config::ConfigData &config) {
 	// todo: tmp
 	TempAllConfig all_configs = CreateTempConfig();
 	AddVirtualServers(all_configs);
-	Init();
 }
 
 Server::~Server() {}

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -9,7 +9,6 @@
 #include "virtual_server_storage.hpp"
 #include <list>
 #include <string>
-#include <vector>
 
 namespace server {
 
@@ -22,8 +21,7 @@ struct TempConfig {
 
 class Server {
   public:
-	typedef std::list<TempConfig>   TempAllConfig; // todo: tmp
-	typedef std::vector<ServerInfo> ServerInfoVec;
+	typedef std::list<TempConfig> TempAllConfig; // todo: tmp
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();
@@ -35,7 +33,7 @@ class Server {
 	Server &operator=(const Server &other);
 	// functions
 	void        AddVirtualServers(const TempAllConfig &all_configs); // todo: tmp
-	void        Init(const ServerInfoVec &server_infos);
+	void        Init();
 	void        HandleEvent(const event::Event &event);
 	void        HandleNewConnection(int server_fd);
 	void        HandleExistingConnection(const event::Event &event);

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -24,6 +24,7 @@ class Server {
 	typedef std::list<TempConfig> TempAllConfig; // todo: tmp
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
+	void Init();
 	void Run();
 
   private:
@@ -33,7 +34,6 @@ class Server {
 	Server &operator=(const Server &other);
 	// functions
 	void        AddVirtualServers(const TempAllConfig &all_configs); // todo: tmp
-	void        Init();
 	void        HandleEvent(const event::Event &event);
 	void        HandleNewConnection(int server_fd);
 	void        HandleExistingConnection(const event::Event &event);

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -6,6 +6,7 @@
 #include "connection.hpp"
 #include "epoll.hpp"
 #include "sock_context.hpp"
+#include "virtual_server_storage.hpp"
 #include <list>
 #include <string>
 #include <vector>
@@ -31,7 +32,9 @@ class Server {
 	Server();
 	// prohibit copy
 	Server(const Server &other);
-	Server     &operator=(const Server &other);
+	Server &operator=(const Server &other);
+	// functions
+	void        AddVirtualServers(const TempAllConfig &all_configs); // todo: tmp
 	void        Init(const ServerInfoVec &server_infos);
 	void        HandleEvent(const event::Event &event);
 	void        HandleNewConnection(int server_fd);
@@ -41,6 +44,8 @@ class Server {
 	void        SendResponse(int client_fd);
 	// const
 	static const int SYSTEM_ERROR = -1;
+	// virtual servers storage
+	VirtualServerStorage virtual_servers_;
 	// connection
 	Connection connection_;
 	// context

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -6,13 +6,22 @@
 #include "connection.hpp"
 #include "epoll.hpp"
 #include "sock_context.hpp"
+#include <list>
 #include <string>
 #include <vector>
 
 namespace server {
 
+// todo: tmp
+struct TempConfig {
+	std::string            server_name;
+	std::list<std::string> locations;
+	std::list<std::string> ports;
+};
+
 class Server {
   public:
+	typedef std::list<TempConfig>   TempAllConfig; // todo: tmp
 	typedef std::vector<ServerInfo> ServerInfoVec;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -13,8 +13,7 @@ namespace server {
 
 class Server {
   public:
-	typedef std::pair<std::string, std::string> TempConfig; // todo: tmp
-	typedef std::vector<ServerInfo>             ServerInfoVec;
+	typedef std::vector<ServerInfo> ServerInfoVec;
 	explicit Server(const _config::Config::ConfigData &config);
 	~Server();
 	void Run();

--- a/srcs/server_info.cpp
+++ b/srcs/server_info.cpp
@@ -4,8 +4,7 @@ namespace server {
 
 ServerInfo::ServerInfo() : fd_(0), port_(0) {}
 
-ServerInfo::ServerInfo(const std::string &name, unsigned int port)
-	: fd_(0), name_(name), port_(port) {}
+ServerInfo::ServerInfo(unsigned int port) : fd_(0), port_(port) {}
 
 ServerInfo::~ServerInfo() {}
 
@@ -16,7 +15,6 @@ ServerInfo::ServerInfo(const ServerInfo &other) {
 ServerInfo &ServerInfo::operator=(const ServerInfo &other) {
 	if (this != &other) {
 		fd_   = other.fd_;
-		name_ = other.name_;
 		port_ = other.port_;
 	}
 	return *this;
@@ -24,10 +22,6 @@ ServerInfo &ServerInfo::operator=(const ServerInfo &other) {
 
 int ServerInfo::GetFd() const {
 	return fd_;
-}
-
-const std::string &ServerInfo::GetName() const {
-	return name_;
 }
 
 unsigned int ServerInfo::GetPort() const {

--- a/srcs/server_info.hpp
+++ b/srcs/server_info.hpp
@@ -9,20 +9,18 @@ class ServerInfo {
   public:
 	// default constructor: necessary for map's insert/[]
 	ServerInfo();
-	ServerInfo(const std::string &name, unsigned int port);
+	explicit ServerInfo(unsigned int port);
 	~ServerInfo();
 	ServerInfo(const ServerInfo &other);
 	ServerInfo &operator=(const ServerInfo &other);
 	// getter
-	int                GetFd() const;
-	const std::string &GetName() const;
-	unsigned int       GetPort() const;
+	int          GetFd() const;
+	unsigned int GetPort() const;
 	// setter
 	void SetSockFd(int fd);
 
   private:
 	int          fd_;
-	std::string  name_;
 	unsigned int port_;
 };
 

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -32,6 +32,17 @@ std::string ToString(T value) {
 	return oss.str();
 }
 
+template <typename T>
+std::string FormatListToStr(const T &list) {
+	std::ostringstream oss;
+
+	typedef typename T::const_iterator It;
+	for (It it = list.begin(); it != list.end(); ++it) {
+		oss << "[" << *it << "]";
+	}
+	return oss.str();
+}
+
 // string
 bool                     ConvertStrToUint(const std::string &str, unsigned int &num);
 std::string              ConvertUintToStr(unsigned int num);

--- a/srcs/virtual_server/virtual_server.cpp
+++ b/srcs/virtual_server/virtual_server.cpp
@@ -4,8 +4,10 @@ namespace server {
 
 VirtualServer::VirtualServer() {}
 
-VirtualServer::VirtualServer(const std::string &server_name, const LocationList &locations)
-	: server_name_(server_name), locations_(locations) {
+VirtualServer::VirtualServer(
+	const std::string &server_name, const LocationList &locations, const PortList &ports
+)
+	: server_name_(server_name), locations_(locations), ports_(ports) {
 	// todo: error handling?
 }
 
@@ -19,6 +21,7 @@ VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
 		server_name_ = other.server_name_;
 		locations_   = other.locations_;
+		ports_       = other.ports_;
 	}
 	return *this;
 }
@@ -29,6 +32,10 @@ const std::string &VirtualServer::GetServerName() const {
 
 const VirtualServer::LocationList &VirtualServer::GetLocations() const {
 	return locations_;
+}
+
+const VirtualServer::PortList &VirtualServer::GetPorts() const {
+	return ports_;
 }
 
 } // namespace server

--- a/srcs/virtual_server/virtual_server.hpp
+++ b/srcs/virtual_server/virtual_server.hpp
@@ -9,22 +9,27 @@ namespace server {
 // virtual serverとして必要な情報を保持・取得する
 class VirtualServer {
   public:
-	typedef std::list<std::string> LocationList;
+	typedef std::list<std::string>  LocationList;
+	typedef std::list<unsigned int> PortList;
 	// default constructor: necessary for map's insert/[]
 	VirtualServer();
 	// todo: configもらう？
-	VirtualServer(const std::string &server_name, const LocationList &locations);
+	VirtualServer(
+		const std::string &server_name, const LocationList &locations, const PortList &ports
+	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);
 	VirtualServer &operator=(const VirtualServer &other);
 	// getter
 	const std::string  &GetServerName() const;
 	const LocationList &GetLocations() const;
+	const PortList     &GetPorts() const;
 
   private:
 	// todo: add member(& operator=)
 	std::string  server_name_;
 	LocationList locations_; // todo
+	PortList     ports_;
 };
 
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.cpp
+++ b/srcs/virtual_server/virtual_server_storage.cpp
@@ -46,4 +46,10 @@ const VirtualServer &VirtualServerStorage::GetVirtualServer(int server_fd) const
 	}
 }
 
+// todo: tmp. need?
+const VirtualServerStorage::VirtualServerList &
+VirtualServerStorage::GetAllVirtualServerList() const {
+	return virtual_servers_;
+}
+
 } // namespace server

--- a/srcs/virtual_server/virtual_server_storage.hpp
+++ b/srcs/virtual_server/virtual_server_storage.hpp
@@ -21,7 +21,8 @@ class VirtualServerStorage {
 	void AddVirtualServer(const VirtualServer &virtual_server);
 	void AddMapping(int server_fd, const VirtualServer *virtual_server);
 	// getter
-	const VirtualServer &GetVirtualServer(int server_fd) const;
+	const VirtualServer     &GetVirtualServer(int server_fd) const;
+	const VirtualServerList &GetAllVirtualServerList() const;
 
   private:
 	// 全VirtualServerを保持

--- a/test/unit/sock_context/test_sock_context.cpp
+++ b/test/unit/sock_context/test_sock_context.cpp
@@ -76,7 +76,7 @@ Result RunGetClientInfo(
 }
 
 bool IsSameServerInfo(const server::ServerInfo &a, const server::ServerInfo &b) {
-	return a.GetFd() == b.GetFd() && a.GetName() == b.GetName() && a.GetPort() == b.GetPort();
+	return a.GetFd() == b.GetFd() && a.GetPort() == b.GetPort();
 }
 
 // ServerInfo同士のメンバが全て等しいことを期待するテスト
@@ -95,8 +95,6 @@ Result RunGetConnectedServerInfo(
 		std::ostringstream oss;
 		oss << "server_fd  : result   [" << a.GetFd() << "]" << std::endl;
 		oss << "             expected [" << b.GetFd() << "]" << std::endl;
-		oss << "server_name: result   [" << a.GetName() << "]" << std::endl;
-		oss << "             expected [" << b.GetName() << "]" << std::endl;
 		oss << "port       : result   [" << a.GetPort() << "]" << std::endl;
 		oss << "             expected [" << b.GetPort() << "]" << std::endl;
 		result.error_log = oss.str();
@@ -200,9 +198,9 @@ int RunTestSockContext() {
 
 	/* ----------- 準備 ----------- */
 	// SockContextに渡す用のServerInfoを2個作成
-	server::ServerInfo server_info1("localhost", 8080);
+	server::ServerInfo server_info1(8080);
 	server_info1.SetSockFd(4);
-	server::ServerInfo server_info2("abcde", 12345);
+	server::ServerInfo server_info2(12345);
 	server_info2.SetSockFd(5);
 
 	// SockContextに渡す用のClientInfoを2個作成

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -8,6 +8,7 @@
 namespace {
 
 typedef server::VirtualServer::LocationList LocationList;
+typedef server::VirtualServer::PortList     PortList;
 
 struct Result {
 	bool        is_ok;
@@ -50,15 +51,16 @@ int Test(Result result) {
 }
 
 // -----------------------------------------------------------------------------
-// テストfail時のlocationsのdebug出力
+// テストfail時のlist(locations,ports)のdebug出力
 // (todo: test_virtual_server.cppと全く同じ関数なのでどうにかしても良いかも)
-std::string PrintLocations(const LocationList &locations) {
+template <typename T>
+std::string PrintList(const T &list) {
 	std::ostringstream oss;
 
-	typedef LocationList::const_iterator It;
-	for (It it = locations.begin(); it != locations.end(); ++it) {
+	typedef typename T::const_iterator It;
+	for (It it = list.begin(); it != list.end(); ++it) {
 		oss << *it;
-		if (++LocationList::const_iterator(it) != locations.end()) {
+		if (++It(it) != list.end()) {
 			oss << std::endl;
 		}
 	}
@@ -88,9 +90,21 @@ TestIsSameVirtualServer(const server::VirtualServer &vs, const server::VirtualSe
 		result.is_ok = false;
 		oss << "locations" << std::endl;
 		oss << "- result  " << std::endl;
-		oss << "[" << PrintLocations(locations) << "]" << std::endl;
+		oss << "[" << PrintList(locations) << "]" << std::endl;
 		oss << "- expected" << std::endl;
-		oss << "[" << PrintLocations(expected_locations) << "]" << std::endl;
+		oss << "[" << PrintList(expected_locations) << "]" << std::endl;
+	}
+
+	// ports
+	const PortList &ports          = vs.GetPorts();
+	const PortList &expected_ports = expected_vs.GetPorts();
+	if (!IsSame(ports, expected_ports)) {
+		result.is_ok = false;
+		oss << "ports" << std::endl;
+		oss << "- result  " << std::endl;
+		oss << "[" << PrintList(ports) << "]" << std::endl;
+		oss << "- expected" << std::endl;
+		oss << "[" << PrintList(expected_ports) << "]" << std::endl;
 	}
 
 	result.error_log = oss.str();
@@ -120,13 +134,18 @@ int RunTestVirtualServerStorage() {
 	std::string  expected_server_name1 = "localhost";
 	LocationList expected_locations1;
 	expected_locations1.push_back("/www/");
-	server::VirtualServer vs1(expected_server_name1, expected_locations1);
+	PortList expected_ports1;
+	expected_ports1.push_back(8080);
+	expected_ports1.push_back(12345);
+	server::VirtualServer vs1(expected_server_name1, expected_locations1, expected_ports1);
 
 	std::string  expected_server_name2 = "localhost2";
 	LocationList expected_locations2;
 	expected_locations2.push_back("/");
 	expected_locations2.push_back("/static/");
-	server::VirtualServer vs2(expected_server_name2, expected_locations2);
+	PortList expected_ports2;
+	expected_ports2.push_back(9999);
+	server::VirtualServer vs2(expected_server_name2, expected_locations2, expected_ports2);
 
 	/* -------------- VirtualServerStorage -------------- */
 	server::VirtualServerStorage vs_storage;


### PR DESCRIPTION
主に見てほしい変更 : `+143, -59` くらい
unit test 更新 : `+82, -28` くらい

---
## 目的
現在は 1 つの仮想サーバのみ対応しているので、複数仮想サーバに対応する

以下の流れで実装していて、この PR は `3` のみの実装です (イメージは miro の全体図の右上の方にあります)
1. ~~`class VirtualServer` 作成~~
(PR #178 )
2. ~~`1` を全て保持する `class VirtualServerStorage` 作成~~
(PR #211  )
3. `1`, `2` を Server class 内に組み込む <-

## したこと
- `VirtualServer class` : メンバに `PortList` を追加
- `Server class` : 上記 `1`, `2` で作成した `VirtualServer`, `VirtualServerStorage` を `Server class` に組み込み、複数仮想サーバを使って処理できるようにしました

現在は以下のような雰囲気の config がくる想定でコード内にべた書きしています
(複数仮想 server・複数 listen port・1 つの server_name・複数 location のみ)
-> そろそろ Config class と Server class を統合予定 (Issue #213) で、統合後に TempConfig は削除します

```
server {
	listen 8080 12345
	server_name localhost
	location /www/
}
server {
	listen 9999
	server_name test_serv
	location /
	location /static/
}
```
- もし CGI だった場合、`VirtualServer` から情報を取得する例も追加しました (とりあえず情報の取得を羅列しています、きれいにしていくのは今後)

### してないこと
- `Server` の `Init()` も今後きれいになっていく予定です…
- 他にも VirtualServer を使って処理できるところがありそうなので、今後考えていきます

## 実行確認
```sh
make run

make e2e
# or
curl localhost:8080
curl localhost:12345
curl localhost:9999
# or
# browser から

make unit
```

```sh
# こんな感じでdebugを出力しています
[server] ClientInfo - IP: 127.0.0.1 / ServerInfo - name: test_serv, location: [/][/static/], port: 9999, fd(6)
```

<br>
<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
  - サーバーの初期化プロセスを強化するため、新しい初期化メソッドを追加しました。
  - 仮想サーバーの管理が改善され、ポートのリストをサポートするようになりました。
  - サーバーの設定を容易にするための新しい構成管理機能を追加しました。
  - リストをフォーマットする新しいユーティリティ関数を追加しました。

- **バグ修正**
  - サーバーの初期化時に発生する可能性のあるランタイムエラーを防ぐための修正を行いました。

- **テスト**
  - 新しいポート管理機能に対応するため、テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->