### PR TITLE
[add] 225 test configparserのテスト追加

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -7,7 +7,8 @@ TEST_DIRS	:=	convert_str \
 				split_str \
 				virtual_server \
 				virtual_server_storage \
-				config_parse/lexer
+				config_parse/lexer \
+				config_parse/parser
 
 .PHONY	: run
 run:

--- a/test/unit/config_parse/parser/Makefile
+++ b/test/unit/config_parse/parser/Makefile
@@ -28,7 +28,7 @@ OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
 INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
 
 CXX			:=	c++
-CXXFLAGS	:=	-std=c++98 -MMD -MP -pedantic # -Wall -Wextra -Werror
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
 
 DEPS		:=	$(OBJS:.o=.d)
 MKDIR		:=	mkdir -p

--- a/test/unit/config_parse/parser/Makefile
+++ b/test/unit/config_parse/parser/Makefile
@@ -1,0 +1,75 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	parser
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR		:=	../../../../srcs
+WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
+WS_CONFIG_PARSE_DIR	:=	$(WS_SRCS_DIR)/config_parse
+SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
+					$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
+					$(WS_UTILS_DIR)/color.cpp
+
+# 3. Add unit test files
+SRCS	+=	test_config_parser.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_CONFIG_PARSE_DIR) $(WS_UTILS_DIR)
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -MMD -MP -pedantic # -Wall -Wextra -Werror
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+#--------------------------------------------
+
+-include $(DEPS)

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -182,24 +182,24 @@ int main() {
 
 	/* Test1 */
 	ServerList     expected_result_test_1;
-	std::list<int> expected_test_1_ports_1;
-	expected_test_1_ports_1.push_back(8080);
-	LocationList       expected_test_1_locationlist_1;
+	std::list<int> expected_test_1_ports;
+	expected_test_1_ports.push_back(8080);
+	LocationList       expected_test_1_locationlist;
 	context::ServerCon expected_test_1_server_1 = {
-		expected_test_1_ports_1, "localhost", expected_test_1_locationlist_1
+		expected_test_1_ports, "localhost", expected_test_1_locationlist
 	};
 	expected_result_test_1.push_back(expected_test_1_server_1);
 
 	/* Test2 */
 	ServerList     expected_result_test_2;
-	std::list<int> expected_test_2_ports_1;
-	expected_test_2_ports_1.push_back(8080);
-	expected_test_2_ports_1.push_back(80);
-	LocationList         expected_test_2_locationlist_1;
+	std::list<int> expected_test_2_ports;
+	expected_test_2_ports.push_back(8080);
+	expected_test_2_ports.push_back(80);
+	LocationList         expected_test_2_locationlist;
 	context::LocationCon expected_test_2_location_1 = {"/", "/www/", "index.html", ""};
-	expected_test_2_locationlist_1.push_back(expected_test_2_location_1);
+	expected_test_2_locationlist.push_back(expected_test_2_location_1);
 	context::ServerCon expected_test_2_server_1 = {
-		expected_test_2_ports_1, "localhost", expected_test_2_locationlist_1
+		expected_test_2_ports, "localhost", expected_test_2_locationlist
 	};
 	expected_result_test_2.push_back(expected_test_2_server_1);
 

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -183,7 +183,7 @@ int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
 
 } // namespace
 
