### PR TITLE
[fix] Rin/228 fix configparserのエラー修正

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -13,7 +13,8 @@ server {
 }
 
 server {
-	listen 9999 12345;
+	listen 9999;
+	listen 12345;
 	server_name test_serv;
 	location / {
 		root /data/www/test;

--- a/srcs/config_parse/config.cpp
+++ b/srcs/config_parse/config.cpp
@@ -20,7 +20,7 @@ Config::Config(const std::string &file_path) : config_file_(file_path.c_str()) {
 		parser::Parser        par(tokens);
 		servers_ = par.GetServers();
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << '\n';
+		throw std::runtime_error(e.what());
 	}
 	// try catchをどこでするか
 }

--- a/srcs/config_parse/config.cpp
+++ b/srcs/config_parse/config.cpp
@@ -14,14 +14,12 @@ Config::Config(const std::string &file_path) : config_file_(file_path.c_str()) {
 	}
 	std::stringstream buffer;
 	buffer << config_file_.rdbuf();
-	try {
-		std::list<node::Node> tokens;
-		lexer::Lexer          lex(buffer.str(), tokens);
-		parser::Parser        par(tokens);
-		servers_ = par.GetServers();
-	} catch (const std::exception &e) {
-		throw std::runtime_error(e.what());
-	}
+	std::list<node::Node> tokens;
+	lexer::Lexer          lex(buffer.str(), tokens);
+	parser::Parser        par(tokens);
+	if (tokens.size() == 0)
+		throw std::runtime_error("No file content");
+	servers_ = par.GetServers();
 	// try catchをどこでするか
 }
 

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -47,6 +47,8 @@ Parser::Parser(std::list<node::Node> &tokens) : tokens_(tokens) {
 	for (NodeItr it = tokens_.begin(); it != tokens_.end(); ++it) {
 		if ((*it).token_type == node::CONTEXT && (*it).token == "server") {
 			servers_.push_back(CreateServerContext(++it));
+		} else {
+			throw std::runtime_error("expect server context");
 		}
 	}
 }

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -9,17 +9,17 @@ namespace {
 void HandleServerContextDirective(context::ServerCon &server, NodeItr &it) {
 	if ((*it).token == "server_name") {
 		++it;
-		if ((*it).token_type != node::WORD)
+		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'server_name' directive");
+		}
 		server.server_name = (*it++).token; // TODO: 複数の名前
 	} else if ((*it).token == "listen") {
 		++it;
-		if ((*it).token_type != node::WORD)
+		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'listen' directive");
-		while ((*it).token_type == node::WORD) {
-			server.port.push_back(std::atoi((*it++).token.c_str())
-			); // TODO: atoi, validation, 重複チェック
 		}
+		server.port.push_back(std::atoi((*it++).token.c_str())
+		); // TODO: atoi, validation, 重複チェック
 	}
 	if ((*it).token_type != node::DELIM)
 		throw std::runtime_error("expect ';' after arguments");

--- a/test/unit/config_parse/Makefile
+++ b/test/unit/config_parse/Makefile
@@ -63,7 +63,7 @@ TEST_FILE_DIR = ./test_file
 ERROR_TEST_FILE_DIR = ./test_file_error
 
 .PHONY	: run
-run: all log run_success
+run: all log run_success run_error
 
 # PHONYなし
 log:

--- a/test/unit/config_parse/test_config.cpp
+++ b/test/unit/config_parse/test_config.cpp
@@ -157,6 +157,25 @@ int Test(const Result &result, const std::string &src, int test_num) {
 	}
 }
 
+/* For Error Tests */
+int RunErrorTest(
+	const std::string &file_path, const ServerList &expected, const std::string &src, int test_num
+) {
+	int ret_code = EXIT_SUCCESS;
+
+	try {
+		Result result = Run(file_path, expected);
+		PrintNg(test_num);
+		PrintError("ConfigParser failed (No Throw):");
+		std::cerr << "src:[\n" << src << "]" << std::endl;
+		ret_code |= EXIT_FAILURE;
+	} catch (const std::exception &e) {
+		PrintOk(test_num);
+		utils::Debug(e.what());
+	}
+	return ret_code;
+}
+
 /* Test1 One Server */
 ServerList MakeExpectedTest1() {
 	ServerList         expected_result;
@@ -303,7 +322,7 @@ int main(int argc, char *argv[]) {
 		}
 		ret_code |= Test(Run(argv[2], expected), buffer.str(), test_num);
 	} else if (std::string(argv[1]) == "error") {
-		ret_code |= Test(Run(argv[2], expected), buffer.str(), test_num);
+		ret_code |= RunErrorTest(argv[2], expected, buffer.str(), test_num);
 	}
 
 	return ret_code;


### PR DESCRIPTION
## ConfigParseのエラーを修正しました

- [x] listen 8000 8080
- [x] listen 800 \n server_name servname
- [x] ファイルが空白の時
- [x] serv {} のように最初のディレクティブ名が間違えている時
- [x] {}

のケースを弾きました。

### TODO
- [ ] 機能の追加 #145 #250 
- [ ] 独自の例外

主に

- [ ] ディレクティブ種類の追加
- [ ] クォーテーションへの対応
- [ ] port等の範囲チェック

をやっていこうと思います。
