### PR TITLE
[http] ParseHttpRequestFormat関数 作成

### DIFF
--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -24,7 +24,7 @@ typedef std::map<std::string, std::string> HeaderFields;
 struct HttpRequest {
 	RequestLine  request_line;
 	HeaderFields header_fields;
-	std::string  message_body;
+	std::string  body_message;
 };
 
 enum StatusCode {

--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -7,20 +7,32 @@ const std::string HTAB                = "\t";
 const std::string OPTIONAL_WHITESPACE = SP + HTAB;
 const std::string CRLF                = "\r\n";
 const std::string HTTP_VERSION        = "HTTP/1.1";
-const std::string CONNECTION          = "Connection";
-const std::string CONTENT_LENGTH      = "Content-Length";
 
-const std::string BASIC_METHODS[]       = {"GET", "DELETE", "POST"};
-const std::size_t BASIC_METHODS_SIZE    = sizeof(BASIC_METHODS) / sizeof(BASIC_METHODS[0]);
+const std::string GET                = "GET";
+const std::string DELETE             = "DELETE";
+const std::string POST               = "POST";
+const std::string BASIC_METHODS[]    = {GET, DELETE, POST};
+const std::size_t BASIC_METHODS_SIZE = sizeof(BASIC_METHODS) / sizeof(BASIC_METHODS[0]);
+
+const std::string HOST                  = "Host";
+const std::string USER_AGENT            = "User-Agent";
+const std::string ACCEPT                = "Accept";
+const std::string ACCEPT_ENCODING       = "Accept-Encoding";
+const std::string CONNECTION            = "Connection";
+const std::string CONTENT_TYPE          = "Content-Type";
+const std::string CONTENT_LENGTH        = "Content-Length";
+const std::string TRANSFER_ENCODING     = "Transfer-Encoding";
+const std::string AUTHORIZATION         = "Authorization";
 const std::string BASIC_HEADER_FIELDS[] = {
-	"Host",
-	"User-Agent",
-	"Accept",
-	"Accept-Encoding",
-	"Content-Type",
-	"Content-Length",
-	"Connection",
-	"Authorization"
+	HOST,
+	USER_AGENT,
+	ACCEPT,
+	ACCEPT_ENCODING,
+	CONNECTION,
+	CONTENT_TYPE,
+	CONTENT_LENGTH,
+	TRANSFER_ENCODING,
+	AUTHORIZATION
 };
 const std::size_t BASIC_HEADER_FIELDS_SIZE =
 	sizeof(BASIC_HEADER_FIELDS) / sizeof(BASIC_HEADER_FIELDS[0]);

--- a/srcs/http/http_message.hpp
+++ b/srcs/http/http_message.hpp
@@ -10,11 +10,22 @@ extern const std::string HTAB;
 extern const std::string OPTIONAL_WHITESPACE;
 extern const std::string CRLF;
 extern const std::string HTTP_VERSION;
-extern const std::string CONNECTION;
-extern const std::string CONTENT_LENGTH;
 
+extern const std::string GET;
+extern const std::string DELETE;
+extern const std::string POST;
 extern const std::string BASIC_METHODS[];
 extern const std::size_t BASIC_METHODS_SIZE;
+
+extern const std::string HOST;
+extern const std::string USER_AGENT;
+extern const std::string ACCEPT;
+extern const std::string ACCEPT_ENCODING;
+extern const std::string CONNECTION;
+extern const std::string CONTENT_TYPE;
+extern const std::string CONTENT_LENGTH;
+extern const std::string TRANSFER_ENCODING;
+extern const std::string AUTHORIZATION;
 extern const std::string BASIC_HEADER_FIELDS[];
 extern const std::size_t BASIC_HEADER_FIELDS_SIZE;
 

--- a/srcs/http/request/http_storage.cpp
+++ b/srcs/http/request/http_storage.cpp
@@ -18,7 +18,7 @@ bool HttpStorage::IsClientSaveData(int client_fd) {
 }
 
 // ClientSaveDataを取得する関数
-const ClientSaveData &HttpStorage::GetClientSaveData(int client_fd) {
+const HttpRequestParsedData &HttpStorage::GetClientSaveData(int client_fd) {
 	if (!IsClientSaveData(client_fd)) {
 		CreateClientSaveData(client_fd);
 	}
@@ -26,11 +26,11 @@ const ClientSaveData &HttpStorage::GetClientSaveData(int client_fd) {
 }
 
 // クライアント情報を更新する関数
-void HttpStorage::UpdateClientSaveData(int client_fd, const ClientSaveData &client_data) {
+void HttpStorage::UpdateClientSaveData(int client_fd, const HttpRequestParsedData &client_data) {
 	if (IsClientSaveData(client_fd)) {
 		save_data_[client_fd] = client_data;
 	} else {
-		throw std::logic_error("ClientSaveData doesn't exists.");
+		throw std::logic_error("HttpRequestParsedData doesn't exists.");
 	}
 }
 

--- a/srcs/http/request/http_storage.cpp
+++ b/srcs/http/request/http_storage.cpp
@@ -9,7 +9,7 @@ HttpStorage::~HttpStorage() {}
 
 // ClientSaveDataを初期化する関数
 void HttpStorage::CreateClientSaveData(int client_fd) {
-	save_data_[client_fd] = ClientSaveData();
+	save_data_[client_fd] = HttpRequestParsedData();
 }
 
 // ClientSaveDataが存在するかを確認する関数

--- a/srcs/http/request/http_storage.hpp
+++ b/srcs/http/request/http_storage.hpp
@@ -6,32 +6,14 @@
 
 namespace http {
 
-// todo: 今後http_parse.hppに移動する
-struct IsHttpRequestFormat {
-	IsHttpRequestFormat()
-		: is_request_line(false), is_header_fields(false), is_body_message(false){};
-	bool is_request_line;
-	bool is_header_fields;
-	bool is_body_message;
-};
-
-struct ClientSaveData {
-	// HTTP各書式のパースしたかどうか
-	IsHttpRequestFormat save_is_request_format;
-	// HttpRequestResult
-	HttpRequestResult save_request_result;
-	// HTTP各書式をパースする前の読み込んだ情報
-	std::string save_current_buf;
-};
-
 class HttpStorage {
   public:
 	HttpStorage();
 	~HttpStorage();
 	// Get
-	const ClientSaveData &GetClientSaveData(int client_fd);
+	const HttpRequestParsedData &GetClientSaveData(int client_fd);
 	// Update
-	void UpdateClientSaveData(int client_fd, const ClientSaveData &client_data);
+	void UpdateClientSaveData(int client_fd, const HttpRequestParsedData &client_data);
 	// Delete
 	void DeleteClientSaveData(int client_fd);
 
@@ -39,7 +21,7 @@ class HttpStorage {
 	HttpStorage(const HttpStorage &other);
 	HttpStorage &operator=(const HttpStorage &other);
 	// client_fd -> 前回保存した情報にアクセスするためのデータ構造
-	typedef std::map<int, ClientSaveData> ClientSaveDataMap;
+	typedef std::map<int, HttpRequestParsedData> ClientSaveDataMap;
 	ClientSaveDataMap                     save_data_;
 	// Create
 	void CreateClientSaveData(int client_fd);

--- a/srcs/http/request/http_storage.hpp
+++ b/srcs/http/request/http_storage.hpp
@@ -22,7 +22,7 @@ class HttpStorage {
 	HttpStorage &operator=(const HttpStorage &other);
 	// client_fd -> 前回保存した情報にアクセスするためのデータ構造
 	typedef std::map<int, HttpRequestParsedData> ClientSaveDataMap;
-	ClientSaveDataMap                     save_data_;
+	ClientSaveDataMap                            save_data_;
 	// Create
 	void CreateClientSaveData(int client_fd);
 	// Check

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -99,7 +99,19 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData *data) {
 	if (!data->is_request_format.is_body_message) {
 		// todo: current_bufをContentLength文まで読み取り、HttpRequestResultを格納する
 		// todo: ContentLengthまで読み込んだらtrueになる
-		data->is_request_format.is_body_message = true;
+		size_t content_length =
+			std::stoi(data->request_result.request.header_fields[CONTENT_LENGTH]);
+		size_t readable_content_length =
+			content_length - data->request_result.request.body_message.size();
+		if (data->current_buf.size() >= readable_content_length) {
+			data->request_result.request.body_message =
+				data->current_buf.substr(0, readable_content_length);
+			data->current_buf.erase(0, readable_content_length);
+			data->is_request_format.is_body_message = true;
+		} else {
+			data->request_result.request.body_message = data->current_buf;
+			data->current_buf.clear();
+		}
 	}
 }
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -43,10 +43,6 @@ std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
 
 } // namespace
 
-// todo: is_request_lineがfalseの場合
-// - current_bufをCRLFまで切り取る。
-// - HttpRequestResultを格納する。
-// - is_request_line = true;
 void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 	if (!data->is_request_format.is_request_line) {
 		size_t pos = data->current_buf.find(CRLF);
@@ -97,8 +93,6 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData *data) {
 		return;
 	}
 	if (!data->is_request_format.is_body_message) {
-		// todo: current_bufをContentLength文まで読み取り、HttpRequestResultを格納する
-		// todo: ContentLengthまで読み込んだらtrueになる
 		size_t content_length =
 			std::stoi(data->request_result.request.header_fields[CONTENT_LENGTH]);
 		size_t readable_content_length =

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -60,6 +60,14 @@ void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 	}
 }
 
+bool IsBodyMessage(const HeaderFields &header_fileds) {
+	if (header_fileds.find(CONTENT_LENGTH) == header_fileds.end() &&
+		header_fileds.find(TRANSFER_ENCODING) == header_fileds.end()) {
+		return false;
+	}
+	return true;
+}
+
 // todo: is_request_lineがtrue, is_header_filedsがfalseの場合
 // - current_bufをCRLFCRLFまで切り取る。
 // - HttpRequestResultを格納する。
@@ -73,11 +81,7 @@ void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
 			data->request_result.request.header_fields =
 				SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
 			data->is_request_format.is_header_fields = true;
-			data->current_buf.erase(0, pos + CRLF.size() + CRLF.size());
-			if (data->request_result.request.header_fields.find("Content-Length") ==
-					data->request_result.request.header_fields.end() &&
-				data->request_result.request.header_fields.find("Transfer-Encoding") ==
-					data->request_result.request.header_fields.end()) {
+			if (!IsBodyMessage(data->request_result.request.header_fields)) {
 				data->is_request_format.is_body_message = true;
 			}
 		}

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -102,12 +102,12 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData &data) {
 		size_t readable_content_length =
 			content_length - data.request_result.request.body_message.size();
 		if (data.current_buf.size() >= readable_content_length) {
-			data.request_result.request.body_message =
+			data.request_result.request.body_message +=
 				data.current_buf.substr(0, readable_content_length);
 			data.current_buf.erase(0, readable_content_length);
 			data.is_request_format.is_body_message = true;
 		} else {
-			data.request_result.request.body_message = data.current_buf;
+			data.request_result.request.body_message += data.current_buf;
 			data.current_buf.clear();
 		}
 	}

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -51,6 +51,20 @@ void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 			data->request_result.request.request_line =
 				SetRequestLine(utils::SplitStr(request_line, SP));
 			data->is_request_format.is_request_line = true;
+			data->current_buf.erase(0, pos + 2);
+		}
+	}
+}
+
+void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
+	if (data->is_request_format.is_request_line && !data->is_request_format.is_header_fields) {
+		size_t pos = data->current_buf.find(CRLF + CRLF);
+		if (pos != std::string::npos) {
+			std::string header_fileds = data->current_buf.substr(0, pos);
+			data->request_result.request.header_fields =
+				SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
+			data->is_request_format.is_header_fields = true;
+			data->current_buf.erase(0, pos + 2);
 		}
 	}
 }