-int main(int argc, char *argv[]) {
+int main() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* Test1 */
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
 	expected_test_2_ports_1.push_back(8080);
 	expected_test_2_ports_1.push_back(80);
 	LocationList         expected_test_2_locationlist_1;
-	context::LocationCon expected_test_2_location_1 = {"/", "/www/", "index.html"};
+	context::LocationCon expected_test_2_location_1 = {"/", "/www/", "index.html", ""};
 	expected_test_2_locationlist_1.push_back(expected_test_2_location_1);
 	context::ServerCon expected_test_2_server_1 = {
 		expected_test_2_ports_1, "localhost", expected_test_2_locationlist_1

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -119,7 +119,7 @@ std::ostream &operator<<(std::ostream &os, const std::list<int> &ports) {
 std::ostream &operator<<(std::ostream &os, const context::ServerCon &server) {
 	os << "{port: " << server.port << ", "
 	   << "server_name: " << server.server_name << ", "
-	   << "location_context: " << server.location_con << "}"; // {}で括る
+	   << "location_context: " << server.location_con << "}";
 	return os;
 }
 

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -1,0 +1,190 @@
+#include "color.hpp"
+#include "context.hpp"
+#include "lexer.hpp"
+#include "parser.hpp"
+/*  消す  */
+#include "../../../../srcs/config_parse/context.hpp"
+#include "../../../../srcs/config_parse/lexer.hpp"
+#include "../../../../srcs/config_parse/parser.hpp"
+#include "../../../../srcs/utils/color.hpp"
+/*-------*/
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+namespace { /*テスト汎用*/
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+
+struct Result {
+	Result() : is_success(true) {}
+	bool        is_success;
+	std::string error_log;
+};
+
+int GetTestCaseNum() {
+	static unsigned int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+void PrintOk() {
+	std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK] " << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintNg() {
+	std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintError(const std::string &message) {
+	std::cerr << utils::color::RED << message << utils::color::RESET << std::endl;
+}
+
+} // namespace
+
+/*------------------------------------------------------------------*/
+/*------------------------------------------------------------------*/
+
+/* namespace内で定義しないと他のコードで使えない */
+namespace config {
+namespace context {
+
+bool operator==(const LocationCon &lhs, const LocationCon &rhs) {
+	return lhs.location == rhs.location && lhs.root == rhs.root && lhs.index == rhs.index &&
+		   lhs.allowed_method == rhs.allowed_method;
+}
+
+bool operator!=(const LocationCon &lhs, const LocationCon &rhs) {
+	return lhs.location != rhs.location || lhs.root != rhs.root || lhs.index != rhs.index ||
+		   lhs.allowed_method != rhs.allowed_method;
+}
+
+bool operator==(const ServerCon &lhs, const ServerCon &rhs) {
+	return lhs.port == rhs.port && lhs.server_name == rhs.server_name &&
+		   lhs.location_con == rhs.location_con;
+}
+
+bool operator!=(const ServerCon &lhs, const ServerCon &rhs) {
+	return lhs.port != rhs.port || lhs.server_name != rhs.server_name ||
+		   lhs.location_con != rhs.location_con;
+}
+
+} // namespace context
+} // namespace config
+
+using namespace config;
+
+namespace { /*parser固有*/
+
+typedef std::list<node::Node>           NodeList;
+typedef std::list<context::LocationCon> LocationList;
+typedef std::list<context::ServerCon>   ServerList;
+
+// expected
+struct TestCase {
+	TestCase(const std::string &input, const ServerList &expected)
+		: input(input), expected(expected) {}
+	const std::string input;
+	const ServerList  expected;
+};
+
+std::ostream &operator<<(std::ostream &os, const context::LocationCon location) {
+	os << "{location: " << location.location << ", "
+	   << "root: " << location.root << ", "
+	   << "index: " << location.index << ", "
+	   << "allowed_method: " << location.allowed_method << "}";
+	return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const context::ServerCon server) {
+	os << "{port: " << *(server.port.begin()) << ", " // tmp
+	   << "server_name: " << server.server_name << ", "
+	   << "location_context: " << *(server.location_con.begin()) << "}"; // tmp
+	return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const ServerList &servers) {
+	ServerList::const_iterator it = servers.begin();
+	while (it != servers.end()) {
+		os << *it;
+		++it;
+		if (it != servers.end()) {
+			os << ", ";
+		}
+	}
+	return os;
+}
+
+Result Run(const std::string &src, const ServerList &expected) {
+	Result run_result;
+
+	NodeList       nodes;
+	lexer::Lexer   lex(src, nodes);
+	parser::Parser par(nodes);
+	if (par.GetServers() != expected) {
+		std::ostringstream error_log;
+		error_log << "- Expected: [ " << expected << " ]\n";
+		error_log << "- Result  : [ " << par.GetServers() << " ]\n";
+		run_result.is_success = false;
+		run_result.error_log  = error_log.str();
+	}
+	return run_result;
+}
+
+int Test(const Result &result, const std::string &src) {
+	if (result.is_success) {
+		PrintOk();
+		return EXIT_SUCCESS;
+	} else {
+		PrintNg();
+		PrintError("ConfigParser failed:");
+		std::cerr << "src:[\n" << src << "]" << std::endl;
+		std::cerr << "--------------------------------" << std::endl;
+		std::cerr << result.error_log;
+		return EXIT_FAILURE;
+	}
+}
+
+int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
+	int ret_code = 0;
+
+	for (std::size_t i = 0; i < num_test_cases; i++) {
+		const TestCase test_case = test_cases[i];
+		ret_code |= Test(Run(test_case.input, test_case.expected), test_case.input);
+	}
+	return ret_code;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+	int ret_code = EXIT_SUCCESS;
+
+	/* Test1 */
+	ServerList     expected_result_test_1;
+	std::list<int> expected_test_1_ports_1;
+	expected_test_1_ports_1.push_back(8080);
+	LocationList expected_test_1_locationlist_1;
+	// context::LocationCon expected_test_1_location_1 = {"/", "/www/", "index.html", "GET"};
+	// expected_test_1_locationlist_1.push_back(expected_test_1_location_1);
+	context::ServerCon expected_test_1_server_1 = {
+		expected_test_1_ports_1, "localhost", expected_test_1_locationlist_1
+	};
+	expected_result_test_1.push_back(expected_test_1_server_1);
+
+	static const TestCase test_cases[] = {
+		TestCase(
+			"server {\n \
+				server_name localhost;\n \
+				listen 8080;\n \
+				}\n",
+			expected_result_test_1
+		),
+	};
+
+	ret_code |= RunTests(test_cases, ARRAY_SIZE(test_cases));
+
+	return ret_code;
+}

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -90,7 +90,7 @@ struct TestCase {
 	const ServerList  expected;
 };
 
-std::ostream &operator<<(std::ostream &os, const context::LocationCon location) {
+std::ostream &operator<<(std::ostream &os, const context::LocationCon &location) {
 	os << "{location: " << location.location << ", "
 	   << "root: " << location.root << ", "
 	   << "index: " << location.index << ", "
@@ -98,10 +98,34 @@ std::ostream &operator<<(std::ostream &os, const context::LocationCon location) 
 	return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const context::ServerCon server) {
-	os << "{port: " << *(server.port.begin()) << ", " // tmp
+std::ostream &operator<<(std::ostream &os, const LocationList &locations) {
+	LocationList::const_iterator it = locations.begin();
+	while (it != locations.end()) {
+		os << *it;
+		++it;
+		if (it != locations.end()) {
+			os << ", ";
+		}
+	}
+	return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const std::list<int> &ports) {
+	std::list<int>::const_iterator it = ports.begin();
+	while (it != ports.end()) {
+		os << *it;
+		++it;
+		if (it != ports.end()) {
+			os << ", ";
+		}
+	}
+	return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const context::ServerCon &server) {
+	os << "{port: " << server.port << ", "
 	   << "server_name: " << server.server_name << ", "
-	   << "location_context: " << *(server.location_con.begin()) << "}"; // tmp
+	   << "location_context: " << server.location_con << "}"; // {}で括る
 	return os;
 }
 

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -190,13 +190,24 @@ int main(int argc, char *argv[]) {
 	ServerList     expected_result_test_1;
 	std::list<int> expected_test_1_ports_1;
 	expected_test_1_ports_1.push_back(8080);
-	LocationList expected_test_1_locationlist_1;
-	// context::LocationCon expected_test_1_location_1 = {"/", "/www/", "index.html", "GET"};
-	// expected_test_1_locationlist_1.push_back(expected_test_1_location_1);
+	LocationList       expected_test_1_locationlist_1;
 	context::ServerCon expected_test_1_server_1 = {
 		expected_test_1_ports_1, "localhost", expected_test_1_locationlist_1
 	};
 	expected_result_test_1.push_back(expected_test_1_server_1);
+
+	/* Test2 */
+	ServerList     expected_result_test_2;
+	std::list<int> expected_test_2_ports_1;
+	expected_test_2_ports_1.push_back(8080);
+	expected_test_2_ports_1.push_back(80);
+	LocationList         expected_test_2_locationlist_1;
+	context::LocationCon expected_test_2_location_1 = {"/", "/www/", "index.html"};
+	expected_test_2_locationlist_1.push_back(expected_test_2_location_1);
+	context::ServerCon expected_test_2_server_1 = {
+		expected_test_2_ports_1, "localhost", expected_test_2_locationlist_1
+	};
+	expected_result_test_2.push_back(expected_test_2_server_1);
 
 	static const TestCase test_cases[] = {
 		TestCase(
@@ -206,6 +217,17 @@ int main(int argc, char *argv[]) {
 				}\n",
 			expected_result_test_1
 		),
+		TestCase(
+			"server {\n \
+				server_name localhost;\n \
+				listen 8080 80;\n \
+				location / {\n \
+					root /www/;\n \
+					index index.html;\n \
+					} \
+				}\n",
+			expected_result_test_2
+		)
 	};
 
 	ret_code |= RunTests(test_cases, ARRAY_SIZE(test_cases));

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -2,12 +2,6 @@
 #include "context.hpp"
 #include "lexer.hpp"
 #include "parser.hpp"
-/*  消す  */
-#include "../../../../srcs/config_parse/context.hpp"
-#include "../../../../srcs/config_parse/lexer.hpp"
-#include "../../../../srcs/config_parse/parser.hpp"
-#include "../../../../srcs/utils/color.hpp"
-/*-------*/
 #include <cstdlib>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## ConfigParserのテストを作りました

### Usage
webserv/test/unit/config_parse/parserにて

```
make run
```

または

```
make val
```

すると動きます。テストの追加はC++コード中にファイルを手書きすることを想定しています。
自分で用意した想定のServerListとParserを通した状態でのServerListを比較して結果を出力しています。
Lexerのテストと作りはそんなに変わりません。

### Further
- [ ] テストケースの追加
- [ ] テストケース追加用の関数追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 設定解析モジュールのパーサーコンポーネントに対するユニットテストフレームワークを追加しました。
  
- **テスト**
  - 新しいテストファイルが追加され、サーバー設定のパーサー機能を検証するテストケースが実装されました。
  
- **ドキュメント**
  - テストのビルドプロセスを管理する新しいMakefileが作成され、開発ワークフローが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->