### PR TITLE
[update] Rin/229 update configlexerに対するテストケース追加

### DIFF
--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -417,12 +417,13 @@ int main() {
 				}\n",
 			expected_result_test_6
 		),
+		// TODO: \を追加
 		// TestCase(
-		// 	"server {\n \
-		// 			server_name \"test.serv\";\n \
-		// 			location / {\n \
-		// 				index \"index.html\";\n \
-		// 			}\n \
+		// 	"server {\n
+		// 			server_name \"test.serv\";\n
+		// 			location / {\n
+		// 				index \"index.html\";\n
+		// 			}\n
 		// 		}\n",
 		// 	expected_result_test_7
 		// ),

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -1,3 +1,7 @@
+/*---------------------------------------------------*/
+#include "../../../../srcs/config_parse/lexer.hpp"
+#include "../../../../srcs/utils/color.hpp"
+/*---------------------------------------------------*/
 #include "color.hpp"
 #include "lexer.hpp"
 #include <cstdlib>
@@ -125,13 +129,10 @@ int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
 	return ret_code;
 }
 
-} // namespace
+/* Test1 */
+NodeList MakeExpectedTest1() {
+	NodeList expected_result_test_1;
 
-int main() {
-	int ret_code = EXIT_SUCCESS;
-
-	/* Test1 */
-	NodeList   expected_result_test_1;
 	node::Node expected_test_1_node_1 = {"server", node::CONTEXT};
 	node::Node expected_test_1_node_2 = {"{", node::L_BRACKET};
 	node::Node expected_test_1_node_3 = {"}", node::R_BRACKET};
@@ -139,8 +140,13 @@ int main() {
 	expected_result_test_1.push_back(expected_test_1_node_2);
 	expected_result_test_1.push_back(expected_test_1_node_3);
 
-	/* Test2 */
-	NodeList   expected_result_test_2;
+	return expected_result_test_1;
+}
+
+/* Test2 */
+NodeList MakeExpectedTest2() {
+	NodeList expected_result_test_2;
+
 	node::Node expected_test_2_node_1 = {"server", node::CONTEXT};
 	node::Node expected_test_2_node_2 = {"{", node::L_BRACKET};
 	node::Node expected_test_2_node_3 = {"location", node::CONTEXT};
@@ -154,7 +160,18 @@ int main() {
 	expected_result_test_2.push_back(expected_test_2_node_5);
 	expected_result_test_2.push_back(expected_test_2_node_6);
 
-	static const TestCase test_cases[] = {
+	return expected_result_test_2;
+}
+
+} // namespace
+
+int main() {
+	int ret_code = EXIT_SUCCESS;
+
+	NodeList expected_result_test_1 = MakeExpectedTest1();
+	NodeList expected_result_test_2 = MakeExpectedTest2();
+
+	static TestCase test_cases[] = {
 		TestCase(
 			"server {\n \
 				}\n",

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -323,6 +323,41 @@ NodeList MakeExpectedTest6() {
 	return expected_result;
 }
 
+/* Test7 Quotation*/
+NodeList MakeExpectedTest7() {
+	NodeList expected_result;
+
+	node::Node expected_node_1  = {"server", node::CONTEXT};
+	node::Node expected_node_2  = {"{", node::L_BRACKET};
+	node::Node expected_node_3  = {"server_name", node::DIRECTIVE};
+	node::Node expected_node_4  = {"test.serv", node::WORD};
+	node::Node expected_node_5  = {";", node::DELIM};
+	node::Node expected_node_6  = {"location", node::CONTEXT};
+	node::Node expected_node_7  = {"/", node::WORD};
+	node::Node expected_node_8  = {"{", node::L_BRACKET};
+	node::Node expected_node_9  = {"index", node::DIRECTIVE};
+	node::Node expected_node_10 = {"index.html", node::WORD};
+	node::Node expected_node_11 = {";", node::DELIM};
+	node::Node expected_node_12 = {"}", node::R_BRACKET};
+	node::Node expected_node_13 = {"}", node::R_BRACKET};
+
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
+	expected_result.push_back(expected_node_8);
+	expected_result.push_back(expected_node_9);
+	expected_result.push_back(expected_node_10);
+	expected_result.push_back(expected_node_11);
+	expected_result.push_back(expected_node_12);
+	expected_result.push_back(expected_node_13);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -334,6 +369,7 @@ int main() {
 	NodeList expected_result_test_4 = MakeExpectedTest4();
 	NodeList expected_result_test_5 = MakeExpectedTest5();
 	NodeList expected_result_test_6 = MakeExpectedTest6();
+	NodeList expected_result_test_7 = MakeExpectedTest7();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -384,6 +420,15 @@ int main() {
 					}\n \
 				}\n",
 			expected_result_test_6
+		),
+		TestCase(
+			"server {\n \
+					server_name \"test.serv\";\n \
+					location / {\n \
+						index \"index.html\";\n \
+					}\n \
+				}\n",
+			expected_result_test_7
 		),
 	};
 

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -245,6 +245,84 @@ NodeList MakeExpectedTest4() {
 	return expected_result;
 }
 
+/* Test5 */
+NodeList MakeExpectedTest5() {
+	NodeList expected_result;
+
+	node::Node expected_node_1  = {"server", node::CONTEXT};
+	node::Node expected_node_2  = {"{", node::L_BRACKET};
+	node::Node expected_node_3  = {"listen", node::DIRECTIVE};
+	node::Node expected_node_4  = {"8080", node::WORD};
+	node::Node expected_node_5  = {"8000", node::WORD};
+	node::Node expected_node_6  = {"80", node::WORD};
+	node::Node expected_node_7  = {"server_name", node::WORD};
+	node::Node expected_node_8  = {"localhost", node::WORD};
+	node::Node expected_node_9  = {";", node::DELIM};
+	node::Node expected_node_10 = {"}", node::R_BRACKET};
+
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
+	expected_result.push_back(expected_node_8);
+	expected_result.push_back(expected_node_9);
+	expected_result.push_back(expected_node_10);
+
+	return expected_result;
+}
+
+/* Test6 */
+NodeList MakeExpectedTest6() {
+	NodeList expected_result;
+
+	node::Node expected_node_1  = {"server", node::CONTEXT};
+	node::Node expected_node_2  = {"{", node::L_BRACKET};
+	node::Node expected_node_3  = {"server_name", node::DIRECTIVE};
+	node::Node expected_node_4  = {"test.serv", node::WORD};
+	node::Node expected_node_5  = {";", node::DELIM};
+	node::Node expected_node_6  = {"location", node::CONTEXT};
+	node::Node expected_node_7  = {"/", node::WORD};
+	node::Node expected_node_8  = {"{", node::L_BRACKET};
+	node::Node expected_node_9  = {"index", node::DIRECTIVE};
+	node::Node expected_node_10 = {"index.html", node::WORD};
+	node::Node expected_node_11 = {";", node::DELIM};
+	node::Node expected_node_12 = {"}", node::R_BRACKET};
+	node::Node expected_node_13 = {"location", node::CONTEXT};
+	node::Node expected_node_14 = {"/www/", node::WORD};
+	node::Node expected_node_15 = {"{", node::L_BRACKET};
+	node::Node expected_node_16 = {"index", node::DIRECTIVE};
+	node::Node expected_node_17 = {"index", node::WORD};
+	node::Node expected_node_18 = {";", node::DELIM};
+	node::Node expected_node_19 = {"}", node::R_BRACKET};
+	node::Node expected_node_20 = {"}", node::R_BRACKET};
+
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
+	expected_result.push_back(expected_node_8);
+	expected_result.push_back(expected_node_9);
+	expected_result.push_back(expected_node_10);
+	expected_result.push_back(expected_node_11);
+	expected_result.push_back(expected_node_12);
+	expected_result.push_back(expected_node_13);
+	expected_result.push_back(expected_node_14);
+	expected_result.push_back(expected_node_15);
+	expected_result.push_back(expected_node_16);
+	expected_result.push_back(expected_node_17);
+	expected_result.push_back(expected_node_18);
+	expected_result.push_back(expected_node_19);
+	expected_result.push_back(expected_node_20);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -254,6 +332,8 @@ int main() {
 	NodeList expected_result_test_2 = MakeExpectedTest2();
 	NodeList expected_result_test_3 = MakeExpectedTest3();
 	NodeList expected_result_test_4 = MakeExpectedTest4();
+	NodeList expected_result_test_5 = MakeExpectedTest5();
+	NodeList expected_result_test_6 = MakeExpectedTest6();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -285,7 +365,26 @@ int main() {
 					server_name server_name;\n \
 				}\n",
 			expected_result_test_4
-		)
+		),
+		TestCase(
+			"server {\n \
+					listen 8080 8000 80\n \
+					server_name localhost;\n \
+				}\n",
+			expected_result_test_5
+		),
+		TestCase(
+			"server {\n \
+					server_name test.serv;\n \
+					location / {\n \
+						index index.html;\n \
+					}\n \
+					location /www/ {\n \
+						index index;\n \
+					}\n \
+				}\n",
+			expected_result_test_6
+		),
 	};
 
 	ret_code |= RunTests(test_cases, ARRAY_SIZE(test_cases));

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -129,7 +129,7 @@ int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
 	return ret_code;
 }
 
-/* Test1 */
+/* Test1 One Server*/
 NodeList MakeExpectedTest1() {
 	NodeList expected_result;
 
@@ -144,7 +144,7 @@ NodeList MakeExpectedTest1() {
 	return expected_result;
 }
 
-/* Test2 */
+/* Test2 One Server One Location*/
 NodeList MakeExpectedTest2() {
 	NodeList expected_result;
 
@@ -167,7 +167,7 @@ NodeList MakeExpectedTest2() {
 	return expected_result;
 }
 
-/* Test3 */
+/* Test3 listen, server_name, root, index Directive*/
 NodeList MakeExpectedTest3() {
 	NodeList expected_result;
 
@@ -214,7 +214,7 @@ NodeList MakeExpectedTest3() {
 	return expected_result;
 }
 
-/* Test4 */
+/* Test4 Multiple ports, "server_name" as server_name*/
 NodeList MakeExpectedTest4() {
 	NodeList expected_result;
 
@@ -245,7 +245,7 @@ NodeList MakeExpectedTest4() {
 	return expected_result;
 }
 
-/* Test5 */
+/* Test5 No Delimiter*/
 NodeList MakeExpectedTest5() {
 	NodeList expected_result;
 
@@ -274,7 +274,7 @@ NodeList MakeExpectedTest5() {
 	return expected_result;
 }
 
-/* Test6 */
+/* Test6 Multiple Locations*/
 NodeList MakeExpectedTest6() {
 	NodeList expected_result;
 

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -167,6 +167,84 @@ NodeList MakeExpectedTest2() {
 	return expected_result;
 }
 
+/* Test3 */
+NodeList MakeExpectedTest3() {
+	NodeList expected_result;
+
+	node::Node expected_node_1  = {"server", node::CONTEXT};
+	node::Node expected_node_2  = {"{", node::L_BRACKET};
+	node::Node expected_node_3  = {"listen", node::DIRECTIVE};
+	node::Node expected_node_4  = {"8080", node::WORD};
+	node::Node expected_node_5  = {";", node::DELIM};
+	node::Node expected_node_6  = {"server_name", node::DIRECTIVE};
+	node::Node expected_node_7  = {"localhost", node::WORD};
+	node::Node expected_node_8  = {";", node::DELIM};
+	node::Node expected_node_9  = {"location", node::CONTEXT};
+	node::Node expected_node_10 = {"/", node::WORD};
+	node::Node expected_node_11 = {"{", node::L_BRACKET};
+	node::Node expected_node_12 = {"root", node::DIRECTIVE};
+	node::Node expected_node_13 = {"/data/", node::WORD};
+	node::Node expected_node_14 = {";", node::DELIM};
+	node::Node expected_node_15 = {"index", node::DIRECTIVE};
+	node::Node expected_node_16 = {"index.html", node::WORD};
+	node::Node expected_node_17 = {";", node::DELIM};
+	node::Node expected_node_18 = {"}", node::R_BRACKET};
+	node::Node expected_node_19 = {"}", node::R_BRACKET};
+
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
+	expected_result.push_back(expected_node_8);
+	expected_result.push_back(expected_node_9);
+	expected_result.push_back(expected_node_10);
+	expected_result.push_back(expected_node_11);
+	expected_result.push_back(expected_node_12);
+	expected_result.push_back(expected_node_13);
+	expected_result.push_back(expected_node_14);
+	expected_result.push_back(expected_node_15);
+	expected_result.push_back(expected_node_16);
+	expected_result.push_back(expected_node_17);
+	expected_result.push_back(expected_node_18);
+	expected_result.push_back(expected_node_19);
+
+	return expected_result;
+}
+
+/* Test4 */
+NodeList MakeExpectedTest4() {
+	NodeList expected_result;
+
+	node::Node expected_node_1  = {"server", node::CONTEXT};
+	node::Node expected_node_2  = {"{", node::L_BRACKET};
+	node::Node expected_node_3  = {"listen", node::DIRECTIVE};
+	node::Node expected_node_4  = {"8080", node::WORD};
+	node::Node expected_node_5  = {"8000", node::WORD};
+	node::Node expected_node_6  = {"80", node::WORD};
+	node::Node expected_node_7  = {";", node::DELIM};
+	node::Node expected_node_8  = {"server_name", node::DIRECTIVE};
+	node::Node expected_node_9  = {"server_name", node::WORD};
+	node::Node expected_node_10 = {";", node::DELIM};
+	node::Node expected_node_11 = {"}", node::R_BRACKET};
+
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
+	expected_result.push_back(expected_node_8);
+	expected_result.push_back(expected_node_9);
+	expected_result.push_back(expected_node_10);
+	expected_result.push_back(expected_node_11);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -174,6 +252,8 @@ int main() {
 
 	NodeList expected_result_test_1 = MakeExpectedTest1();
 	NodeList expected_result_test_2 = MakeExpectedTest2();
+	NodeList expected_result_test_3 = MakeExpectedTest3();
+	NodeList expected_result_test_4 = MakeExpectedTest4();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -187,6 +267,24 @@ int main() {
 					}\n \
 				}\n",
 			expected_result_test_2
+		),
+		TestCase(
+			"server {\n \
+					listen 8080;\n \
+					server_name localhost;\n \
+					location / {\n \
+						root /data/;\n \
+						index index.html;\n \
+					}\n \
+				}\n",
+			expected_result_test_3
+		),
+		TestCase(
+			"server {\n \
+					listen 8080 8000 80;\n \
+					server_name server_name;\n \
+				}\n",
+			expected_result_test_4
 		)
 	};
 

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -1,7 +1,3 @@
-/*---------------------------------------------------*/
-#include "../../../../srcs/config_parse/lexer.hpp"
-#include "../../../../srcs/utils/color.hpp"
-/*---------------------------------------------------*/
 #include "color.hpp"
 #include "lexer.hpp"
 #include <cstdlib>
@@ -324,39 +320,39 @@ NodeList MakeExpectedTest6() {
 }
 
 /* Test7 Quotation*/
-NodeList MakeExpectedTest7() {
-	NodeList expected_result;
+// NodeList MakeExpectedTest7() {
+// 	NodeList expected_result;
 
-	node::Node expected_node_1  = {"server", node::CONTEXT};
-	node::Node expected_node_2  = {"{", node::L_BRACKET};
-	node::Node expected_node_3  = {"server_name", node::DIRECTIVE};
-	node::Node expected_node_4  = {"test.serv", node::WORD};
-	node::Node expected_node_5  = {";", node::DELIM};
-	node::Node expected_node_6  = {"location", node::CONTEXT};
-	node::Node expected_node_7  = {"/", node::WORD};
-	node::Node expected_node_8  = {"{", node::L_BRACKET};
-	node::Node expected_node_9  = {"index", node::DIRECTIVE};
-	node::Node expected_node_10 = {"index.html", node::WORD};
-	node::Node expected_node_11 = {";", node::DELIM};
-	node::Node expected_node_12 = {"}", node::R_BRACKET};
-	node::Node expected_node_13 = {"}", node::R_BRACKET};
+// 	node::Node expected_node_1  = {"server", node::CONTEXT};
+// 	node::Node expected_node_2  = {"{", node::L_BRACKET};
+// 	node::Node expected_node_3  = {"server_name", node::DIRECTIVE};
+// 	node::Node expected_node_4  = {"test.serv", node::WORD};
+// 	node::Node expected_node_5  = {";", node::DELIM};
+// 	node::Node expected_node_6  = {"location", node::CONTEXT};
+// 	node::Node expected_node_7  = {"/", node::WORD};
+// 	node::Node expected_node_8  = {"{", node::L_BRACKET};
+// 	node::Node expected_node_9  = {"index", node::DIRECTIVE};
+// 	node::Node expected_node_10 = {"index.html", node::WORD};
+// 	node::Node expected_node_11 = {";", node::DELIM};
+// 	node::Node expected_node_12 = {"}", node::R_BRACKET};
+// 	node::Node expected_node_13 = {"}", node::R_BRACKET};
 
-	expected_result.push_back(expected_node_1);
-	expected_result.push_back(expected_node_2);
-	expected_result.push_back(expected_node_3);
-	expected_result.push_back(expected_node_4);
-	expected_result.push_back(expected_node_5);
-	expected_result.push_back(expected_node_6);
-	expected_result.push_back(expected_node_7);
-	expected_result.push_back(expected_node_8);
-	expected_result.push_back(expected_node_9);
-	expected_result.push_back(expected_node_10);
-	expected_result.push_back(expected_node_11);
-	expected_result.push_back(expected_node_12);
-	expected_result.push_back(expected_node_13);
+// 	expected_result.push_back(expected_node_1);
+// 	expected_result.push_back(expected_node_2);
+// 	expected_result.push_back(expected_node_3);
+// 	expected_result.push_back(expected_node_4);
+// 	expected_result.push_back(expected_node_5);
+// 	expected_result.push_back(expected_node_6);
+// 	expected_result.push_back(expected_node_7);
+// 	expected_result.push_back(expected_node_8);
+// 	expected_result.push_back(expected_node_9);
+// 	expected_result.push_back(expected_node_10);
+// 	expected_result.push_back(expected_node_11);
+// 	expected_result.push_back(expected_node_12);
+// 	expected_result.push_back(expected_node_13);
 
-	return expected_result;
-}
+// 	return expected_result;
+// }
 
 } // namespace
 
@@ -369,7 +365,7 @@ int main() {
 	NodeList expected_result_test_4 = MakeExpectedTest4();
 	NodeList expected_result_test_5 = MakeExpectedTest5();
 	NodeList expected_result_test_6 = MakeExpectedTest6();
-	NodeList expected_result_test_7 = MakeExpectedTest7();
+	// NodeList expected_result_test_7 = MakeExpectedTest7();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -421,15 +417,15 @@ int main() {
 				}\n",
 			expected_result_test_6
 		),
-		TestCase(
-			"server {\n \
-					server_name \"test.serv\";\n \
-					location / {\n \
-						index \"index.html\";\n \
-					}\n \
-				}\n",
-			expected_result_test_7
-		),
+		// TestCase(
+		// 	"server {\n \
+		// 			server_name \"test.serv\";\n \
+		// 			location / {\n \
+		// 				index \"index.html\";\n \
+		// 			}\n \
+		// 		}\n",
+		// 	expected_result_test_7
+		// ),
 	};
 
 	ret_code |= RunTests(test_cases, ARRAY_SIZE(test_cases));

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -136,6 +136,7 @@ NodeList MakeExpectedTest1() {
 	node::Node expected_node_1 = {"server", node::CONTEXT};
 	node::Node expected_node_2 = {"{", node::L_BRACKET};
 	node::Node expected_node_3 = {"}", node::R_BRACKET};
+
 	expected_result.push_back(expected_node_1);
 	expected_result.push_back(expected_node_2);
 	expected_result.push_back(expected_node_3);
@@ -150,15 +151,18 @@ NodeList MakeExpectedTest2() {
 	node::Node expected_node_1 = {"server", node::CONTEXT};
 	node::Node expected_node_2 = {"{", node::L_BRACKET};
 	node::Node expected_node_3 = {"location", node::CONTEXT};
-	node::Node expected_node_4 = {"{", node::L_BRACKET};
-	node::Node expected_node_5 = {"}", node::R_BRACKET};
+	node::Node expected_node_4 = {"/", node::WORD};
+	node::Node expected_node_5 = {"{", node::L_BRACKET};
 	node::Node expected_node_6 = {"}", node::R_BRACKET};
+	node::Node expected_node_7 = {"}", node::R_BRACKET};
+
 	expected_result.push_back(expected_node_1);
 	expected_result.push_back(expected_node_2);
 	expected_result.push_back(expected_node_3);
 	expected_result.push_back(expected_node_4);
 	expected_result.push_back(expected_node_5);
 	expected_result.push_back(expected_node_6);
+	expected_result.push_back(expected_node_7);
 
 	return expected_result;
 }
@@ -179,7 +183,7 @@ int main() {
 		),
 		TestCase(
 			"server {\n \
-					location {\n \
+					location / {\n \
 					}\n \
 				}\n",
 			expected_result_test_2

--- a/test/unit/config_parse/lexer/test_config_lexer.cpp
+++ b/test/unit/config_parse/lexer/test_config_lexer.cpp
@@ -131,36 +131,36 @@ int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
 
 /* Test1 */
 NodeList MakeExpectedTest1() {
-	NodeList expected_result_test_1;
+	NodeList expected_result;
 
-	node::Node expected_test_1_node_1 = {"server", node::CONTEXT};
-	node::Node expected_test_1_node_2 = {"{", node::L_BRACKET};
-	node::Node expected_test_1_node_3 = {"}", node::R_BRACKET};
-	expected_result_test_1.push_back(expected_test_1_node_1);
-	expected_result_test_1.push_back(expected_test_1_node_2);
-	expected_result_test_1.push_back(expected_test_1_node_3);
+	node::Node expected_node_1 = {"server", node::CONTEXT};
+	node::Node expected_node_2 = {"{", node::L_BRACKET};
+	node::Node expected_node_3 = {"}", node::R_BRACKET};
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
 
-	return expected_result_test_1;
+	return expected_result;
 }
 
 /* Test2 */
 NodeList MakeExpectedTest2() {
-	NodeList expected_result_test_2;
+	NodeList expected_result;
 
-	node::Node expected_test_2_node_1 = {"server", node::CONTEXT};
-	node::Node expected_test_2_node_2 = {"{", node::L_BRACKET};
-	node::Node expected_test_2_node_3 = {"location", node::CONTEXT};
-	node::Node expected_test_2_node_4 = {"{", node::L_BRACKET};
-	node::Node expected_test_2_node_5 = {"}", node::R_BRACKET};
-	node::Node expected_test_2_node_6 = {"}", node::R_BRACKET};
-	expected_result_test_2.push_back(expected_test_2_node_1);
-	expected_result_test_2.push_back(expected_test_2_node_2);
-	expected_result_test_2.push_back(expected_test_2_node_3);
-	expected_result_test_2.push_back(expected_test_2_node_4);
-	expected_result_test_2.push_back(expected_test_2_node_5);
-	expected_result_test_2.push_back(expected_test_2_node_6);
+	node::Node expected_node_1 = {"server", node::CONTEXT};
+	node::Node expected_node_2 = {"{", node::L_BRACKET};
+	node::Node expected_node_3 = {"location", node::CONTEXT};
+	node::Node expected_node_4 = {"{", node::L_BRACKET};
+	node::Node expected_node_5 = {"}", node::R_BRACKET};
+	node::Node expected_node_6 = {"}", node::R_BRACKET};
+	expected_result.push_back(expected_node_1);
+	expected_result.push_back(expected_node_2);
+	expected_result.push_back(expected_node_3);
+	expected_result.push_back(expected_node_4);
+	expected_result.push_back(expected_node_5);
+	expected_result.push_back(expected_node_6);
 
-	return expected_result_test_2;
+	return expected_result;
 }
 
 } // namespace


### PR DESCRIPTION
## ConfigLexerに対してテストケースを追加しました

テストケース全7個、追加しました。他にもエッジケースがあったら教えて欲しいです。
Test7はクォーテーションマークに関するもので、現在は失敗します。(Actionsを通すために一旦コメントアウトしました)

### Tests
- Test1 一つのserver
- Test2 一つのserver, 一つのlocation
- Test3 listen, server_name, root, index
- Test4 複数ポート、server_name server_name
- Test5 ";"がない
- Test6 複数のlocation
- Test7 クォーテーションへの対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **テストの改善**
  - 様々なサーバー設定に対するテストケースを大幅に拡充しました。
  - 新しい関数を追加し、期待される結果の生成をより構造化された方法で行うようにしました。
  - テストケースのロジックが明確になり、可読性と保守性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->