@@ -58,6 +72,7 @@ void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 void HttpParse::TmpRun(HttpRequestParsedData *data) {
 	try {
 		ParseRequestLine(data);
+		ParseHeaderFields(data);
 	} catch (const HttpParseException &e) {
 		data->request_result.status_code = e.GetStatusCode();
 	}

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -42,27 +42,25 @@ std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
 }
 
 } // namespace
-void HttpParse::TmpRun(HttpRequestParsedData *data) {
-	// todo: is_request_lineがfalseの場合
-	try {
-		if (!data->is_request_format.is_request_line) {
-			size_t pos = data->current_buf.find(CRLF);
-			if (pos != std::string::npos) {
-				std::string request_line = data->current_buf.substr(0, pos);
-				data->request_result.request.request_line =
-					SetRequestLine(utils::SplitStr(request_line, SP));
-				data->is_request_format.is_request_line = true;
-			}
+
+void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
+	if (!data->is_request_format.is_request_line) {
+		size_t pos = data->current_buf.find(CRLF);
+		if (pos != std::string::npos) {
+			std::string request_line = data->current_buf.substr(0, pos);
+			data->request_result.request.request_line =
+				SetRequestLine(utils::SplitStr(request_line, SP));
+			data->is_request_format.is_request_line = true;
 		}
+	}
+}
+
+void HttpParse::TmpRun(HttpRequestParsedData *data) {
+	try {
+		ParseRequestLine(data);
 	} catch (const HttpParseException &e) {
 		data->request_result.status_code = e.GetStatusCode();
 	}
-	// if (is_request_line) {
-	// todo:
-	// - current_bufをCRLFまで切り取る。
-	// - HttpRequestResultを格納する。
-	// - is_request_line = true;
-	//}
 
 	// todo: is_request_lineがtrue, is_header_filedsがfalseの場合
 	// if (is_request_line && !is_header_fileds) {

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -55,7 +55,7 @@ void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 			data->request_result.request.request_line =
 				SetRequestLine(utils::SplitStr(request_line, SP));
 			data->is_request_format.is_request_line = true;
-			data->current_buf.erase(0, pos + 2);
+			data->current_buf.erase(0, pos + CRLF.size());
 		}
 	}
 }
