### PR TITLE
[add] Rin/241 add configparserのエラーテストの作成

### DIFF
--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -187,8 +187,6 @@ int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
 			PrintNg();
 			PrintError("ConfigParser failed (No Throw):");
 			std::cerr << "src:[\n" << test_case.input << "]" << std::endl;
-			std::cerr << "--------------------------------" << std::endl;
-			std::cerr << result.error_log;
 			ret_code |= EXIT_FAILURE;
 		} catch (const std::exception &e) {
 			PrintOk();

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -2,6 +2,7 @@
 #include "context.hpp"
 #include "lexer.hpp"
 #include "parser.hpp"
+#include "utils.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
@@ -191,6 +192,7 @@ int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
 			ret_code |= EXIT_FAILURE;
 		} catch (const std::exception &e) {
 			PrintOk();
+			utils::Debug(e.what());
 		}
 	}
 	return ret_code;

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -166,7 +166,7 @@ int Test(const Result &result, const std::string &src) {
 }
 
 int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
-	int ret_code = 0;
+	int ret_code = EXIT_SUCCESS;
 
 	for (std::size_t i = 0; i < num_test_cases; i++) {
 		const TestCase test_case = test_cases[i];
@@ -175,21 +175,26 @@ int RunTests(const TestCase test_cases[], std::size_t num_test_cases) {
 	return ret_code;
 }
 
-/* For Error Test */
-// int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
-// 	int ret_code = 0;
+/* For Error Tests */
+int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
+	int ret_code = EXIT_SUCCESS;
 
-// 	for (std::size_t i = 0; i < num_test_cases; i++) {
-// 		const TestCase test_case = test_cases[i];
-// 		try {
-// 			ret_code |= Test(Run(test_case.input, test_case.expected), test_case.input);
-// 			PrintNg();
-// 		} catch (const std::exception &e) {
-// 			PrintOk();
-// 		}
-// 	}
-// 	return ret_code;
-// }
+	for (std::size_t i = 0; i < num_test_cases; i++) {
+		const TestCase test_case = test_cases[i];
+		try {
+			Result result = Run(test_case.input, test_case.expected);
+			PrintNg();
+			PrintError("ConfigParser failed (No Throw):");
+			std::cerr << "src:[\n" << test_case.input << "]" << std::endl;
+			std::cerr << "--------------------------------" << std::endl;
+			std::cerr << result.error_log;
+			ret_code |= EXIT_FAILURE;
+		} catch (const std::exception &e) {
+			PrintOk();
+		}
+	}
+	return ret_code;
+}
 
 // TODO: Lexerとテストケースを揃える
 
@@ -322,26 +327,26 @@ int main() {
 
 	ret_code |= RunTests(test_cases, ARRAY_SIZE(test_cases));
 
-	// ServerList expected_result_error_test;
+	ServerList expected_result_error_test;
 
-	// static TestCase error_test_cases[] = {
-	// 	TestCase(
-	// 		"server {\n
-	// 				listen 8080\n
-	// 				server_name localhost;\n
-	// 			}\n",
-	// 		expected_result_error_test
-	// 	),
-	// 	TestCase(
-	// 		"server {\n
-	// 				listen 8080;\n
-	// 				server_name localhost\n
-	// 			}\n",
-	// 		expected_result_error_test
-	// 	)
-	// };
+	static TestCase error_test_cases[] = {
+		TestCase(
+			"server {\n \
+					listen 8080\n \
+					server_name localhost;\n \
+				}\n",
+			expected_result_error_test
+		),
+		TestCase(
+			"server {\n \
+					listen 8080;\n \
+					server_name localhost\n \
+				}\n",
+			expected_result_error_test
+		)
+	};
 
-	// ret_code |= RunErrorTests(error_test_cases, ARRAY_SIZE(error_test_cases));
+	ret_code |= RunErrorTests(error_test_cases, ARRAY_SIZE(error_test_cases));
 
 	return ret_code;
 }

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -200,7 +200,7 @@ int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
 
 // TODO: Lexerとテストケースを揃える
 
