### PR TITLE
[utils] 試しに uilts の convert 系の返り値を Result 型にしてみる

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -98,13 +98,13 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData &data) {
 	}
 	// todo: HttpRequestParsedDataクラスでcontent_lengthを保持？
 	// why: ParseBodyMessageが呼ばれるたびにcontent_lengthを変換するのを避けるため
-	size_t content_length;
-	if (!utils::ConvertStrToSize(
-			data.request_result.request.header_fields[CONTENT_LENGTH], content_length
-		)) {
+	const utils::Result<std::size_t> convert_result =
+		utils::ConvertStrToSize(data.request_result.request.header_fields[CONTENT_LENGTH]);
+	if (!convert_result.IsOk()) {
 		throw HttpParseException("Error: wrong Content-Length number", BAD_REQUEST);
 	}
-	size_t readable_content_length =
+	const size_t content_length = convert_result.GetValue();
+	size_t       readable_content_length =
 		content_length - data.request_result.request.body_message.size();
 	if (data.current_buf.size() >= readable_content_length) {
 		data.request_result.request.body_message +=

--- a/srcs/utils/convert_str.cpp
+++ b/srcs/utils/convert_str.cpp
@@ -6,20 +6,21 @@
 
 namespace utils {
 
-bool ConvertStrToUint(const std::string &str, unsigned int &num) {
+Result<unsigned int> ConvertStrToUint(const std::string &str) {
+	Result<unsigned int> convert_result(false, 0);
 	if (str.empty() || !IsDigit(str[0])) {
-		return false;
+		return convert_result;
 	}
 
 	char            *end;
-	static const int BASE = 10;
-	errno                 = 0;
-	unsigned long tmp_num = std::strtoul(str.c_str(), &end, BASE);
-	if (errno == ERANGE || *end != '\0' || tmp_num > std::numeric_limits<unsigned int>::max()) {
-		return false;
+	static const int BASE   = 10;
+	errno                   = 0;
+	const unsigned long num = std::strtoul(str.c_str(), &end, BASE);
+	if (errno == ERANGE || *end != '\0' || num > std::numeric_limits<unsigned int>::max()) {
+		return convert_result;
 	}
-	num = static_cast<unsigned int>(tmp_num);
-	return true;
+	convert_result.Set(true, static_cast<unsigned int>(num));
+	return convert_result;
 }
 
 std::string ConvertUintToStr(unsigned int num) {

--- a/srcs/utils/convert_str.cpp
+++ b/srcs/utils/convert_str.cpp
@@ -1,5 +1,6 @@
 #include "utils.hpp"
 #include <cerrno>
+#include <cstddef> // size_t
 #include <cstdlib> // strtoul
 #include <limits>  // numeric_limits
 #include <sstream>
@@ -29,20 +30,21 @@ std::string ConvertUintToStr(unsigned int num) {
 	return oss.str();
 }
 
-bool ConvertStrToSize(const std::string &str, size_t &num) {
+Result<std::size_t> ConvertStrToSize(const std::string &str) {
+	Result<std::size_t> convert_result(false, 0);
 	if (str.empty() || !IsDigit(str[0])) {
-		return false;
+		return convert_result;
 	}
 
 	char            *end;
-	static const int BASE = 10;
-	errno                 = 0;
-	unsigned long tmp_num = std::strtoul(str.c_str(), &end, BASE);
-	if (errno == ERANGE || *end != '\0' || tmp_num > std::numeric_limits<size_t>::max()) {
-		return false;
+	static const int BASE   = 10;
+	errno                   = 0;
+	const unsigned long num = std::strtoul(str.c_str(), &end, BASE);
+	if (errno == ERANGE || *end != '\0' || num > std::numeric_limits<size_t>::max()) {
+		return convert_result;
 	}
-	num = static_cast<size_t>(tmp_num);
-	return true;
+	convert_result.Set(true, static_cast<std::size_t>(num));
+	return convert_result;
 }
 
 } // namespace utils

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -2,6 +2,7 @@
 #define UTILS_HPP_
 
 #include "color.hpp"
+#include "result.hpp"
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -33,7 +34,7 @@ std::string ToString(T value) {
 }
 
 // string
-bool                     ConvertStrToUint(const std::string &str, unsigned int &num);
+Result<unsigned int>     ConvertStrToUint(const std::string &str);
 bool                     ConvertStrToSize(const std::string &str, size_t &num);
 std::string              ConvertUintToStr(unsigned int num);
 std::vector<std::string> SplitStr(const std::string &src, const std::string &substring);

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -35,7 +35,7 @@ std::string ToString(T value) {
 
 // string
 Result<unsigned int>     ConvertStrToUint(const std::string &str);
-bool                     ConvertStrToSize(const std::string &str, size_t &num);
+Result<std::size_t>      ConvertStrToSize(const std::string &str);
 std::string              ConvertUintToStr(unsigned int num);
 std::vector<std::string> SplitStr(const std::string &src, const std::string &substring);
 

--- a/test/unit/convert_str/test_convert_str.cpp
+++ b/test/unit/convert_str/test_convert_str.cpp
@@ -33,9 +33,9 @@ struct TestCase {
 
 // ConvertStrToUint()を実行してexpectedと比較
 int Run(const std::string &src, Expect expected, Result result) {
-	Expect num;
-	bool   is_success = utils::ConvertStrToUint(src, num);
-	if ((is_success && result == SUCCESS && num == expected) || (!is_success && result == FAIL)) {
+	const utils::Result<Expect> convert_result = utils::ConvertStrToUint(src);
+	if ((convert_result.IsOk() && result == SUCCESS && convert_result.GetValue() == expected) ||
+		(!convert_result.IsOk() && result == FAIL)) {
 		std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK] " << utils::color::RESET
 				  << std::endl;
 		return EXIT_SUCCESS;
@@ -45,7 +45,7 @@ int Run(const std::string &src, Expect expected, Result result) {
 	std::cerr << utils::color::RED << "ConvertStrToUint() failed" << utils::color::RESET
 			  << std::endl;
 	std::cerr << "src     : [" << src << "]" << std::endl;
-	std::cerr << "result  : [" << num << "]" << std::endl;
+	std::cerr << "result  : [" << convert_result.GetValue() << "]" << std::endl;
 	std::cerr << "expected: [" << expected << "]" << std::endl;
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
PR #276 の後に main merge

## したこと
同時に 2 つの返り値が欲しい以下の関数について、Result 型を使ってみました
- utils/convert_str.cpp
  - `ConvertStrToUint()` : utils::Result を返り値に使用。併せて unit test 変更
  -  `ConvertStrToSize()` : utils::Result を返り値に使用。併せて `HttpParse::ParseBodyMessage()` 内で使ってる部分を変更

[別 PR のコメント](https://github.com/s1-haya/webserv/pull/276#issuecomment-2288465541) で汎用 Result の持ち回しは微妙かも？と意見もらったので、utils の関数に対して Result を使うことは大丈夫そうか？知りたいです！

## 実行確認
挙動に変更はないです
```sh
make run
make test 
```


<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コンテンツ長ヘッダーの処理方法が改善され、エラーハンドリングが強化されました。新しい結果タイプにより、変換の成功/失敗が明確に示されます。

- **バグ修正**
  - 文字列を整数に変換する関数の戻り値が改善され、エラーステータスと変換された値を提供するようになりました。

- **テスト**
  - テストケース内での変換結果の処理が改善され、より明確なエラーハンドリングが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->