### PR TITLE
[add] 簡易的な汎用 Result 型追加, `TryBind()` で使用

### DIFF
--- a/srcs/result/result.hpp
+++ b/srcs/result/result.hpp
@@ -1,0 +1,46 @@
+#ifndef RESULT_HPP_
+#define RESULT_HPP_
+
+template <typename T>
+class Result {
+  public:
+	Result() : is_success_(true), success_value_(T()) {}
+	~Result() {}
+	explicit Result(const T &success_value) : is_success_(true), success_value_(success_value) {}
+	Result(bool is_success, T success_value)
+		: is_success_(is_success), success_value_(success_value) {}
+	Result(const Result &other) {
+		*this = other;
+	}
+	Result &operator=(const Result &other) {
+		if (this != &other) {
+			is_success_    = other.is_success_;
+			success_value_ = other.success_value_;
+		}
+		return *this;
+	}
+	// getter
+	bool IsOk() const {
+		return is_success_;
+	}
+	const T &GetValue() const {
+		return success_value_;
+	}
+	// setter
+	void Set(bool is_success) {
+		is_success_ = is_success;
+	}
+	void Set(bool is_success, const T &success_value) {
+		is_success_    = is_success;
+		success_value_ = success_value;
+	}
+	void SetValue(const T &success_value) {
+		success_value_ = success_value;
+	}
+
+  private:
+	bool is_success_;
+	T    success_value_;
+};
+
+#endif /* RESULT_HPP_ */

--- a/srcs/result/result.hpp
+++ b/srcs/result/result.hpp
@@ -1,6 +1,13 @@
 #ifndef RESULT_HPP_
 #define RESULT_HPP_
 
+/**
+ * @brief Represents the result of an operation, indicating success or failure.
+ *
+ * This class stores the outcome of an operation, which can either be a success or a failure.
+ * If the operation is successful, the `success_value_` is stored.
+ * Otherwise, only `is_success_` flag is set to `false`.
+ */
 template <typename T>
 class Result {
   public:

--- a/srcs/server/connection.hpp
+++ b/srcs/server/connection.hpp
@@ -13,9 +13,9 @@ class ClientInfo;
 
 class Connection {
   public:
-	typedef struct addrinfo AddrInfo;
-	typedef std::set<int>   FdSet;
-	typedef Result<int>     BindResult;
+	typedef struct addrinfo    AddrInfo;
+	typedef std::set<int>      FdSet;
+	typedef utils::Result<int> BindResult;
 	Connection();
 	~Connection();
 	// function

--- a/srcs/server/connection.hpp
+++ b/srcs/server/connection.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_CONNECTION_HPP_
 #define SERVER_CONNECTION_HPP_
 
+#include "result.hpp"
 #include <netdb.h> // struct addrinfo,gai_strerror
 #include <set>
 #include <string>
@@ -14,6 +15,7 @@ class Connection {
   public:
 	typedef struct addrinfo AddrInfo;
 	typedef std::set<int>   FdSet;
+	typedef Result<int>     BindResult;
 	Connection();
 	~Connection();
 	// function
@@ -26,8 +28,8 @@ class Connection {
 	Connection(const Connection &other);
 	Connection &operator=(const Connection &other);
 	// functions
-	AddrInfo *GetAddrInfoList(const ServerInfo &server_info);
-	int       TryBind(AddrInfo *addrinfo) const;
+	AddrInfo  *GetAddrInfoList(const ServerInfo &server_info);
+	BindResult TryBind(AddrInfo *addrinfo) const;
 	// const
 	static const int SYSTEM_ERROR = -1;
 	// variable

--- a/srcs/utils/result.hpp
+++ b/srcs/utils/result.hpp
@@ -1,6 +1,8 @@
 #ifndef RESULT_HPP_
 #define RESULT_HPP_
 
+namespace utils {
+
 /**
  * @brief Represents the result of an operation, indicating success or failure.
  *
@@ -49,5 +51,7 @@ class Result {
 	bool is_success_;
 	T    success_value_;
 };
+
+} // namespace utils
 
 #endif /* RESULT_HPP_ */


### PR DESCRIPTION
## したこと
- 一旦作らないと言いつつ簡易的に汎用 Result 型を作成
  - 成功時に value がセットされ、失敗時は `IsOk()` が false で value は特になし、という使い方を想定
- Result 型を使用することで [Connection class のこの TryBind() 関数内の cppcheck の warning？](https://github.com/s1-haya/webserv/issues/188#issue-2418291495) に対応
-> 返り値の int が server_fd とエラー (-1) を兼ねていたが、Result を使うことで成功した場合に server_fd を取り出し、失敗していた場合はエラー処理、というように分けられるようになった
- Result 型はあんまりちゃんと作ってないので今後問題が発生するかも…

## 実行
挙動に変更はないです
```sh
make run
make test
```

<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- `TryBind`メソッドの戻り値をより明確な`BindResult`構造体に変更し、バインド操作の成功状態と関連ファイルディスクリプタを提供。
	- 新しい`Result`クラスを導入し、操作の結果を成功または失敗として表現できるように改善。

- **バグ修正**
	- `Connect`メソッド内の`TryBind`の結果処理を改善し、エラーハンドリングを強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->