-/* Test1 */
+/* Test1 One Server */
 ServerList MakeExpectedTest1() {
 	ServerList         expected_result;
 	std::list<int>     expected_ports_1;
@@ -211,7 +211,7 @@ ServerList MakeExpectedTest1() {
 	return expected_result;
 }
 
-/* Test2 */
+/* Test2 One Server, One Location */
 ServerList MakeExpectedTest2() {
 	ServerList           expected_result;
 	std::list<int>       expected_ports_1;
@@ -224,7 +224,7 @@ ServerList MakeExpectedTest2() {
 	return expected_result;
 }
 
-/* Test3 */
+/* Test3 Server, Location Directive */
 ServerList MakeExpectedTest3() {
 	ServerList     expected_result;
 	std::list<int> expected_ports_1;
@@ -238,7 +238,7 @@ ServerList MakeExpectedTest3() {
 	return expected_result;
 }
 
-/* Test4 */
+/* Test4 Multiple ports */
 ServerList MakeExpectedTest4() {
 	ServerList     expected_result;
 	std::list<int> expected_ports_1;
@@ -254,7 +254,7 @@ ServerList MakeExpectedTest4() {
 	return expected_result;
 }
 
-/* Test5 */
+/* Test5 Multiple Locations */
 ServerList MakeExpectedTest5() {
 	ServerList           expected_result;
 	std::list<int>       expected_ports_1;

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -269,6 +269,21 @@ ServerList MakeExpectedTest5() {
 	return expected_result;
 }
 
+/* Test6 Tab+Space, Comment */
+ServerList MakeExpectedTest6() {
+	ServerList           expected_result;
+	std::list<int>       expected_ports_1;
+	LocationList         expected_locationlist_1;
+	context::LocationCon expected_location_1_1 = {"/", "", "index.html", ""};
+	expected_locationlist_1.push_back(expected_location_1_1);
+	context::ServerCon expected_server_1 = {
+		expected_ports_1, "comment.serv", expected_locationlist_1
+	};
+	expected_result.push_back(expected_server_1);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -279,6 +294,7 @@ int main() {
 	ServerList expected_result_test_3 = MakeExpectedTest3();
 	ServerList expected_result_test_4 = MakeExpectedTest4();
 	ServerList expected_result_test_5 = MakeExpectedTest5();
+	ServerList expected_result_test_6 = MakeExpectedTest6();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -324,6 +340,19 @@ int main() {
 					}\n \
 				}\n",
 			expected_result_test_5
+		),
+		TestCase(
+			"server {\n \
+					\n \
+				    \n \
+			#ashjkahsk\n\
+					server_name comment.serv;\n \
+					location / {\n \
+						index index.html;\n \
+				    #ashjkahsk\n \
+					}\n \
+				}\n",
+			expected_result_test_6
 		)
 	};
 
@@ -332,12 +361,12 @@ int main() {
 	ServerList expected_result_error_test;
 
 	static TestCase error_test_cases[] = {
-		/* Test6 */ TestCase(
+		/* Test7 */ TestCase(
 			"server {\n \
 				\n",
 			expected_result_error_test
 		),
-		/* Test7 */
+		/* Test8 */
 		TestCase(
 			"server {\n \
 					server {\n \
@@ -345,21 +374,21 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test8 */
+		/* Test9 */
 		TestCase(
 			"server {\n \
 					listen\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test9 */
+		/* Test10 */
 		TestCase(
 			"server {\n \
 					server_name server_name\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test10 */
+		/* Test11 */
 		TestCase(
 			"server {\n \
 					listen 8080\n \
@@ -367,7 +396,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test11 */
+		/* Test12 */
 		TestCase(
 			"server {\n \
 					listen 8080 8000;\n \
@@ -375,13 +404,13 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test12 */
+		/* Test13 */
 		TestCase(
 			"serv {\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test13 */
+		/* Test14 */
 		TestCase(
 			"server {\n \
 					location / /www/ {\n \
@@ -389,7 +418,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test14 */
+		/* Test15 */
 		TestCase(
 			"server {\n \
 					location /www/ {\n \
@@ -397,7 +426,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test15 */
+		/* Test16 */
 		TestCase(
 			"server {\n \
 					listen 8080;\n \
@@ -408,26 +437,26 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test16 */
+		/* Test17 */
 		TestCase(
 			"{\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test17 */
+		/* Test18 */
 		TestCase(
 			"server	{{{\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test18 */
+		/* Test19 */
 		TestCase(
 			"server 	{\n \
 				server_name server; ;;;;\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test19 */
+		/* Test20 */
 		TestCase(
 			"server {\n \
 				unknown test;\n \

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -284,6 +284,25 @@ ServerList MakeExpectedTest6() {
 	return expected_result;
 }
 
+/* Test7 Multiple Servers */
+ServerList MakeExpectedTest7() {
+	ServerList expected_result;
+
+	std::list<int> expected_ports_1;
+	expected_ports_1.push_back(8080);
+	LocationList       expected_locationlist_1;
+	context::ServerCon expected_server_1 = {expected_ports_1, "localhost", expected_locationlist_1};
+	expected_result.push_back(expected_server_1);
+
+	std::list<int> expected_ports_2;
+	expected_ports_2.push_back(12345);
+	LocationList       expected_locationlist_2;
+	context::ServerCon expected_server_2 = {expected_ports_2, "test.www", expected_locationlist_2};
+	expected_result.push_back(expected_server_2);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -295,6 +314,7 @@ int main() {
 	ServerList expected_result_test_4 = MakeExpectedTest4();
 	ServerList expected_result_test_5 = MakeExpectedTest5();
 	ServerList expected_result_test_6 = MakeExpectedTest6();
+	ServerList expected_result_test_7 = MakeExpectedTest7();
 
 	static TestCase test_cases[] = {
 		TestCase(
@@ -353,6 +373,17 @@ int main() {
 					}\n \
 				}\n",
 			expected_result_test_6
+		),
+		TestCase(
+			"server {\n \
+					listen 8080;\n \
+					server_name localhost;\n \
+				}\n \
+			 server {\n \
+					listen 12345;\n \
+					server_name test.www;\n \
+				}\n",
+			expected_result_test_7
 		)
 	};
 
@@ -361,12 +392,12 @@ int main() {
 	ServerList expected_result_error_test;
 
 	static TestCase error_test_cases[] = {
-		/* Test7 */ TestCase(
+		/* Test8 */ TestCase(
 			"server {\n \
 				\n",
 			expected_result_error_test
 		),
-		/* Test8 */
+		/* Test9 */
 		TestCase(
 			"server {\n \
 					server {\n \
@@ -374,21 +405,21 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test9 */
+		/* Test10 */
 		TestCase(
 			"server {\n \
 					listen\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test10 */
+		/* Test11 */
 		TestCase(
 			"server {\n \
 					server_name server_name\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test11 */
+		/* Test12 */
 		// TestCase(
 		// 	"server {\n
 		// 			listen 8080\n
@@ -396,7 +427,7 @@ int main() {
 		// 		}\n",
 		// 	expected_result_error_test
 		// ),
-		/* Test12 */
+		/* Test13 */
 		// TestCase(
 		// 	"server {\n
 		// 			listen 8080 8000;\n
@@ -404,13 +435,13 @@ int main() {
 		// 		}\n",
 		// 	expected_result_error_test
 		// ),
-		/* Test13 */
+		/* Test14 */
 		// TestCase(
 		// 	"serv {\n
 		// 		}\n",
 		// 	expected_result_error_test
 		// ),
-		/* Test14 */
+		/* Test15 */
 		TestCase(
 			"server {\n \
 					location / /www/ {\n \
@@ -418,7 +449,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test15 */
+		/* Test16 */
 		TestCase(
 			"server {\n \
 					location /www/ {\n \
@@ -426,7 +457,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test16 */
+		/* Test17 */
 		TestCase(
 			"server {\n \
 					listen 8080;\n \
@@ -437,26 +468,26 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test17 */
+		/* Test18 */
 		// TestCase(
 		// 	"{\n
 		// 		}\n",
 		// 	expected_result_error_test
 		// ),
-		/* Test18 */
+		/* Test19 */
 		TestCase(
 			"server	{{{\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test19 */
+		/* Test20 */
 		TestCase(
 			"server 	{\n \
 				server_name server; ;;;;\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test20 */
+		/* Test21 */
 		TestCase(
 			"server {\n \
 				unknown test;\n \

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -389,27 +389,27 @@ int main() {
 			expected_result_error_test
 		),
 		/* Test11 */
-		TestCase(
-			"server {\n \
-					listen 8080\n \
-					server_name localhost;\n \
-				}\n",
-			expected_result_error_test
-		),
+		// TestCase(
+		// 	"server {\n
+		// 			listen 8080\n
+		// 			server_name localhost;\n
+		// 		}\n",
+		// 	expected_result_error_test
+		// ),
 		/* Test12 */
-		TestCase(
-			"server {\n \
-					listen 8080 8000;\n \
-					server_name localhost;\n \
-				}\n",
-			expected_result_error_test
-		),
+		// TestCase(
+		// 	"server {\n
+		// 			listen 8080 8000;\n
+		// 			server_name localhost;\n
+		// 		}\n",
+		// 	expected_result_error_test
+		// ),
 		/* Test13 */
-		TestCase(
-			"serv {\n \
-				}\n",
-			expected_result_error_test
-		),
+		// TestCase(
+		// 	"serv {\n
+		// 		}\n",
+		// 	expected_result_error_test
+		// ),
 		/* Test14 */
 		TestCase(
 			"server {\n \
@@ -438,11 +438,11 @@ int main() {
 			expected_result_error_test
 		),
 		/* Test17 */
-		TestCase(
-			"{\n \
-				}\n",
-			expected_result_error_test
-		),
+		// TestCase(
+		// 	"{\n
+		// 		}\n",
+		// 	expected_result_error_test
+		// ),
 		/* Test18 */
 		TestCase(
 			"server	{{{\n \

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -362,39 +362,12 @@ int main() {
 		/* Test10 */
 		TestCase(
 			"server {\n \
-					location / /www/ {\n \
-					}\n \
-				}\n",
-			expected_result_error_test
-		),
-		/* Test11 */
-		TestCase(
-			"server {\n \
-					location /www/ {\n \
-					\n \
-				}\n",
-			expected_result_error_test
-		),
-		/* Test12 */
-		TestCase(
-			"server {\n \
-					listen 8080;\n \
-					server_name localhost;\n \
-					location / {\n \
-						root\n \
-					}\n \
-				}\n",
-			expected_result_error_test
-		),
-		/* Test13 */
-		TestCase(
-			"server {\n \
 					listen 8080\n \
 					server_name localhost;\n \
 				}\n",
 			expected_result_error_test
 		),
-		/* Test14 */
+		/* Test11 */
 		TestCase(
 			"server {\n \
 					listen 8080 8000;\n \
@@ -402,9 +375,36 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test15 */
+		/* Test12 */
 		TestCase(
 			"serv {\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test13 */
+		TestCase(
+			"server {\n \
+					location / /www/ {\n \
+					}\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test14 */
+		TestCase(
+			"server {\n \
+					location /www/ {\n \
+					\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test15 */
+		TestCase(
+			"server {\n \
+					listen 8080;\n \
+					server_name localhost;\n \
+					location / {\n \
+						root\n \
+					}\n \
 				}\n",
 			expected_result_error_test
 		)

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -331,65 +331,65 @@ int main() {
 
 	ServerList expected_result_error_test;
 
-	static TestCase error_test_cases[] = {/* Test6 */
-										  TestCase(
-											  "server {\n \
+	static TestCase error_test_cases[] = {
+		/* Test6 */ TestCase(
+			"server {\n \
 				\n",
-											  expected_result_error_test
-										  ),
-										  /* Test7 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test7 */
+		TestCase(
+			"server {\n \
 					server {\n \
 					}\n \
 				}\n",
-											  expected_result_test_2
-										  ),
-										  /* Test8 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test8 */
+		TestCase(
+			"server {\n \
 					location / /www/ {\n \
 					}\n \
 				}\n",
-											  expected_result_test_2
-										  ),
-										  /* Test9 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test9 */
+		TestCase(
+			"server {\n \
 					listen\n \
 				}\n",
-											  expected_result_error_test
-										  ),
-										  /* Test10 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test10 */
+		TestCase(
+			"server {\n \
 					listen 8080\n \
 					server_name localhost;\n \
 				}\n",
-											  expected_result_error_test
-										  ),
-										  /* Test11 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test11 */
+		TestCase(
+			"server {\n \
 					listen 8080;\n \
 					server_name localhost\n \
 				}\n",
-											  expected_result_error_test
-										  ),
-										  /* Test12 */
-										  TestCase(
-											  "server {\n \
+			expected_result_error_test
+		),
+		/* Test12 */
+		TestCase(
+			"server {\n \
 					listen 8080 8000;\n \
 					server_name localhost;\n \
 				}\n",
-											  expected_result_error_test
-										  ),
-										  /* Test13 */
-										  TestCase(
-											  "serv {\n \
+			expected_result_error_test
+		),
+		/* Test13 */
+		TestCase(
+			"serv {\n \
 				}\n",
-											  expected_result_error_test
-										  )
+			expected_result_error_test
+		)
 	};
 
 	ret_code |= RunErrorTests(error_test_cases, ARRAY_SIZE(error_test_cases));

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -329,21 +329,65 @@ int main() {
 
 	ServerList expected_result_error_test;
 
-	static TestCase error_test_cases[] = {
-		TestCase(
-			"server {\n \
+	static TestCase error_test_cases[] = {/* Test6 */
+										  TestCase(
+											  "server {\n \
+				\n",
+											  expected_result_error_test
+										  ),
+										  /* Test7 */
+										  TestCase(
+											  "server {\n \
+					server {\n \
+					}\n \
+				}\n",
+											  expected_result_test_2
+										  ),
+										  /* Test8 */
+										  TestCase(
+											  "server {\n \
+					location / /www/ {\n \
+					}\n \
+				}\n",
+											  expected_result_test_2
+										  ),
+										  /* Test9 */
+										  TestCase(
+											  "server {\n \
+					listen\n \
+				}\n",
+											  expected_result_error_test
+										  ),
+										  /* Test10 */
+										  TestCase(
+											  "server {\n \
 					listen 8080\n \
 					server_name localhost;\n \
 				}\n",
-			expected_result_error_test
-		),
-		TestCase(
-			"server {\n \
+											  expected_result_error_test
+										  ),
+										  /* Test11 */
+										  TestCase(
+											  "server {\n \
 					listen 8080;\n \
 					server_name localhost\n \
 				}\n",
-			expected_result_error_test
-		)
+											  expected_result_error_test
+										  ),
+										  /* Test12 */
+										  TestCase(
+											  "server {\n \
+					listen 8080 8000;\n \
+					server_name localhost;\n \
+				}\n",
+											  expected_result_error_test
+										  ),
+										  /* Test13 */
+										  TestCase(
+											  "serv {\n \
+				}\n",
+											  expected_result_error_test
+										  )
 	};
 
 	ret_code |= RunErrorTests(error_test_cases, ARRAY_SIZE(error_test_cases));

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -407,6 +407,32 @@ int main() {
 					}\n \
 				}\n",
 			expected_result_error_test
+		),
+		/* Test16 */
+		TestCase(
+			"{\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test17 */
+		TestCase(
+			"server	{{{\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test18 */
+		TestCase(
+			"server 	{\n \
+				server_name server; ;;;;\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test19 */
+		TestCase(
+			"server {\n \
+				unknown test;\n \
+				}\n",
+			expected_result_error_test
 		)
 	};
 

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -348,19 +348,45 @@ int main() {
 		/* Test8 */
 		TestCase(
 			"server {\n \
-					location / /www/ {\n \
-					}\n \
+					listen\n \
 				}\n",
 			expected_result_error_test
 		),
 		/* Test9 */
 		TestCase(
 			"server {\n \
-					listen\n \
+					server_name server_name\n \
 				}\n",
 			expected_result_error_test
 		),
 		/* Test10 */
+		TestCase(
+			"server {\n \
+					location / /www/ {\n \
+					}\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test11 */
+		TestCase(
+			"server {\n \
+					location /www/ {\n \
+					\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test12 */
+		TestCase(
+			"server {\n \
+					listen 8080;\n \
+					server_name localhost;\n \
+					location / {\n \
+						root\n \
+					}\n \
+				}\n",
+			expected_result_error_test
+		),
+		/* Test13 */
 		TestCase(
 			"server {\n \
 					listen 8080\n \
@@ -368,15 +394,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test11 */
-		TestCase(
-			"server {\n \
-					listen 8080;\n \
-					server_name localhost\n \
-				}\n",
-			expected_result_error_test
-		),
-		/* Test12 */
+		/* Test14 */
 		TestCase(
 			"server {\n \
 					listen 8080 8000;\n \
@@ -384,7 +402,7 @@ int main() {
 				}\n",
 			expected_result_error_test
 		),
-		/* Test13 */
+		/* Test15 */
 		TestCase(
 			"serv {\n \
 				}\n",


### PR DESCRIPTION
## ConfigParserのテストのエラーケースを追加しました

ファイルが空のときはConfigで弾こうと思います。(token.size() == 0で弾く？)
#146 が弾けているか + 教えてもらったエラーケースを載せました。

### TODO
- [ ] テストを通せるようにParserの修正 -> #228 
- [ ] listen 8000 8080 のように並べるのはエラーだったので修正する -> #247 
- [ ] Lexerとテストを揃える
- [ ] Nginxの挙動を確認しながらテストケースの追加
- [ ] Lexer, Parser自体の機能追加 -> #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- テストスイートのエラーハンドリングが強化され、失敗が期待されるテストを実行する新しい機能が追加されました。
	- 様々な設定を評価するための新しいテストケースが追加され、パーサーの機能がより包括的にテストされるようになりました。
  
- **ドキュメント**
	- 既存のテストケースのコメントが更新され、各テストの検証内容が明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->