@@ -73,7 +73,7 @@ void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
 			data->request_result.request.header_fields =
 				SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
 			data->is_request_format.is_header_fields = true;
-			data->current_buf.erase(0, pos + 4);
+			data->current_buf.erase(0, pos + CRLF.size() + CRLF.size());
 			if (data->request_result.request.header_fields.find("Content-Length") ==
 					data->request_result.request.header_fields.end() &&
 				data->request_result.request.header_fields.find("Transfer-Encoding") ==

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -64,7 +64,13 @@ void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
 			data->request_result.request.header_fields =
 				SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
 			data->is_request_format.is_header_fields = true;
-			data->current_buf.erase(0, pos + 2);
+			data->current_buf.erase(0, pos + 4);
+			if (data->request_result.request.header_fields.find("Content-Length") ==
+					data->request_result.request.header_fields.end() &&
+				data->request_result.request.header_fields.find("Transfer-Encoding") ==
+					data->request_result.request.header_fields.end()) {
+				data->is_request_format.is_body_message = true;
+			}
 		}
 	}
 }

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -43,6 +43,10 @@ std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
 
 } // namespace
 
+// todo: is_request_lineがfalseの場合
+// - current_bufをCRLFまで切り取る。
+// - HttpRequestResultを格納する。
+// - is_request_line = true;
 void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 	if (!data->is_request_format.is_request_line) {
 		size_t pos = data->current_buf.find(CRLF);
@@ -56,6 +60,11 @@ void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 	}
 }
 
+// todo: is_request_lineがtrue, is_header_filedsがfalseの場合
+// - current_bufをCRLFCRLFまで切り取る。
+// - HttpRequestResultを格納する。
+// - is_header_fileds = true;
+// - ContentLengthとTRANSFER_ENCORDINGがない場合 is_body_message = true;
 void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
 	if (data->is_request_format.is_request_line && !data->is_request_format.is_header_fields) {
 		size_t pos = data->current_buf.find(CRLF + CRLF);
@@ -75,30 +84,26 @@ void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
 	}
 }
 
