### PR TITLE
[update] configparserのリファクタリング

### DIFF
--- a/srcs/config_parse/config.hpp
+++ b/srcs/config_parse/config.hpp
@@ -10,6 +10,21 @@
 
 namespace config {
 
+/**
+ * @brief Singleton Class
+ *
+ * - Initialization:
+ * @li `config::ConfigInstance->Create("config_file_path");`
+ *
+ * - Access the Instance:
+ * @li `const config::Config *configInstance = config::ConfigInstance;`
+ *
+ * - Get Servers:
+ * @li `std::list<context::ServerCon> servers = config::ConfigInstance->servers_;`
+ *
+ * - Destroy the Instance:
+ * @li `config::ConfigInstance->Destroy();`
+ */
 class Config {
   private:
 	Config();

--- a/srcs/config_parse/config.hpp
+++ b/srcs/config_parse/config.hpp
@@ -13,7 +13,7 @@ namespace config {
 class Config {
   private:
 	Config();
-	Config(const std::string &file_path);
+	explicit Config(const std::string &);
 	Config(const Config &);
 	Config              &operator=(const Config &);
 	static const Config *s_cInstance;
@@ -23,7 +23,7 @@ class Config {
 	~Config();
 
 	static const Config          *GetInstance();
-	static void                   Create(const std::string &file_path);
+	static void                   Create(const std::string &);
 	static void                   Destroy();
 	std::list<context::ServerCon> servers_;
 };

--- a/srcs/config_parse/directive_names.cpp
+++ b/srcs/config_parse/directive_names.cpp
@@ -5,14 +5,19 @@ namespace config {
 const std::string SERVER   = "server";
 const std::string LOCATION = "location";
 
-const std::string SERVER_NAME          = "server_name";
+const std::string HOST                 = "host";
 const std::string LISTEN               = "listen";
-const std::string ALIAS                = "alias";
-const std::string INDEX                = "index";
-const std::string AUTO_INDEX           = "autoindex";
+const std::string SERVER_NAME          = "server_name";
 const std::string ERROR_PAGE           = "error_page";
 const std::string CLIENT_MAX_BODY_SIZE = "client_max_body_size";
-const std::string ALLOWED_METHODS      = "allowed_methods";
-const std::string RETURN               = "return";
+
+const std::string ALLOWED_METHODS = "allowed_methods";
+const std::string RETURN          = "return";
+const std::string ALIAS           = "alias";
+const std::string AUTO_INDEX      = "autoindex";
+const std::string INDEX           = "index";
+
+const std::string CGI_EXTENSION = "cgi_extension";
+const std::string UPLOAD_DIR    = "upload_dir";
 
 } // namespace config

--- a/srcs/config_parse/directive_names.cpp
+++ b/srcs/config_parse/directive_names.cpp
@@ -1,0 +1,18 @@
+#include "directive_names.hpp"
+
+namespace config {
+
+const std::string SERVER   = "server";
+const std::string LOCATION = "location";
+
+const std::string SERVER_NAME          = "server_name";
+const std::string LISTEN               = "listen";
+const std::string ALIAS                = "alias";
+const std::string INDEX                = "index";
+const std::string AUTO_INDEX           = "autoindex";
+const std::string ERROR_PAGE           = "error_page";
+const std::string CLIENT_MAX_BODY_SIZE = "client_max_body_size";
+const std::string ALLOWED_METHODS      = "allowed_methods";
+const std::string RETURN               = "return";
+
+} // namespace config

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -14,19 +14,38 @@ extern const std::string SERVER;
 extern const std::string LOCATION;
 
 /**
- * @brief Directive in Context
+ * @brief Directive in Server Context
+ * @details Dir_name args;
+ *
+ * @note Host dir Not implemented yet
+ */
+
+extern const std::string HOST;
+extern const std::string LISTEN;
+extern const std::string SERVER_NAME;
+extern const std::string ERROR_PAGE;
+extern const std::string CLIENT_MAX_BODY_SIZE;
+
+/**
+ * @brief Directive in Location Context
  * @details Dir_name args;
  */
 
-extern const std::string SERVER_NAME;
-extern const std::string LISTEN;
-extern const std::string ALIAS;
-extern const std::string INDEX;
-extern const std::string AUTO_INDEX;
-extern const std::string ERROR_PAGE;
-extern const std::string CLIENT_MAX_BODY_SIZE;
 extern const std::string ALLOWED_METHODS;
 extern const std::string RETURN;
+extern const std::string ALIAS;
+extern const std::string AUTO_INDEX;
+extern const std::string INDEX;
+
+/**
+ * @brief Directive in Location Context for CGI
+ * @details Dir_name args;
+ *
+ * @note Not Implemented yet
+ */
+
+extern const std::string CGI_EXTENSION;
+extern const std::string UPLOAD_DIR;
 
 } // namespace config
 

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -1,0 +1,23 @@
+#ifndef DIRECTIVE_NAMES_HPP_
+#define DIRECTIVE_NAMES_HPP_
+
+#include <string>
+
+namespace config {
+
+extern const std::string SERVER;
+extern const std::string LOCATION;
+
+extern const std::string SERVER_NAME;
+extern const std::string LISTEN;
+extern const std::string ALIAS;
+extern const std::string INDEX;
+extern const std::string AUTO_INDEX;
+extern const std::string ERROR_PAGE;
+extern const std::string CLIENT_MAX_BODY_SIZE;
+extern const std::string ALLOWED_METHODS;
+extern const std::string RETURN;
+
+} // namespace config
+
+#endif

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -5,8 +5,18 @@
 
 namespace config {
 
+/**
+ * @brief Block Directive (Context Directive)
+ * @details Dir_name {}
+ */
+
 extern const std::string SERVER;
 extern const std::string LOCATION;
+
+/**
+ * @brief Directive in Context
+ * @details Dir_name args;
+ */
 
 extern const std::string SERVER_NAME;
 extern const std::string LISTEN;

--- a/srcs/config_parse/lexer.cpp
+++ b/srcs/config_parse/lexer.cpp
@@ -28,15 +28,19 @@ void Lexer::InitDefinition() {
 	context_.push_back(SERVER);
 	context_.push_back(LOCATION);
 
-	directive_.push_back(SERVER_NAME);
+	// host 未実装
 	directive_.push_back(LISTEN);
-	directive_.push_back(ALIAS);
-	directive_.push_back(INDEX);
-	directive_.push_back(AUTO_INDEX);
+	directive_.push_back(SERVER_NAME);
 	directive_.push_back(ERROR_PAGE);
 	directive_.push_back(CLIENT_MAX_BODY_SIZE);
+
 	directive_.push_back(ALLOWED_METHODS);
 	directive_.push_back(RETURN);
+	directive_.push_back(ALIAS);
+	directive_.push_back(AUTO_INDEX);
+	directive_.push_back(INDEX);
+
+	// CGI未実装
 }
 
 void Lexer::LexBuffer() {

--- a/srcs/config_parse/lexer.cpp
+++ b/srcs/config_parse/lexer.cpp
@@ -1,4 +1,5 @@
 #include "lexer.hpp"
+#include "directive_names.hpp"
 #include <algorithm>
 #include <iostream>
 
@@ -24,19 +25,18 @@ Lexer::Lexer(const std::string &buffer, std::list<node::Node> &tokens)
 Lexer::~Lexer() {}
 
 void Lexer::InitDefinition() {
-	context_.push_back("server");
-	context_.push_back("location");
+	context_.push_back(SERVER);
+	context_.push_back(LOCATION);
 
-	directive_.push_back("server_name");
-	directive_.push_back("listen");
-	directive_.push_back("rewrite");
-	directive_.push_back("alias");
-	directive_.push_back("index");
-	directive_.push_back("autoindex");
-	directive_.push_back("error_page");
-	directive_.push_back("client_max_body_size");
-	directive_.push_back("allowed_methods");
-	directive_.push_back("return");
+	directive_.push_back(SERVER_NAME);
+	directive_.push_back(LISTEN);
+	directive_.push_back(ALIAS);
+	directive_.push_back(INDEX);
+	directive_.push_back(AUTO_INDEX);
+	directive_.push_back(ERROR_PAGE);
+	directive_.push_back(CLIENT_MAX_BODY_SIZE);
+	directive_.push_back(ALLOWED_METHODS);
+	directive_.push_back(RETURN);
 }
 
 void Lexer::LexBuffer() {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -6,44 +6,138 @@
 namespace config {
 namespace parser {
 
+Parser::Parser(std::list<node::Node> &tokens) : tokens_(tokens) {
+	ParseNode();
+}
+
+Parser::~Parser() {}
+
+void Parser::ParseNode() {
+	for (NodeItr it = tokens_.begin(); it != tokens_.end(); ++it) {
+		if ((*it).token_type == node::CONTEXT && (*it).token == SERVER) {
+			servers_.push_back(CreateServerContext(++it));
+		} else {
+			throw std::runtime_error("expect server context");
+		}
+	}
+}
+
+context::ServerCon Parser::CreateServerContext(NodeItr &it) {
+	context::ServerCon server;
+
+	if ((*it).token_type != node::L_BRACKET) {
+		throw std::runtime_error("expect { after server");
+	}
+	++it; // skip L_BRACKET
+	while (it != tokens_.end() && (*it).token_type != node::R_BRACKET) {
+		switch ((*it).token_type) {
+		case node::DIRECTIVE:
+			HandleServerContextDirective(server, it);
+			break;
+		case node::CONTEXT:
+			if ((*it).token == LOCATION) {
+				server.location_con.push_back(CreateLocationContext(++it));
+			} else {
+				throw std::runtime_error("invalid nest of 'server' directive");
+			}
+			break;
+		case node::DELIM:
+			throw std::runtime_error("unexpected ';'");
+			break;
+		default:
+			throw std::runtime_error("unknown token");
+			break;
+		}
+		++it;
+	}
+	if (it == tokens_.end()) {
+		throw std::runtime_error("expect }");
+	}
+	return server;
+}
+
 void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &it) {
 	if ((*it).token == SERVER_NAME) {
-		++it;
-		while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
-			server.server_names.push_back((*it++).token);
-			if (it == tokens_.end()) {
-				throw std::runtime_error("invalid arguments of 'server_name' directive");
-			}
-		}
+		HandleServerName(server.server_names, ++it);
 	} else if ((*it).token == LISTEN) {
-		++it;
-		if ((*it).token_type != node::WORD) {
-			throw std::runtime_error("invalid number of arguments in 'listen' directive");
-		}
-		server.port.push_back(std::atoi((*it++).token.c_str())
-		); // TODO: atoi, validation, 重複チェック
+		HandleListen(server.port, ++it);
 	} else if ((*it).token == CLIENT_MAX_BODY_SIZE) {
-		++it;
-		if ((*it).token_type != node::WORD) {
-			throw std::runtime_error(
-				"invalid number of arguments in 'client_max_body_size' directive"
-			);
-		}
-		server.client_max_body_size = std::atoi((*it++).token.c_str()); // tmp: atoi
+		HandleClientMaxBodySize(server.client_max_body_size, ++it);
 	} else if ((*it).token == ERROR_PAGE) {
-		++it;
-		if ((*it).token_type != node::WORD || (*++NodeItr(it)).token_type != node::WORD) {
-			throw std::runtime_error("invalid number of arguments in 'error_page' directive");
-		}
-		// ex. 404 /404.html, tmp: atoi
-		NodeItr tmp_it = it; // 404
-		it++;                // /404.html
-		server.error_page = std::make_pair(std::atoi((*tmp_it).token.c_str()), (*it).token);
-		it++;
+		HandleErrorPage(server.error_page, ++it);
 	}
 	if ((*it).token_type != node::DELIM) {
 		throw std::runtime_error("expect ';' after arguments");
 	}
+}
+
+void Parser::HandleServerName(std::list<std::string> &server_names, NodeItr &it) {
+	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
+		server_names.push_back((*it++).token);
+		if (it == tokens_.end()) {
+			throw std::runtime_error("invalid arguments of 'server_name' directive");
+		}
+	}
+}
+
+void Parser::HandleListen(context::PortList &port, NodeItr &it) {
+	if ((*it).token_type != node::WORD) {
+		throw std::runtime_error("invalid number of arguments in 'listen' directive");
+	}
+	port.push_back(std::atoi((*it++).token.c_str())); // TODO: atoi, validation, 重複チェック
+}
+
+void Parser::HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it) {
+	if ((*it).token_type != node::WORD) {
+		throw std::runtime_error("invalid number of arguments in 'client_max_body_size' directive");
+	}
+	client_max_body_size = std::atoi((*it++).token.c_str()); // tmp: atoi
+}
+
+void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it) {
+	if ((*it).token_type != node::WORD || (*++NodeItr(it)).token_type != node::WORD) {
+		throw std::runtime_error("invalid number of arguments in 'error_page' directive");
+	}
+	// ex. 404 /404.html, tmp: atoi
+	NodeItr tmp_it = it; // 404
+	it++;                // /404.html
+	error_page = std::make_pair(std::atoi((*tmp_it).token.c_str()), (*it).token);
+	it++;
+}
+
+context::LocationCon Parser::CreateLocationContext(NodeItr &it) {
+	context::LocationCon location;
+
+	if ((*it).token_type != node::WORD) {
+		throw std::runtime_error("invalid number of arguments in 'location' directive");
+	}
+	location.request_uri = (*it).token;
+	++it; // skip /www/
+	if ((*it).token_type != node::L_BRACKET) {
+		throw std::runtime_error("expect { after location argument");
+	}
+	++it; // skip L_BRACKET
+	while (it != tokens_.end() && (*it).token_type != node::R_BRACKET) {
+		switch ((*it).token_type) {
+		case node::DIRECTIVE:
+			HandleLocationContextDirective(location, it);
+			break;
+		case node::DELIM:
+			throw std::runtime_error("unexpected ';'");
+			break;
+		case node::CONTEXT:
+			throw std::runtime_error("invalid nest of 'location' directive"); // nginxではok
+			break;
+		default:
+			throw std::runtime_error("unknown token");
+			break;
+		}
+		++it;
+	}
+	if (it == tokens_.end()) {
+		throw std::runtime_error("expect }");
+	}
+	return location;
 }
 
 void Parser::HandleLocationContextDirective(context::LocationCon &location, NodeItr &it) {
@@ -87,87 +181,6 @@ void Parser::HandleLocationContextDirective(context::LocationCon &location, Node
 	if ((*it).token_type != node::DELIM) {
 		throw std::runtime_error("expect ';' after arguments");
 	}
-}
-
-Parser::Parser(std::list<node::Node> &tokens) : tokens_(tokens) {
-	for (NodeItr it = tokens_.begin(); it != tokens_.end(); ++it) {
-		if ((*it).token_type == node::CONTEXT && (*it).token == SERVER) {
-			servers_.push_back(CreateServerContext(++it));
-		} else {
-			throw std::runtime_error("expect server context");
-		}
-	}
-}
-
-Parser::~Parser() {}
-
-context::ServerCon Parser::CreateServerContext(NodeItr &it) {
-	context::ServerCon server;
-
-	if ((*it).token_type != node::L_BRACKET) {
-		throw std::runtime_error("expect { after server");
-	}
-	++it; // skip L_BRACKET
-	while (it != tokens_.end() && (*it).token_type != node::R_BRACKET) {
-		switch ((*it).token_type) {
-		case node::DIRECTIVE:
-			HandleServerContextDirective(server, it);
-			break;
-		case node::CONTEXT:
-			if ((*it).token == LOCATION) {
-				server.location_con.push_back(CreateLocationContext(++it));
-			} else {
-				throw std::runtime_error("invalid nest of 'server' directive");
-			}
-			break;
-		case node::DELIM:
-			throw std::runtime_error("unexpected ';'");
-			break;
-		default:
-			throw std::runtime_error("unknown token");
-			break;
-		}
-		++it;
-	}
-	if (it == tokens_.end()) {
-		throw std::runtime_error("expect }");
-	}
-	return server;
-}
-
-context::LocationCon Parser::CreateLocationContext(NodeItr &it) {
-	context::LocationCon location;
-
-	if ((*it).token_type != node::WORD) {
-		throw std::runtime_error("invalid number of arguments in 'location' directive");
-	}
-	location.request_uri = (*it).token;
-	++it; // skip /www/
-	if ((*it).token_type != node::L_BRACKET) {
-		throw std::runtime_error("expect { after location argument");
-	}
-	++it; // skip L_BRACKET
-	while (it != tokens_.end() && (*it).token_type != node::R_BRACKET) {
-		switch ((*it).token_type) {
-		case node::DIRECTIVE:
-			HandleLocationContextDirective(location, it);
-			break;
-		case node::DELIM:
-			throw std::runtime_error("unexpected ';'");
-			break;
-		case node::CONTEXT:
-			throw std::runtime_error("invalid nest of 'location' directive"); // nginxではok
-			break;
-		default:
-			throw std::runtime_error("unknown token");
-			break;
-		}
-		++it;
-	}
-	if (it == tokens_.end()) {
-		throw std::runtime_error("expect }");
-	}
-	return location;
 }
 
 std::list<context::ServerCon> Parser::GetServers() const {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -15,7 +15,11 @@ Parser::~Parser() {}
 void Parser::ParseNode() {
 	for (NodeItr it = tokens_.begin(); it != tokens_.end(); ++it) {
 		if ((*it).token_type == node::CONTEXT && (*it).token == SERVER) {
-			servers_.push_back(CreateServerContext(++it));
+			++it;
+			if (it == tokens_.end()) {
+				throw std::runtime_error("unexpected end of server context");
+			}
+			servers_.push_back(CreateServerContext(it));
 		} else {
 			throw std::runtime_error("expect server context");
 		}

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -1,4 +1,5 @@
 #include "parser.hpp"
+#include "directive_names.hpp"
 #include <cstdlib> // atoi
 #include <stdexcept>
 
@@ -6,7 +7,7 @@ namespace config {
 namespace parser {
 
 void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &it) {
-	if ((*it).token == "server_name") {
+	if ((*it).token == SERVER_NAME) {
 		++it;
 		while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
 			server.server_names.push_back((*it++).token);
@@ -14,14 +15,14 @@ void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &i
 				throw std::runtime_error("invalid arguments of 'server_name' directive");
 			}
 		}
-	} else if ((*it).token == "listen") {
+	} else if ((*it).token == LISTEN) {
 		++it;
 		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'listen' directive");
 		}
 		server.port.push_back(std::atoi((*it++).token.c_str())
 		); // TODO: atoi, validation, 重複チェック
-	} else if ((*it).token == "client_max_body_size") {
+	} else if ((*it).token == CLIENT_MAX_BODY_SIZE) {
 		++it;
 		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error(
@@ -29,7 +30,7 @@ void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &i
 			);
 		}
 		server.client_max_body_size = std::atoi((*it++).token.c_str()); // tmp: atoi
-	} else if ((*it).token == "error_page") {
+	} else if ((*it).token == ERROR_PAGE) {
 		++it;
 		if ((*it).token_type != node::WORD || (*++NodeItr(it)).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'error_page' directive");
@@ -46,25 +47,25 @@ void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &i
 }
 
 void Parser::HandleLocationContextDirective(context::LocationCon &location, NodeItr &it) {
-	if ((*it).token == "alias") {
+	if ((*it).token == ALIAS) {
 		++it;
 		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'alias' directive");
 		}
 		location.alias = (*it++).token;
-	} else if ((*it).token == "index") {
+	} else if ((*it).token == INDEX) {
 		++it;
 		if ((*it).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'index' directive");
 		}
 		location.index = (*it++).token;
-	} else if ((*it).token == "autoindex") {
+	} else if ((*it).token == AUTO_INDEX) {
 		++it;
 		if ((*it).token_type != node::WORD || ((*it).token != "on" && (*it).token != "off")) {
 			throw std::runtime_error("invalid arguments in 'autoindex' directive");
 		}
 		location.autoindex = ((*it++).token == "on");
-	} else if ((*it).token == "allowed_methods") {
+	} else if ((*it).token == ALLOWED_METHODS) {
 		++it;
 		while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
 			location.allowed_methods.push_back((*it++).token);
@@ -72,7 +73,7 @@ void Parser::HandleLocationContextDirective(context::LocationCon &location, Node
 				throw std::runtime_error("invalid arguments of 'allowed_methods' directive");
 			}
 		}
-	} else if ((*it).token == "return") {
+	} else if ((*it).token == RETURN) {
 		++it;
 		if ((*it).token_type != node::WORD || (*++NodeItr(it)).token_type != node::WORD) {
 			throw std::runtime_error("invalid number of arguments in 'return' directive");
@@ -90,7 +91,7 @@ void Parser::HandleLocationContextDirective(context::LocationCon &location, Node
 
 Parser::Parser(std::list<node::Node> &tokens) : tokens_(tokens) {
 	for (NodeItr it = tokens_.begin(); it != tokens_.end(); ++it) {
-		if ((*it).token_type == node::CONTEXT && (*it).token == "server") {
+		if ((*it).token_type == node::CONTEXT && (*it).token == SERVER) {
 			servers_.push_back(CreateServerContext(++it));
 		} else {
 			throw std::runtime_error("expect server context");
@@ -113,7 +114,7 @@ context::ServerCon Parser::CreateServerContext(NodeItr &it) {
 			HandleServerContextDirective(server, it);
 			break;
 		case node::CONTEXT:
-			if ((*it).token == "location") {
+			if ((*it).token == LOCATION) {
 				server.location_con.push_back(CreateLocationContext(++it));
 			} else {
 				throw std::runtime_error("invalid nest of 'server' directive");

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -22,6 +22,11 @@ void Parser::ParseNode() {
 	}
 }
 
+/**
+ * @brief Handlers for Server Context
+ * @details Handlers for each Server Directive
+ */
+
 context::ServerCon Parser::CreateServerContext(NodeItr &it) {
 	context::ServerCon server;
 
@@ -105,6 +110,11 @@ void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, N
 	it++;
 }
 
+/**
+ * @brief Handlers for Location Context
+ * @details Handlers for each Location Directive
+ */
+
 context::LocationCon Parser::CreateLocationContext(NodeItr &it) {
 	context::LocationCon location;
 
@@ -138,6 +148,23 @@ context::LocationCon Parser::CreateLocationContext(NodeItr &it) {
 		throw std::runtime_error("expect }");
 	}
 	return location;
+}
+
+void Parser::HandleLocationContextDirective(context::LocationCon &location, NodeItr &it) {
+	if ((*it).token == ALIAS) {
+		HandleAlias(location.alias, ++it);
+	} else if ((*it).token == INDEX) {
+		HandleIndex(location.index, ++it);
+	} else if ((*it).token == AUTO_INDEX) {
+		HandleAutoIndex(location.autoindex, ++it);
+	} else if ((*it).token == ALLOWED_METHODS) {
+		HandleAllowedMethods(location.allowed_methods, ++it);
+	} else if ((*it).token == RETURN) {
+		HandleReturn(location.redirect, ++it);
+	}
+	if ((*it).token_type != node::DELIM) {
+		throw std::runtime_error("expect ';' after arguments");
+	}
 }
 
 void Parser::HandleAlias(std::string &alias, NodeItr &it) {
@@ -179,23 +206,6 @@ void Parser::HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeIt
 	it++;                // /index.html
 	redirect = std::make_pair(std::atoi((*tmp_it).token.c_str()), (*it).token);
 	it++;
-}
-
-void Parser::HandleLocationContextDirective(context::LocationCon &location, NodeItr &it) {
-	if ((*it).token == ALIAS) {
-		HandleAlias(location.alias, ++it);
-	} else if ((*it).token == INDEX) {
-		HandleIndex(location.index, ++it);
-	} else if ((*it).token == AUTO_INDEX) {
-		HandleAutoIndex(location.autoindex, ++it);
-	} else if ((*it).token == ALLOWED_METHODS) {
-		HandleAllowedMethods(location.allowed_methods, ++it);
-	} else if ((*it).token == RETURN) {
-		HandleReturn(location.redirect, ++it);
-	}
-	if ((*it).token_type != node::DELIM) {
-		throw std::runtime_error("expect ';' after arguments");
-	}
 }
 
 std::list<context::ServerCon> Parser::GetServers() const {

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -21,8 +21,14 @@ class Parser {
 	context::ServerCon   CreateServerContext(NodeItr &);
 	context::LocationCon CreateLocationContext(NodeItr &);
 
+	void ParseNode();
 	void HandleServerContextDirective(context::ServerCon &server, NodeItr &it);
 	void HandleLocationContextDirective(context::LocationCon &location, NodeItr &it);
+
+	void HandleServerName(std::list<std::string> &server_names, NodeItr &it);
+	void HandleListen(context::PortList &ports, NodeItr &it);
+	void HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it);
+	void HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it);
 
   public:
 	Parser(std::list<node::Node> &);

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -37,7 +37,7 @@ class Parser {
 	void HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeItr &it);
 
   public:
-	Parser(std::list<node::Node> &);
+	explicit Parser(std::list<node::Node> &);
 	~Parser();
 
 	std::list<context::ServerCon> GetServers() const;

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -22,13 +22,21 @@ class Parser {
 	context::LocationCon CreateLocationContext(NodeItr &);
 
 	void ParseNode();
-	void HandleServerContextDirective(context::ServerCon &server, NodeItr &it);
-	void HandleLocationContextDirective(context::LocationCon &location, NodeItr &it);
+	void HandleServerContextDirective(context::ServerCon &, NodeItr &);
+	void HandleLocationContextDirective(context::LocationCon &, NodeItr &);
+
+	/**
+	 * @brief Handlers for each Server Directive
+	 */
 
 	void HandleServerName(std::list<std::string> &server_names, NodeItr &it);
 	void HandleListen(context::PortList &ports, NodeItr &it);
 	void HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it);
 	void HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it);
+
+	/**
+	 * @brief Handlers for each Location Directive
+	 */
 
 	void HandleAlias(std::string &alias, NodeItr &it);
 	void HandleIndex(std::string &index, NodeItr &it);

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -30,6 +30,12 @@ class Parser {
 	void HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it);
 	void HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it);
 
+	void HandleAlias(std::string &alias, NodeItr &it);
+	void HandleIndex(std::string &index, NodeItr &it);
+	void HandleAutoIndex(bool &autoindex, NodeItr &it);
+	void HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeItr &it);
+	void HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeItr &it);
+
   public:
 	Parser(std::list<node::Node> &);
 	~Parser();

--- a/test/unit/config_parse/Makefile
+++ b/test/unit/config_parse/Makefile
@@ -14,6 +14,7 @@ WS_CONFIG_PARSE_DIR	:=	$(WS_SRCS_DIR)/config_parse
 SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
 					$(WS_CONFIG_PARSE_DIR)/config.cpp \
+					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
 					$(WS_UTILS_DIR)/color.cpp
 
 # 3. Add unit test files

--- a/test/unit/config_parse/lexer/Makefile
+++ b/test/unit/config_parse/lexer/Makefile
@@ -12,6 +12,7 @@ WS_SRCS_DIR		:=	../../../../srcs
 WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
 WS_CONFIG_PARSE_DIR	:=	$(WS_SRCS_DIR)/config_parse
 SRCS			+=	$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
+					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
 					$(WS_UTILS_DIR)/color.cpp
 
 # 3. Add unit test files

--- a/test/unit/config_parse/parser/Makefile
+++ b/test/unit/config_parse/parser/Makefile
@@ -13,6 +13,7 @@ WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
 WS_CONFIG_PARSE_DIR	:=	$(WS_SRCS_DIR)/config_parse
 SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
+					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
 					$(WS_UTILS_DIR)/color.cpp
 
 # 3. Add unit test files


### PR DESCRIPTION
## ConfigClassをリファクタリングしました

主な変更点
- [x] ConfigParser内の関数の関数分け
- [x] 関数、クラスへのコメント追加
- [x] directive_names.hppに実装予定のディレクティブ名を列挙
- [x] ディレクティブ名をstatic constで定義してlexerとparserで同じものを使う

関数の挙動自体は変えてないです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `Config`クラスのドキュメントが改善され、シングルトンとしての使い方や初期化例が追加されました。
	- 新しい定義を提供する`directive_names`の追加により、サーバー設定指令の管理が向上しました。

- **リファクタリング**
	- `Parser`クラスの指令処理メソッドがモジュール化され、可読性と保守性が向上しました。

- **テスト**
	- ユニットテストに`directive_names.cpp`が追加され、テストカバレッジが拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->