### PR TITLE
[style] fix typo

### DIFF
--- a/srcs/config_parse/context.hpp
+++ b/srcs/config_parse/context.hpp
@@ -13,7 +13,7 @@ struct LocationCon {
 	std::string                          index;
 	bool                                 autoindex;
 	std::list<std::string>               allowed_methods;
-	std::pair<unsigned int, std::string> redirect; // cannnot use return
+	std::pair<unsigned int, std::string> redirect; // cannot use return
 	LocationCon() : autoindex(false) {}
 };
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -130,7 +130,7 @@ void HttpParse::TmpRun(HttpRequestParsedData &data) {
 // todo: tmp request_
 HttpRequestResult HttpParse::Run(const std::string &read_buf) {
 	HttpRequestResult result;
-	// a: [request_line ＋ header_fields, messagebody]
+	// a: [request_line ＋ header_fields, message-body]
 	// b: [request_line, header_fields]
 	std::vector<std::string> a = utils::SplitStr(read_buf, HEADER_FIELDS_END);
 	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
@@ -200,9 +200,9 @@ void HttpParse::CheckValidMethod(const std::string &method) {
 	}
 }
 
-void HttpParse::CheckValidRequestTarget(const std::string &reqest_target) {
+void HttpParse::CheckValidRequestTarget(const std::string &request_target) {
 	// /が先頭になかったら場合 -> 400
-	if (reqest_target.empty() || reqest_target[0] != '/') {
+	if (request_target.empty() || request_target[0] != '/') {
 		throw HttpParseException(
 			"Error: the request target is missing the '/' character at the beginning", BAD_REQUEST
 		);
@@ -238,6 +238,6 @@ StatusCode HttpParse::HttpParseException::GetStatusCode() const {
 }
 
 // status_line && header
-// messagebody
+// message-body
 
 } // namespace http

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -27,7 +27,7 @@ HttpResponseResult HttpResponse::CreateHttpResponseResult(const HttpRequestResul
 	response.status_line.reason_phrase   = "OK";
 	response.header_fields["Host"]       = "sawa";
 	response.header_fields["Connection"] = "close";
-	response.body_message = "You can't connect the dots looking forword. You can only connect the "
+	response.body_message = "You can't connect the dots looking forward. You can only connect the "
 							"dots looking backwards";
 	return response;
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -168,7 +168,7 @@ std::string Server::CreateHttpResponse(int client_fd) const {
 		const DtoServerInfos &server_infos = context_.GetServerInfo(client_fd);
 
 		utils::Debug("server", "ClientInfo - IP: " + client_ip + ", fd", client_fd);
-		utils::Debug("server", "recieved ServerInfo, fd", server_infos.server_fd);
+		utils::Debug("server", "received ServerInfo, fd", server_infos.server_fd);
 		std::cerr << "server_name: " << server_infos.server_name
 				  << ", port: " << server_infos.server_port << std::endl;
 		std::cerr << "locations: " << std::endl;

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -165,18 +165,18 @@ int main(void) {
 	);
 
 	// 4.ヘッダフィールドの書式が正しい場合
-	http::HttpRequestParsedData test1_header_fileds;
-	test1_header_fileds.request_result.status_code         = http::OK;
-	test1_header_fileds.is_request_format.is_request_line  = true;
-	test1_header_fileds.is_request_format.is_header_fields = true;
-	test1_header_fileds.is_request_format.is_body_message  = true;
+	http::HttpRequestParsedData test1_header_fields;
+	test1_header_fields.request_result.status_code         = http::OK;
+	test1_header_fields.is_request_format.is_request_line  = true;
+	test1_header_fields.is_request_format.is_header_fields = true;
+	test1_header_fields.is_request_format.is_body_message  = true;
 
 	// 5.ヘッダフィールドの書式が正しくない場合
-	http::HttpRequestParsedData test2_header_fileds;
-	test2_header_fileds.request_result.status_code         = http::BAD_REQUEST;
-	test2_header_fileds.is_request_format.is_request_line  = true;
-	test2_header_fileds.is_request_format.is_header_fields = false;
-	test2_header_fileds.is_request_format.is_body_message  = false;
+	http::HttpRequestParsedData test2_header_fields;
+	test2_header_fields.request_result.status_code         = http::BAD_REQUEST;
+	test2_header_fields.is_request_format.is_request_line  = true;
+	test2_header_fields.is_request_format.is_header_fields = false;
+	test2_header_fields.is_request_format.is_body_message  = false;
 
 	// 6.ヘッダフィールドにContent-Lengthがあるがボディメッセージがない場合
 	http::HttpRequestParsedData test3_header_fileds;
@@ -187,8 +187,8 @@ int main(void) {
 	test3_header_fileds.is_request_format.is_body_message  = false;
 
 	static const TestCase test_case_http_request_header_fields_format[] = {
-		TestCase(1, "GET / HTTP/1.1\r\nHost: a\r\n\r\n", test1_header_fileds),
-		TestCase(1, "GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fileds),
+		TestCase(1, "GET / HTTP/1.1\r\nHost: a\r\n\r\n", test1_header_fields),
+		TestCase(1, "GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fields),
 		TestCase(
 			1, "GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\n", test3_header_fileds
 		),
@@ -278,7 +278,7 @@ int main(void) {
 	);
 	const std::string test1_expected_response =
 		"HTTP/1.1 200 OK\r\nConnection: close\r\nHost: sawa\r\n\r\nYou can't connect the dots "
-		"looking forword. You can only connect the dots looking backwards";
+		"looking forward. You can only connect the dots looking backwards";
 	ret_code |= HandleResult(test1_response.CreateHttpResponse(1), test1_expected_response);
 
 	// リクエストのステータスコードが400の場合

--- a/test/unit/http_parse/test_http_parse.cpp
+++ b/test/unit/http_parse/test_http_parse.cpp
@@ -198,20 +198,20 @@ int main(void) {
 	expected_header_fields_test_3.request.header_fields["Connection"] = "keep-alive";
 
 	// 存在しないfield_nameの場合
-	http::HttpRequestResult expected_header_fileds_test_4;
-	expected_header_fileds_test_4.status_code = http::BAD_REQUEST;
+	http::HttpRequestResult expected_header_fields_test_4;
+	expected_header_fields_test_4.status_code = http::BAD_REQUEST;
 
 	// 複数のヘッダーフィールドの書式が設定の場合
-	http::HttpRequestResult expected_header_fileds_test_5;
-	expected_header_fileds_test_5.status_code = http::BAD_REQUEST;
+	http::HttpRequestResult expected_header_fields_test_5;
+	expected_header_fields_test_5.status_code = http::BAD_REQUEST;
 
 	// セミコロンがない場合
 	http::HttpRequestResult expected_header_fileds_test_6;
 	expected_header_fileds_test_6.status_code = http::BAD_REQUEST;
 
 	// セミコロンが複数ある場合
-	http::HttpRequestResult expected_header_fileds_test_7;
-	expected_header_fileds_test_7.status_code = http::BAD_REQUEST;
+	http::HttpRequestResult expected_header_fields_test_7;
+	expected_header_fields_test_7.status_code = http::BAD_REQUEST;
 
 	static const TestCase test_cases_for_header_fields[] = {
 		TestCase(
@@ -228,12 +228,12 @@ int main(void) {
 		),
 		TestCase(
 			"GET / HTTP/1.1\r\nGold: www.example.com\r\nConnection: keep-alive\r\n\r\n",
-			expected_header_fileds_test_4
+			expected_header_fields_test_4
 		),
 		TestCase(
 			"GET / HTTP/1.1\r\nHost: www.example.com\r\nHost: www.example.com\r\nConnection: "
 			"keep-alive\r\n\r\n",
-			expected_header_fileds_test_5
+			expected_header_fields_test_5
 		),
 		TestCase(
 			"GET / HTTP/1.1\r\nHost\r\nConnection: "
@@ -243,7 +243,7 @@ int main(void) {
 		TestCase(
 			"GET / HTTP/1.1\r\nHost:kkk:kk\r\nConnection: "
 			"keep-alive\r\n\r\n",
-			expected_header_fileds_test_7
+			expected_header_fields_test_7
 		)
 	};
 

--- a/test/unit/sock_context/test_sock_context.cpp
+++ b/test/unit/sock_context/test_sock_context.cpp
@@ -165,7 +165,7 @@ void AddClientInfoForTest(
 }
 
 // test用にcontextとexpectedから同じclientを削除する
-void DeleteClinetInfoForTest(
+void DeleteClientInfoForTest(
 	server::SockContext                    &context,
 	server::SockContext::ClientInfoMap     &expected_client_info,
 	server::SockContext::HostServerInfoMap &expected_host_server_info,
@@ -277,7 +277,7 @@ int RunTestSockContext() {
 	// - ServerInfoMap     = {{4, ServerInfo1}, {5, ServerInfo2}}
 	// - ClientInfoMap     = {{7, ClientInfo2}}
 	// - HostServerInfoMap = {{7, ServerInfo2*}}
-	DeleteClinetInfoForTest(context, expected_client_info, expected_host_server_info, client_fd1);
+	DeleteClientInfoForTest(context, expected_client_info, expected_host_server_info, client_fd1);
 	// 削除後にgetterを使用し,期待通りthrowされるか確認 (todo: getterがthrowするなら必要なテスト)
 	ret_code |= TestThrow(&server::SockContext::GetClientInfo, context, client_fd1);
 	ret_code |= TestThrow(&server::SockContext::GetConnectedServerInfo, context, client_fd1);


### PR DESCRIPTION
`srcs/`, `test/` 内の typo 修正、`-` つけた、だけなので Issue なしの PR です

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
  - コメント内のタイポを修正しました（"cannnot" → "cannot"、"reqest_target" → "request_target"、"forword" → "forward"、およびデバッグログの"recieved" → "received"）。

- **ドキュメントの改善**
  - コメントの表現を明確にし、HTTPリクエストに関する用語の一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->