+// todo: is_request_lineとis_header_fieldsがtrue, is_bodyがfalseの場合（今回はContentLengthのみ
+// - current_bufをContentLength文まで読み取り、HttpRequestResultを格納する。
+// - is_body_message = true;
+void HttpParse::ParseBodyMessage(HttpRequestParsedData *data) {
+	if (data->is_request_format.is_request_line && data->is_request_format.is_header_fields &&
+		!data->is_request_format.is_body_message) {
+		// todo: current_bufをContentLength文まで読み取り、HttpRequestResultを格納する
+		// todo: ContentLengthまで読み込んだらtrueになる
+		data->is_request_format.is_body_message = true;
+	}
+}
+
 void HttpParse::TmpRun(HttpRequestParsedData *data) {
 	try {
 		ParseRequestLine(data);
 		ParseHeaderFields(data);
+		ParseBodyMessage(data);
 	} catch (const HttpParseException &e) {
 		data->request_result.status_code = e.GetStatusCode();
 	}
-
-	// todo: is_request_lineがtrue, is_header_filedsがfalseの場合
-	// if (is_request_line && !is_header_fileds) {
-	// todo:
-	// - current_bufをCRLFCRLFまで切り取る。
-	// - HttpRequestResultを格納する。
-	// - is_header_fileds = true;
-	// - ContentLengthとTRANSFER_ENCORDINGがない場合 is_body_message = true;
-	//}
-
-	// todo: is_request_lineとis_header_fieldsがtrue,
-	// is_bodyがfalseの場合（今回はContentLengthのみ） if (is_request_line && is_header_fileds &&
-	// !is_body_message) { todo:
-	// - current_bufをContentLength文まで読み取る。
-	// - HttpRequestResultを格納する。
-	// - is_body_message = true;
-	//}
 }
 
 // todo: tmp request_

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -50,13 +50,14 @@ std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
 void HttpParse::ParseRequestLine(HttpRequestParsedData *data) {
 	if (!data->is_request_format.is_request_line) {
 		size_t pos = data->current_buf.find(CRLF);
-		if (pos != std::string::npos) {
-			std::string request_line = data->current_buf.substr(0, pos);
-			data->request_result.request.request_line =
-				SetRequestLine(utils::SplitStr(request_line, SP));
-			data->is_request_format.is_request_line = true;
-			data->current_buf.erase(0, pos + CRLF.size());
+		if (pos == std::string::npos) {
+			return;
 		}
+		std::string request_line = data->current_buf.substr(0, pos);
+		data->current_buf.erase(0, pos + CRLF.size());
+		data->request_result.request.request_line =
+			SetRequestLine(utils::SplitStr(request_line, SP));
+		data->is_request_format.is_request_line = true;
 	}
 }
 
@@ -68,32 +69,34 @@ bool IsBodyMessage(const HeaderFields &header_fileds) {
 	return true;
 }
 
-// todo: is_request_lineがtrue, is_header_filedsがfalseの場合
-// - current_bufをCRLFCRLFまで切り取る。
-// - HttpRequestResultを格納する。
-// - is_header_fileds = true;
-// - ContentLengthとTRANSFER_ENCORDINGがない場合 is_body_message = true;
 void HttpParse::ParseHeaderFields(HttpRequestParsedData *data) {
-	if (data->is_request_format.is_request_line && !data->is_request_format.is_header_fields) {
+	if (!data->is_request_format.is_request_line) {
+		return;
+	}
+	if (!data->is_request_format.is_header_fields) {
 		size_t pos = data->current_buf.find(CRLF + CRLF);
-		if (pos != std::string::npos) {
-			std::string header_fileds = data->current_buf.substr(0, pos);
-			data->request_result.request.header_fields =
-				SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
-			data->is_request_format.is_header_fields = true;
-			if (!IsBodyMessage(data->request_result.request.header_fields)) {
-				data->is_request_format.is_body_message = true;
-			}
+		if (pos == std::string::npos) {
+			return;
+		}
+		std::string header_fileds = data->current_buf.substr(0, pos);
+		data->current_buf.erase(0, pos + CRLF.size() + CRLF.size());
+		data->request_result.request.header_fields =
+			SetHeaderFields(utils::SplitStr(header_fileds, CRLF));
+		data->is_request_format.is_header_fields = true;
+		if (!IsBodyMessage(data->request_result.request.header_fields)) {
+			data->is_request_format.is_body_message = true;
 		}
 	}
 }
 
-// todo: is_request_lineとis_header_fieldsがtrue, is_bodyがfalseの場合（今回はContentLengthのみ
-// - current_bufをContentLength文まで読み取り、HttpRequestResultを格納する。
-// - is_body_message = true;
 void HttpParse::ParseBodyMessage(HttpRequestParsedData *data) {
-	if (data->is_request_format.is_request_line && data->is_request_format.is_header_fields &&
-		!data->is_request_format.is_body_message) {
+	if (!data->is_request_format.is_request_line) {
+		return;
+	}
+	if (!data->is_request_format.is_header_fields) {
+		return;
+	}
+	if (!data->is_request_format.is_body_message) {
 		// todo: current_bufをContentLength文まで読み取り、HttpRequestResultを格納する
 		// todo: ContentLengthまで読み込んだらtrueになる
 		data->is_request_format.is_body_message = true;

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -42,6 +42,45 @@ std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
 }
 
 } // namespace
+void HttpParse::TmpRun(HttpRequestParsedData *data) {
+	// todo: is_request_lineがfalseの場合
+	try {
+		if (!data->is_request_format.is_request_line) {
+			size_t pos = data->current_buf.find(CRLF);
+			if (pos != std::string::npos) {
+				std::string request_line = data->current_buf.substr(0, pos);
+				data->request_result.request.request_line =
+					SetRequestLine(utils::SplitStr(request_line, SP));
+				data->is_request_format.is_request_line = true;
+			}
+		}
+	} catch (const HttpParseException &e) {
+		data->request_result.status_code = e.GetStatusCode();
+	}
+	// if (is_request_line) {
+	// todo:
+	// - current_bufをCRLFまで切り取る。
+	// - HttpRequestResultを格納する。
+	// - is_request_line = true;
+	//}
+
+	// todo: is_request_lineがtrue, is_header_filedsがfalseの場合
+	// if (is_request_line && !is_header_fileds) {
+	// todo:
+	// - current_bufをCRLFCRLFまで切り取る。
+	// - HttpRequestResultを格納する。
+	// - is_header_fileds = true;
+	// - ContentLengthとTRANSFER_ENCORDINGがない場合 is_body_message = true;
+	//}
+
+	// todo: is_request_lineとis_header_fieldsがtrue,
+	// is_bodyがfalseの場合（今回はContentLengthのみ） if (is_request_line && is_header_fileds &&
+	// !is_body_message) { todo:
+	// - current_bufをContentLength文まで読み取る。
+	// - HttpRequestResultを格納する。
+	// - is_body_message = true;
+	//}
+}
 
 // todo: tmp request_
 HttpRequestResult HttpParse::Run(const std::string &read_buf) {

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -93,8 +93,12 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData *data) {
 		return;
 	}
 	if (!data->is_request_format.is_body_message) {
-		size_t content_length =
-			std::stoi(data->request_result.request.header_fields[CONTENT_LENGTH]);
+		size_t content_length;
+		if (!utils::ConvertStrToSize(
+				data->request_result.request.header_fields[CONTENT_LENGTH], content_length
+			)) {
+			throw HttpParseException("Error: wrong Content-Length number", BAD_REQUEST);
+		}
 		size_t readable_content_length =
 			content_length - data->request_result.request.body_message.size();
 		if (data->current_buf.size() >= readable_content_length) {

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -43,10 +43,14 @@ struct IsHttpRequestFormat {
 	bool is_body_message;
 };
 
-struct HttpRequestParsedResult {
+struct HttpRequestParsedData {
+	// HTTP各書式のパースしたかどうか
+	IsHttpRequestFormat is_request_format;
+	// HttpRequestResult
 	HttpRequestResult request_result;
-	IsHttpRequestFormat is_http_request_format;
-}
+	// HTTP各書式をパースする前の読み込んだ情報
+	std::string current_buf;
+};
 
 class HttpParse {
   public:

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -60,6 +60,8 @@ class HttpParse {
   private:
 	HttpParse();
 	~HttpParse();
+	static void ParseRequestLine(HttpRequestParsedData *data);
+
 	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);
 	static void         CheckValidRequestLine(const std::vector<std::string> &request_line_info);

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -55,14 +55,14 @@ struct HttpRequestParsedData {
 class HttpParse {
   public:
 	static HttpRequestResult Run(const std::string &read_buf);
-	static void              TmpRun(HttpRequestParsedData *data);
+	static void              TmpRun(HttpRequestParsedData &data);
 
   private:
 	HttpParse();
 	~HttpParse();
-	static void ParseRequestLine(HttpRequestParsedData *data);
-	static void ParseHeaderFields(HttpRequestParsedData *data);
-	static void ParseBodyMessage(HttpRequestParsedData *data);
+	static void ParseRequestLine(HttpRequestParsedData &data);
+	static void ParseHeaderFields(HttpRequestParsedData &data);
+	static void ParseBodyMessage(HttpRequestParsedData &data);
 
 	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -62,6 +62,7 @@ class HttpParse {
 	~HttpParse();
 	static void ParseRequestLine(HttpRequestParsedData *data);
 	static void ParseHeaderFields(HttpRequestParsedData *data);
+	static void ParseBodyMessage(HttpRequestParsedData *data);
 
 	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -61,6 +61,7 @@ class HttpParse {
 	HttpParse();
 	~HttpParse();
 	static void ParseRequestLine(HttpRequestParsedData *data);
+	static void ParseHeaderFields(HttpRequestParsedData *data);
 
 	static RequestLine  SetRequestLine(const std::vector<std::string> &request_line);
 	static HeaderFields SetHeaderFields(const std::vector<std::string> &header_fields_info);

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -35,6 +35,19 @@ struct HttpRequestResult {
 	HttpRequestResult() : status_code(OK) {}
 };
 
+struct IsHttpRequestFormat {
+	IsHttpRequestFormat()
+		: is_request_line(false), is_header_fields(false), is_body_message(false){};
+	bool is_request_line;
+	bool is_header_fields;
+	bool is_body_message;
+};
+
+struct HttpRequestParsedResult {
+	HttpRequestResult request_result;
+	IsHttpRequestFormat is_http_request_format;
+}
+
 class HttpParse {
   public:
 	static HttpRequestResult Run(const std::string &buf);

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -54,7 +54,8 @@ struct HttpRequestParsedData {
 
 class HttpParse {
   public:
-	static HttpRequestResult Run(const std::string &buf);
+	static HttpRequestResult Run(const std::string &read_buf);
+	static void              TmpRun(HttpRequestParsedData *data);
 
   private:
 	HttpParse();

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -19,7 +19,7 @@ typedef std::map<std::string, std::string> HeaderFields;
 struct HttpRequest {
 	RequestLine  request_line;
 	HeaderFields header_fields;
-	std::string  message_body;
+	std::string  body_message;
 };
 
 enum StatusCode {

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -41,27 +41,27 @@ bool TmpHttp::GetIsHttpRequestFormatComplete(int client_fd) {
 // For test
 StatusCode TmpHttp::GetStatusCode(int client_fd) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
-	return (save_data.request_result.status_code);
+	return save_data.request_result.status_code;
 }
 
 bool TmpHttp::GetIsRequestLineFormat(int client_fd) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
-	return (save_data.is_request_format.is_request_line);
+	return save_data.is_request_format.is_request_line;
 }
 
 bool TmpHttp::GetIsHeaderFieldsFormat(int client_fd) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
-	return (save_data.is_request_format.is_header_fields);
+	return save_data.is_request_format.is_header_fields;
 }
 
 bool TmpHttp::GetIsBodyMessageFormat(int client_fd) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
-	return (save_data.is_request_format.is_body_message);
+	return save_data.is_request_format.is_body_message;
 }
 
 std::string TmpHttp::GetBodyMessage(int client_fd) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
-	return (save_data.request_result.request.body_message);
+	return save_data.request_result.request.body_message;
 }
 
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -11,8 +11,7 @@ TmpHttp::~TmpHttp() {}
 void TmpHttp::ParseHttpRequestFormat(int client_fd, const std::string &read_buf) {
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
 	save_data.current_buf += read_buf;
-	// todo: HttpRequestParsedResult(HttpRequestResultとIsHttpRequestFormat)を受け取る。
-	HttpParse::TmpRun(&save_data);
+	HttpParse::TmpRun(save_data);
 	storage_.UpdateClientSaveData(client_fd, save_data);
 }
 

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -55,4 +55,9 @@ bool TmpHttp::GetIsHeaderFieldsFormat(int client_fd) {
 	return (save_data.is_request_format.is_header_fields);
 }
 
+bool TmpHttp::GetIsBodyMessageFormat(int client_fd) {
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return (save_data.is_request_format.is_body_message);
+}
+
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -9,7 +9,6 @@ TmpHttp::~TmpHttp() {}
 
 // todo: クライアントのリクエスト情報を読み込む
 void TmpHttp::ParseHttpRequestFormat(int client_fd, const std::string &read_buf) {
-	std::cout << read_buf << std::endl;
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
 	save_data.current_buf += read_buf;
 	// todo: HttpRequestParsedResult(HttpRequestResultとIsHttpRequestFormat)を受け取る。
@@ -38,6 +37,17 @@ bool TmpHttp::GetIsHttpRequestFormatComplete(int client_fd) {
 	return save_data.is_request_format.is_request_line &&
 		   save_data.is_request_format.is_header_fields &&
 		   save_data.is_request_format.is_body_message;
+}
+
+// For test
+StatusCode TmpHttp::GetStatusCode(int client_fd) {
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return (save_data.request_result.status_code);
+}
+
+bool TmpHttp::GetIsRequestLineFormat(int client_fd) {
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return (save_data.is_request_format.is_request_line);
 }
 
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -10,19 +10,19 @@ TmpHttp::~TmpHttp() {}
 // todo: クライアントのリクエスト情報を読み込む
 void TmpHttp::ParseHttpRequestFormat(int client_fd, const std::string &read_buf) {
 	std::cout << read_buf << std::endl;
-	ClientSaveData save_data = storage_.GetClientSaveData(client_fd);
-	save_data.save_current_buf += read_buf;
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	save_data.current_buf += read_buf;
 	// todo: HttpRequestParsedResult(HttpRequestResultとIsHttpRequestFormat)を受け取る。
-	// save_data.result = http::HttpParse::parse_.Run(&save_current_buf);
+	HttpParse::TmpRun(&save_data);
 	storage_.UpdateClientSaveData(client_fd, save_data);
 }
 
 // todo: レスポンスを作成する
 std::string TmpHttp::CreateHttpResponse(int client_fd) {
-	std::string    response  = "OK";
-	ClientSaveData save_data = storage_.GetClientSaveData(client_fd);
+	std::string           response  = "OK";
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
 	// todo: ステータスコードを確認し、OK以外はレスポンスを作成し、savedataを削除してから出力する
-	if (save_data.save_request_result.status_code != OK) {
+	if (save_data.request_result.status_code != OK) {
 		storage_.DeleteClientSaveData(client_fd);
 		return response;
 	}
@@ -34,10 +34,10 @@ std::string TmpHttp::CreateHttpResponse(int client_fd) {
 
 // todo: HTTPRequestの書式が完全かどうか(どのように取得するかは要検討)
 bool TmpHttp::GetIsHttpRequestFormatComplete(int client_fd) {
-	ClientSaveData save_data = storage_.GetClientSaveData(client_fd);
-	return save_data.save_is_request_format.is_request_line &&
-		   save_data.save_is_request_format.is_header_fields &&
-		   save_data.save_is_request_format.is_body_message;
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return save_data.is_request_format.is_request_line &&
+		   save_data.is_request_format.is_header_fields &&
+		   save_data.is_request_format.is_body_message;
 }
 
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -50,4 +50,9 @@ bool TmpHttp::GetIsRequestLineFormat(int client_fd) {
 	return (save_data.is_request_format.is_request_line);
 }
 
+bool TmpHttp::GetIsHeaderFieldsFormat(int client_fd) {
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return (save_data.is_request_format.is_header_fields);
+}
+
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -60,4 +60,9 @@ bool TmpHttp::GetIsBodyMessageFormat(int client_fd) {
 	return (save_data.is_request_format.is_body_message);
 }
 
+std::string TmpHttp::GetBodyMessage(int client_fd) {
+	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
+	return (save_data.request_result.request.body_message);
+}
+
 } // namespace http

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -18,6 +18,7 @@ class TmpHttp {
 	// For test
 	StatusCode GetStatusCode(int client_fd);
 	bool       GetIsRequestLineFormat(int client_fd);
+	bool       GetIsHeaderFieldsFormat(int client_fd);
 
   private:
 	TmpHttp(const TmpHttp &other);

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -19,6 +19,7 @@ class TmpHttp {
 	StatusCode GetStatusCode(int client_fd);
 	bool       GetIsRequestLineFormat(int client_fd);
 	bool       GetIsHeaderFieldsFormat(int client_fd);
+	bool       GetIsBodyMessageFormat(int client_fd);
 
   private:
 	TmpHttp(const TmpHttp &other);

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -16,11 +16,13 @@ class TmpHttp {
 	// todo: 408のtimeoutのレスポンス
 
 	// For test
-	HttpStorage storage_;
+	StatusCode GetStatusCode(int client_fd);
+	bool       GetIsRequestLineFormat(int client_fd);
 
   private:
 	TmpHttp(const TmpHttp &other);
-	TmpHttp &operator=(const TmpHttp &other);
+	TmpHttp    &operator=(const TmpHttp &other);
+	HttpStorage storage_;
 };
 
 } // namespace http

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -21,6 +21,8 @@ class TmpHttp {
 	bool       GetIsHeaderFieldsFormat(int client_fd);
 	bool       GetIsBodyMessageFormat(int client_fd);
 
+	std::string GetBodyMessage(int client_fd);
+
   private:
 	TmpHttp(const TmpHttp &other);
 	TmpHttp    &operator=(const TmpHttp &other);

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -15,10 +15,12 @@ class TmpHttp {
 	bool        GetIsHttpRequestFormatComplete(int client_fd);
 	// todo: 408のtimeoutのレスポンス
 
+	// For test
+	HttpStorage storage_;
+
   private:
 	TmpHttp(const TmpHttp &other);
-	TmpHttp    &operator=(const TmpHttp &other);
-	HttpStorage storage_;
+	TmpHttp &operator=(const TmpHttp &other);
 };
 
 } // namespace http

--- a/srcs/utils/convert_str.cpp
+++ b/srcs/utils/convert_str.cpp
@@ -28,4 +28,20 @@ std::string ConvertUintToStr(unsigned int num) {
 	return oss.str();
 }
 
+bool ConvertStrToSize(const std::string &str, size_t &num) {
+	if (str.empty() || !IsDigit(str[0])) {
+		return false;
+	}
+
+	char            *end;
+	static const int BASE = 10;
+	errno                 = 0;
+	unsigned long tmp_num = std::strtoul(str.c_str(), &end, BASE);
+	if (errno == ERANGE || *end != '\0' || tmp_num > std::numeric_limits<size_t>::max()) {
+		return false;
+	}
+	num = static_cast<size_t>(tmp_num);
+	return true;
+}
+
 } // namespace utils

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -34,6 +34,7 @@ std::string ToString(T value) {
 
 // string
 bool                     ConvertStrToUint(const std::string &str, unsigned int &num);
+bool                     ConvertStrToSize(const std::string &str, size_t &num);
 std::string              ConvertUintToStr(unsigned int num);
 std::vector<std::string> SplitStr(const std::string &src, const std::string &substring);
 

--- a/test/unit/http/Makefile
+++ b/test/unit/http/Makefile
@@ -16,6 +16,8 @@ WS_HTTP_PARSE_DIR	:=	$(WS_HTTP_REQUEST_DIR)/parse
 
 SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/tmp_http.cpp \
 						$(WS_HTTP_REQUEST_DIR)/http_storage.cpp \

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -44,6 +44,20 @@ int main(void) {
 	ret_code |= HandleResult(test3.GetStatusCode(1), http::OK);
 	ret_code |= HandleResult(test3.GetIsRequestLineFormat(1), false);
 
+	// ヘッダフィールドの書式が正しい場合
+	http::TmpHttp test1_header_fileds;
+	test1_header_fileds.ParseHttpRequestFormat(1, "GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+	ret_code |= HandleResult(test1_header_fileds.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test1_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test1_header_fileds.GetIsHeaderFieldsFormat(1), true);
+
+	// ヘッダフィールドの書式が正しくない場合
+	http::TmpHttp test2_header_fileds;
+	test2_header_fileds.ParseHttpRequestFormat(1, "GET / HTTP/1.1\r\nHost \r\n\r\n");
+	ret_code |= HandleResult(test2_header_fileds.GetStatusCode(1), http::BAD_REQUEST);
+	ret_code |= HandleResult(test2_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test2_header_fileds.GetIsHeaderFieldsFormat(1), false);
+
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
 	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -91,8 +91,19 @@ int main(void) {
 	ret_code |= HandleResult(test5_header_fileds.GetIsHeaderFieldsFormat(1), true);
 	ret_code |= HandleResult(test5_header_fileds.GetIsBodyMessageFormat(1), false);
 
-	// const std::string &expected1 = "OK";
-	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
-	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);
+	// ボディメッセージを追加で送信した場合
+	http::TmpHttp test6_header_fileds;
+	test6_header_fileds.ParseHttpRequestFormat(
+		1, "GET / HTTP/1.1\r\nHost: test\r\nContent-Length:  3\r\n\r\na"
+	);
+	ret_code |= HandleResult(test6_header_fileds.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test6_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test6_header_fileds.GetIsHeaderFieldsFormat(1), true);
+	ret_code |= HandleResult(test6_header_fileds.GetIsBodyMessageFormat(1), false);
+	test6_header_fileds.ParseHttpRequestFormat(1, "bc");
+	const std::string &test6_body_message = "abc";
+	ret_code |= HandleResult(test6_header_fileds.GetIsBodyMessageFormat(1), true);
+	std::cout << test6_header_fileds.GetBodyMessage(1) ;ret_code |=
+		HandleResult(test6_header_fileds.GetBodyMessage(1), test6_body_message);
 	return ret_code;
 }

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -82,6 +82,15 @@ int main(void) {
 	ret_code |= HandleResult(test4_header_fileds.GetIsBodyMessageFormat(1), true);
 	ret_code |= HandleResult(test4_header_fileds.GetBodyMessage(1), test4_body_message);
 
+	http::TmpHttp test5_header_fileds;
+	test5_header_fileds.ParseHttpRequestFormat(
+		1, "GET / HTTP/1.1\r\nHost: test\r\nContent-Length: dddd\r\n\r\nabccccccccc"
+	);
+	ret_code |= HandleResult(test5_header_fileds.GetStatusCode(1), http::BAD_REQUEST);
+	ret_code |= HandleResult(test5_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test5_header_fileds.GetIsHeaderFieldsFormat(1), true);
+	ret_code |= HandleResult(test5_header_fileds.GetIsBodyMessageFormat(1), false);
+
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
 	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -26,9 +26,11 @@ int main(void) {
 	int ret_code = 0;
 
 	http::TmpHttp test;
-	test.ParseHttpRequestFormat(1, "PARSE");
-	const std::string &expected1 = "OK";
-	ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
-	ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);
+	test.ParseHttpRequestFormat(1, "GET / \r\n");
+	http::HttpRequestParsedData a = test.storage_.GetClientSaveData(1);
+	ret_code |= HandleResult(a.request_result.status_code, http::BAD_REQUEST);
+	// const std::string &expected1 = "OK";
+	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
+	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);
 	return ret_code;
 }

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -50,13 +50,25 @@ int main(void) {
 	ret_code |= HandleResult(test1_header_fileds.GetStatusCode(1), http::OK);
 	ret_code |= HandleResult(test1_header_fileds.GetIsRequestLineFormat(1), true);
 	ret_code |= HandleResult(test1_header_fileds.GetIsHeaderFieldsFormat(1), true);
+	ret_code |= HandleResult(test1_header_fileds.GetIsBodyMessageFormat(1), true);
 
 	// ヘッダフィールドの書式が正しくない場合
 	http::TmpHttp test2_header_fileds;
-	test2_header_fileds.ParseHttpRequestFormat(1, "GET / HTTP/1.1\r\nHost \r\n\r\n");
+	test2_header_fileds.ParseHttpRequestFormat(1, "GET / HTTP/1.1\r\nHost :\r\n\r\n");
 	ret_code |= HandleResult(test2_header_fileds.GetStatusCode(1), http::BAD_REQUEST);
 	ret_code |= HandleResult(test2_header_fileds.GetIsRequestLineFormat(1), true);
 	ret_code |= HandleResult(test2_header_fileds.GetIsHeaderFieldsFormat(1), false);
+	ret_code |= HandleResult(test2_header_fileds.GetIsBodyMessageFormat(1), false);
+
+	// ヘッダフィールドにContent-Lengthがある場合
+	http::TmpHttp test3_header_fileds;
+	test3_header_fileds.ParseHttpRequestFormat(
+		1, "GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\nab"
+	);
+	ret_code |= HandleResult(test3_header_fileds.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test3_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test3_header_fileds.GetIsHeaderFieldsFormat(1), true);
+	ret_code |= HandleResult(test3_header_fileds.GetIsBodyMessageFormat(1), false);
 
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -25,10 +25,25 @@ int HandleResult(const T &result, const T &expected) {
 int main(void) {
 	int ret_code = 0;
 
-	http::TmpHttp test;
-	test.ParseHttpRequestFormat(1, "GET / \r\n");
-	http::HttpRequestParsedData a = test.storage_.GetClientSaveData(1);
-	ret_code |= HandleResult(a.request_result.status_code, http::BAD_REQUEST);
+	// リクエストラインの書式が正しい場合
+	http::TmpHttp test1;
+	test1.ParseHttpRequestFormat(1, "GET / HTTP/1.1\r\n");
+	ret_code |= HandleResult(test1.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test1.GetIsRequestLineFormat(1), true);
+
+	// リクエストラインの書式が正しいくない場合
+	http::TmpHttp test2;
+	test2.ParseHttpRequestFormat(1, "GET / \r\n");
+	ret_code |= HandleResult(test2.GetStatusCode(1), http::BAD_REQUEST);
+	ret_code |= HandleResult(test2.GetIsRequestLineFormat(1), false);
+
+	// CRLNがない場合
+	http::TmpHttp test3;
+	test3.ParseHttpRequestFormat(1, "GET / ");
+	// 本来のステータスコードはRequest Timeout
+	ret_code |= HandleResult(test3.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test3.GetIsRequestLineFormat(1), false);
+
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
 	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -70,6 +70,18 @@ int main(void) {
 	ret_code |= HandleResult(test3_header_fileds.GetIsHeaderFieldsFormat(1), true);
 	ret_code |= HandleResult(test3_header_fileds.GetIsBodyMessageFormat(1), true);
 
+	// Content-Lengthの数値以上にボディメッセージがある場合
+	http::TmpHttp test4_header_fileds;
+	test4_header_fileds.ParseHttpRequestFormat(
+		1, "GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\nabccccccccc"
+	);
+	const std::string &test4_body_message = "ab";
+	ret_code |= HandleResult(test4_header_fileds.GetStatusCode(1), http::OK);
+	ret_code |= HandleResult(test4_header_fileds.GetIsRequestLineFormat(1), true);
+	ret_code |= HandleResult(test4_header_fileds.GetIsHeaderFieldsFormat(1), true);
+	ret_code |= HandleResult(test4_header_fileds.GetIsBodyMessageFormat(1), true);
+	ret_code |= HandleResult(test4_header_fileds.GetBodyMessage(1), test4_body_message);
+
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);
 	// ret_code |= HandleResult(test.GetIsHttpRequestFormatComplete(1), false);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -68,7 +68,7 @@ int main(void) {
 	ret_code |= HandleResult(test3_header_fileds.GetStatusCode(1), http::OK);
 	ret_code |= HandleResult(test3_header_fileds.GetIsRequestLineFormat(1), true);
 	ret_code |= HandleResult(test3_header_fileds.GetIsHeaderFieldsFormat(1), true);
-	ret_code |= HandleResult(test3_header_fileds.GetIsBodyMessageFormat(1), false);
+	ret_code |= HandleResult(test3_header_fileds.GetIsBodyMessageFormat(1), true);
 
 	// const std::string &expected1 = "OK";
 	// ret_code |= HandleResult(test.CreateHttpResponse(1), expected1);

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -103,7 +103,6 @@ int main(void) {
 	test6_header_fileds.ParseHttpRequestFormat(1, "bc");
 	const std::string &test6_body_message = "abc";
 	ret_code |= HandleResult(test6_header_fileds.GetIsBodyMessageFormat(1), true);
-	std::cout << test6_header_fileds.GetBodyMessage(1) ;ret_code |=
-		HandleResult(test6_header_fileds.GetBodyMessage(1), test6_body_message);
+	ret_code |= HandleResult(test6_header_fileds.GetBodyMessage(1), test6_body_message);
 	return ret_code;
 }

--- a/test/unit/http_parse/Makefile
+++ b/test/unit/http_parse/Makefile
@@ -15,6 +15,8 @@ WS_HTTP_PARSE_DIR	:=	$(WS_HTTP_DIR)/request/parse
 
 SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp
 

--- a/test/unit/http_storage/Makefile
+++ b/test/unit/http_storage/Makefile
@@ -16,6 +16,8 @@ WS_HTTP_PARSE_DIR	:=	$(WS_HTTP_REQUEST_DIR)/parse
 
 SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_REQUEST_DIR)/http_storage.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp

--- a/test/unit/http_storage/test_http_storage.cpp
+++ b/test/unit/http_storage/test_http_storage.cpp
@@ -34,13 +34,13 @@ int main(void) {
 	int               ret_code = 0;
 	http::HttpStorage storage;
 
-	// ClientSaveDataを新規作成 -> OK
-	http::ClientSaveData new_data = storage.GetClientSaveData(1);
-	ret_code |= HandleResult(new_data.save_request_result.status_code, http::OK);
+	// クライアントのHttpRequestParsedDataを新規作成 -> OK
+	http::HttpRequestParsedData new_data = storage.GetClientSaveData(1);
+	ret_code |= HandleResult(new_data.request_result.status_code, http::OK);
 
-	// client_fdを登録したClientSaveData取得 -> OK
-	http::ClientSaveData save_data = storage.GetClientSaveData(1);
-	ret_code |= HandleResult(save_data.save_request_result.status_code, http::OK);
+	// 登録したクライアントのHttpRequestParsedData取得 -> OK
+	http::HttpRequestParsedData save_data = storage.GetClientSaveData(1);
+	ret_code |= HandleResult(save_data.request_result.status_code, http::OK);
 
 	// ClientSaveDataを更新 -> OK
 	try {

--- a/test/unit/http_storage/test_http_storage.cpp
+++ b/test/unit/http_storage/test_http_storage.cpp
@@ -44,10 +44,10 @@ int main(void) {
 
 	// ClientSaveDataを更新 -> OK
 	try {
-		save_data.save_request_result.status_code = http::BAD_REQUEST;
+		save_data.request_result.status_code = http::BAD_REQUEST;
 		storage.UpdateClientSaveData(1, save_data);
-		http::ClientSaveData update_data = storage.GetClientSaveData(1);
-		ret_code |= HandleResult(update_data.save_request_result.status_code, http::BAD_REQUEST);
+		http::HttpRequestParsedData update_data = storage.GetClientSaveData(1);
+		ret_code |= HandleResult(update_data.request_result.status_code, http::BAD_REQUEST);
 	} catch (const std::logic_error &e) {
 		ret_code |= ResultNg();
 		std::cerr << e.what() << std::endl;
@@ -67,7 +67,7 @@ int main(void) {
 		storage.DeleteClientSaveData(1);
 		new_data = storage.GetClientSaveData(1);
 		// 更新したSaveData情報を削除されているかどうかを確認するため、BAD_REQUESTではなくOK
-		ret_code |= HandleResult(new_data.save_request_result.status_code, http::OK);
+		ret_code |= HandleResult(new_data.request_result.status_code, http::OK);
 	} catch (const std::logic_error &e) {
 		ret_code |= ResultNg();
 		std::cerr << e.what() << std::endl;


### PR DESCRIPTION
#216　マージ後

---

### 特に見て欲しいところ
- 各書式の関数のコード: 正直もっと可読性が上がると思っているのですが、どう書けばいいのかわからないのでアドバイスあれば教えていただけると嬉しいです。

### したこと
- ParseHttpRequestFormat: 各HTTPRequestFormatをParseする関数

### してないこと
- テストケースとテスト関数作成 -> #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
  - HTTPメソッドとヘッダーの定義が改善され、可読性と保守性が向上しました。
  - `HttpRequestParsedData`を用いたクライアントデータの管理が追加され、データ処理が効率化されました。
  - HTTPリクエストの構成要素を解析する新しいメソッドが追加され、リクエスト処理が強化されました。
  - HTTPリクエストの形式をチェックする新しいメソッドが追加され、より強力なリクエスト検証が可能になりました。

- **バグ修正**
  - 旧データ構造から新しいデータ構造への置換に伴い、エラーメッセージが更新されました。

- **テスト**
  - HTTPリクエスト解析に対するテストケースが拡充され、さまざまなシナリオを検証できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->