### PR TITLE
[add] configのパラメータに対してのバリデーションを追加

### DIFF
--- a/sandbox/rin/util_test.cpp
+++ b/sandbox/rin/util_test.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <list>
+#include <string>
+
+namespace {
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+
+template <typename T>
+bool SearchListInArray(const std::list<T> &lst, const T *array, std::size_t array_size) {
+	for (typename std::list<T>::const_iterator it = lst.begin(); it != lst.end(); ++it) {
+		bool found = (std::find(array, array + array_size, *it) != (array + array_size));
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace
+
+int main() {
+	std::string            array[] = {"GET", "POST"};
+	std::list<std::string> list;
+	list.push_back("GET");
+	list.push_back("TEST");
+	std::cout << std::boolalpha << SearchListInArray(list, array, ARRAY_SIZE(array)) << std::endl;
+}

--- a/srcs/config_parse/context.hpp
+++ b/srcs/config_parse/context.hpp
@@ -17,9 +17,8 @@ struct LocationCon {
 	LocationCon() : autoindex(false) {}
 };
 
-// todo: PortListをstd::list<unsigned int>で作成？
-typedef std::list<int>         PortList;
-typedef std::list<LocationCon> LocationList;
+typedef std::list<unsigned int> PortList;
+typedef std::list<LocationCon>  LocationList;
 
 struct ServerCon {
 	PortList                             port;

--- a/srcs/config_parse/directive_names.cpp
+++ b/srcs/config_parse/directive_names.cpp
@@ -17,6 +17,10 @@ const std::string ALIAS           = "alias";
 const std::string AUTO_INDEX      = "autoindex";
 const std::string INDEX           = "index";
 
+extern const std::string VALID_ALLOWED_METHODS[] = {"GET", "DELETE", "POST"};
+extern const std::size_t VALID_ALLOWED_METHODS_SIZE =
+	sizeof(VALID_ALLOWED_METHODS) / sizeof(VALID_ALLOWED_METHODS[0]);
+
 const std::string CGI_EXTENSION = "cgi_extension";
 const std::string UPLOAD_DIR    = "upload_dir";
 

--- a/srcs/config_parse/directive_names.cpp
+++ b/srcs/config_parse/directive_names.cpp
@@ -18,7 +18,7 @@ const std::string AUTO_INDEX      = "autoindex";
 const std::string INDEX           = "index";
 
 extern const std::string VALID_ALLOWED_METHODS[] = {"GET", "DELETE", "POST"};
-extern const std::size_t VALID_ALLOWED_METHODS_SIZE =
+extern const std::size_t SIZE_OF_VALID_ALLOWED_METHODS =
 	sizeof(VALID_ALLOWED_METHODS) / sizeof(VALID_ALLOWED_METHODS[0]);
 
 const std::string CGI_EXTENSION = "cgi_extension";

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -37,6 +37,9 @@ extern const std::string ALIAS;
 extern const std::string AUTO_INDEX;
 extern const std::string INDEX;
 
+extern const std::string VALID_ALLOWED_METHODS[];
+extern const std::size_t VALID_ALLOWED_METHODS_SIZE;
+
 /**
  * @brief Directive in Location Context for CGI
  * @details Dir_name args;

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -38,7 +38,7 @@ extern const std::string AUTO_INDEX;
 extern const std::string INDEX;
 
 extern const std::string VALID_ALLOWED_METHODS[];
-extern const std::size_t VALID_ALLOWED_METHODS_SIZE;
+extern const std::size_t SIZE_OF_VALID_ALLOWED_METHODS;
 
 /**
  * @brief Directive in Location Context for CGI

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -26,6 +26,18 @@ void Parser::ParseNode() {
 	}
 }
 
+namespace {
+
+template <typename T>
+bool FindDuplicated(const std::list<T> &list, const T &element) {
+	if (std::find(list.begin(), list.end(), element) != std::end(list)) {
+		return true;
+	}
+	return false;
+}
+
+} // namespace
+
 /**
  * @brief Handlers for Server Context
  * @details Handlers for each Server Directive
@@ -82,6 +94,9 @@ void Parser::HandleServerContextDirective(context::ServerCon &server, NodeItr &i
 
 void Parser::HandleServerName(std::list<std::string> &server_names, NodeItr &it) {
 	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
+		if (FindDuplicated(server_names, (*it).token)) {
+			throw std::runtime_error("a duplicated parameter in 'server_name' directive");
+		}
 		server_names.push_back((*it++).token);
 		if (it == tokens_.end()) {
 			throw std::runtime_error("invalid arguments of 'server_name' directive");
@@ -194,6 +209,9 @@ void Parser::HandleAutoIndex(bool &autoindex, NodeItr &it) {
 
 void Parser::HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeItr &it) {
 	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
+		if (FindDuplicated(allowed_methods, (*it).token)) {
+			throw std::runtime_error("a duplicated parameter in 'allowed_methods' directive");
+		}
 		allowed_methods.push_back((*it++).token);
 		if (it == tokens_.end()) {
 			throw std::runtime_error("invalid arguments of 'allowed_methods' directive");

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -38,6 +38,23 @@ bool FindDuplicated(const std::list<T> &list, const T &element) {
 	return false;
 }
 
+template <typename T>
+bool SearchListInArray(const std::list<T> &lst, const T *array, std::size_t array_size) {
+	for (typename std::list<T>::const_iterator it = lst.begin(); it != lst.end(); ++it) {
+		bool found = false;
+		for (size_t i = 0; i < array_size; ++i) {
+			if (*it == array[i]) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
 } // namespace
 
 /**
@@ -229,6 +246,10 @@ void Parser::HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeI
 	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
 		if (FindDuplicated(allowed_methods, (*it).token)) {
 			throw std::runtime_error("a duplicated parameter in 'allowed_methods' directive");
+		} else if (!SearchListInArray(
+					   allowed_methods, VALID_ALLOWED_METHODS, VALID_ALLOWED_METHODS_SIZE
+				   )) {
+			throw std::runtime_error("an invalid method in 'allowed_methods' directive");
 		}
 		allowed_methods.push_back((*it++).token);
 		if (it == tokens_.end()) {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -2,6 +2,7 @@
 #include "directive_names.hpp"
 #include "result.hpp"
 #include "utils.hpp"
+#include <algorithm>
 #include <cstdlib> // atoi
 #include <stdexcept>
 
@@ -32,7 +33,7 @@ namespace {
 
 template <typename T>
 bool FindDuplicated(const std::list<T> &list, const T &element) {
-	if (std::find(list.begin(), list.end(), element) != std::end(list)) {
+	if (std::find(list.begin(), list.end(), element) != list.end()) {
 		return true;
 	}
 	return false;

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -38,23 +38,6 @@ bool FindDuplicated(const std::list<T> &list, const T &element) {
 	return false;
 }
 
-template <typename T>
-bool SearchListInArray(const std::list<T> &lst, const T *array, std::size_t array_size) {
-	for (typename std::list<T>::const_iterator it = lst.begin(); it != lst.end(); ++it) {
-		bool found = false;
-		for (size_t i = 0; i < array_size; ++i) {
-			if (*it == array[i]) {
-				found = true;
-				break;
-			}
-		}
-		if (!found) {
-			return false;
-		}
-	}
-	return true;
-}
-
 } // namespace
 
 /**
@@ -246,13 +229,15 @@ void Parser::HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeI
 	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
 		if (FindDuplicated(allowed_methods, (*it).token)) {
 			throw std::runtime_error("a duplicated parameter in 'allowed_methods' directive");
-		} else if (!SearchListInArray(
-					   allowed_methods, VALID_ALLOWED_METHODS, VALID_ALLOWED_METHODS_SIZE
-				   )) {
-			throw std::runtime_error("an invalid method in 'allowed_methods' directive");
 		}
-		allowed_methods.push_back((*it++).token);
-		if (it == tokens_.end()) {
+		allowed_methods.push_back((*it).token);
+		if (std::find(
+				VALID_ALLOWED_METHODS,
+				VALID_ALLOWED_METHODS + SIZE_OF_VALID_ALLOWED_METHODS,
+				(*it).token
+			) == VALID_ALLOWED_METHODS + SIZE_OF_VALID_ALLOWED_METHODS) {
+			throw std::runtime_error("an invalid method in 'allowed_methods' directive");
+		} else if (it++ == tokens_.end()) {
 			throw std::runtime_error("invalid arguments of 'allowed_methods' directive");
 		}
 	}

--- a/test/config/conf_file/success/single_server_ok1.conf
+++ b/test/config/conf_file/success/single_server_ok1.conf
@@ -6,6 +6,7 @@ events {
 http {
     server {
         listen       8080;
+        listen       8080;
         server_name  localhost;
     }
 }

--- a/test/unit/config_parse/Makefile
+++ b/test/unit/config_parse/Makefile
@@ -15,7 +15,9 @@ SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
 					$(WS_CONFIG_PARSE_DIR)/config.cpp \
 					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
-					$(WS_UTILS_DIR)/color.cpp
+					$(WS_UTILS_DIR)/color.cpp \
+					$(WS_UTILS_DIR)/convert_str.cpp \
+					$(WS_UTILS_DIR)/isdigit.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_config.cpp

--- a/test/unit/config_parse/parser/Makefile
+++ b/test/unit/config_parse/parser/Makefile
@@ -14,7 +14,9 @@ WS_CONFIG_PARSE_DIR	:=	$(WS_SRCS_DIR)/config_parse
 SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/lexer.cpp \
 					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
-					$(WS_UTILS_DIR)/color.cpp
+					$(WS_UTILS_DIR)/color.cpp \
+					$(WS_UTILS_DIR)/convert_str.cpp \
+					$(WS_UTILS_DIR)/isdigit.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_config_parser.cpp

--- a/test/unit/config_parse/parser/test_config_parser.cpp
+++ b/test/unit/config_parse/parser/test_config_parser.cpp
@@ -111,7 +111,7 @@ context::LocationCon BuildLocationCon(
 
 // 引数付きのFactory Function: 引数ありコンストラクタはここでしか使わないため
 context::ServerCon BuildServerCon(
-	const std::list<int>                       &port,
+	const std::list<unsigned int>              &port,
 	const std::list<std::string>               &server_names,
 	const LocationList                         &location_con,
 	std::size_t                                 client_max_body_size,
@@ -140,8 +140,8 @@ std::ostream &operator<<(std::ostream &os, const std::list<std::string> &str_lis
 }
 
 /* For ports */
-std::ostream &operator<<(std::ostream &os, const std::list<int> &int_list) {
-	std::list<int>::const_iterator it = int_list.begin();
+std::ostream &operator<<(std::ostream &os, const std::list<unsigned int> &int_list) {
+	std::list<unsigned int>::const_iterator it = int_list.begin();
 	while (it != int_list.end()) {
 		os << *it;
 		++it;
@@ -262,7 +262,7 @@ int RunErrorTests(const TestCase test_cases[], std::size_t num_test_cases) {
 /* Test1 One Server */
 ServerList MakeExpectedTest1() {
 	ServerList                           expected_result;
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	std::list<std::string>               server_names_1;
 	LocationList                         expected_locationlist_1;
 	std::pair<unsigned int, std::string> error_page_1;
@@ -277,7 +277,7 @@ ServerList MakeExpectedTest1() {
 /* Test2 One Server, One Location */
 ServerList MakeExpectedTest2() {
 	ServerList                           expected_result;
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	std::list<std::string>               server_names_1;
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1;
@@ -296,8 +296,8 @@ ServerList MakeExpectedTest2() {
 
 /* Test3 Server, Location Directive */
 ServerList MakeExpectedTest3() {
-	ServerList     expected_result;
-	std::list<int> expected_ports_1;
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("localhost");
@@ -322,10 +322,9 @@ ServerList MakeExpectedTest4() {
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("server_name");
 	server_names_1.push_back("server");
-	std::list<int> expected_ports_1;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	expected_ports_1.push_back(8000);
-	expected_ports_1.push_back(80);
 	LocationList                         expected_locationlist_1;
 	std::pair<unsigned int, std::string> error_page_1;
 	context::ServerCon                   expected_server_1 = BuildServerCon(
@@ -338,9 +337,9 @@ ServerList MakeExpectedTest4() {
 
 /* Test5 Multiple Locations */
 ServerList MakeExpectedTest5() {
-	ServerList             expected_result;
-	std::list<int>         expected_ports_1;
-	std::list<std::string> server_names_1;
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
+	std::list<std::string>  server_names_1;
 	server_names_1.push_back("test.serv");
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1_1;
@@ -367,7 +366,7 @@ ServerList MakeExpectedTest6() {
 	ServerList             expected_result;
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("comment.serv");
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1;
 	std::pair<unsigned int, std::string> redirect_1;
@@ -387,7 +386,7 @@ ServerList MakeExpectedTest6() {
 ServerList MakeExpectedTest7() {
 	ServerList expected_result;
 
-	std::list<int> expected_ports_1;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("localhost");
@@ -398,7 +397,7 @@ ServerList MakeExpectedTest7() {
     );
 	expected_result.push_back(expected_server_1);
 
-	std::list<int> expected_ports_2;
+	std::list<unsigned int> expected_ports_2;
 	expected_ports_2.push_back(12345);
 	std::list<std::string> server_names_2;
 	server_names_2.push_back("test.www");
@@ -453,7 +452,6 @@ int main() {
 			"server {\n \
 					listen 8080;\n \
 					listen 8000;\n \
-					listen 80;\n \
 					server_name server_name server;\n \
 				}\n",
 			expected_result_test_4

--- a/test/unit/config_parse/test_config.cpp
+++ b/test/unit/config_parse/test_config.cpp
@@ -495,6 +495,15 @@ int main() {
 	ret_code |= RunErrorTest(
 		"test_file_error/error_test16.conf", expected, "test_file_error/error_test16.conf"
 	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test17.conf", expected, "test_file_error/error_test17.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test18.conf", expected, "test_file_error/error_test18.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test19.conf", expected, "test_file_error/error_test19.conf"
+	);
 
 	return ret_code;
 }

--- a/test/unit/config_parse/test_config.cpp
+++ b/test/unit/config_parse/test_config.cpp
@@ -111,7 +111,7 @@ context::LocationCon BuildLocationCon(
 
 // 引数付きのFactory Function: 引数ありコンストラクタはここでしか使わないため
 context::ServerCon BuildServerCon(
-	const std::list<int>                       &port,
+	const std::list<unsigned int>              &port,
 	const std::list<std::string>               &server_names,
 	const LocationList                         &location_con,
 	std::size_t                                 client_max_body_size,
@@ -140,8 +140,8 @@ std::ostream &operator<<(std::ostream &os, const std::list<std::string> &str_lis
 }
 
 /* For ports */
-std::ostream &operator<<(std::ostream &os, const std::list<int> &int_list) {
-	std::list<int>::const_iterator it = int_list.begin();
+std::ostream &operator<<(std::ostream &os, const std::list<unsigned int> &int_list) {
+	std::list<unsigned int>::const_iterator it = int_list.begin();
 	while (it != int_list.end()) {
 		os << *it;
 		++it;
@@ -256,7 +256,7 @@ int RunErrorTest(const std::string &file_path, const ServerList &expected, const
 /* Test1 One Server */
 ServerList MakeExpectedTest1() {
 	ServerList                           expected_result;
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	std::list<std::string>               server_names_1;
 	LocationList                         expected_locationlist_1;
 	std::pair<unsigned int, std::string> error_page_1;
@@ -271,7 +271,7 @@ ServerList MakeExpectedTest1() {
 /* Test2 One Server, One Location */
 ServerList MakeExpectedTest2() {
 	ServerList                           expected_result;
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	std::list<std::string>               server_names_1;
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1;
@@ -290,8 +290,8 @@ ServerList MakeExpectedTest2() {
 
 /* Test3 Server, Location Directive */
 ServerList MakeExpectedTest3() {
-	ServerList     expected_result;
-	std::list<int> expected_ports_1;
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("localhost");
@@ -316,10 +316,9 @@ ServerList MakeExpectedTest4() {
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("server_name");
 	server_names_1.push_back("server");
-	std::list<int> expected_ports_1;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	expected_ports_1.push_back(8000);
-	expected_ports_1.push_back(80);
 	LocationList                         expected_locationlist_1;
 	std::pair<unsigned int, std::string> error_page_1;
 	context::ServerCon                   expected_server_1 = BuildServerCon(
@@ -332,9 +331,9 @@ ServerList MakeExpectedTest4() {
 
 /* Test5 Multiple Locations */
 ServerList MakeExpectedTest5() {
-	ServerList             expected_result;
-	std::list<int>         expected_ports_1;
-	std::list<std::string> server_names_1;
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
+	std::list<std::string>  server_names_1;
 	server_names_1.push_back("test.serv");
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1_1;
@@ -361,7 +360,7 @@ ServerList MakeExpectedTest6() {
 	ServerList             expected_result;
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("comment.serv");
-	std::list<int>                       expected_ports_1;
+	std::list<unsigned int>              expected_ports_1;
 	LocationList                         expected_locationlist_1;
 	std::list<std::string>               allowed_methods_1;
 	std::pair<unsigned int, std::string> redirect_1;
@@ -381,7 +380,7 @@ ServerList MakeExpectedTest6() {
 ServerList MakeExpectedTest7() {
 	ServerList expected_result;
 
-	std::list<int> expected_ports_1;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("localhost");
@@ -392,7 +391,7 @@ ServerList MakeExpectedTest7() {
     );
 	expected_result.push_back(expected_server_1);
 
-	std::list<int> expected_ports_2;
+	std::list<unsigned int> expected_ports_2;
 	expected_ports_2.push_back(12345);
 	std::list<std::string> server_names_2;
 	server_names_2.push_back("test.www");
@@ -408,8 +407,8 @@ ServerList MakeExpectedTest7() {
 
 /* Test8 Additional Directives */
 ServerList MakeExpectedTest8() {
-	ServerList     expected_result;
-	std::list<int> expected_ports_1;
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
 	expected_ports_1.push_back(8080);
 	std::list<std::string> server_names_1;
 	server_names_1.push_back("localhost");

--- a/test/unit/config_parse/test_file/test4.conf
+++ b/test/unit/config_parse/test_file/test4.conf
@@ -1,6 +1,5 @@
 server {
 	listen 8080;
 	listen 8000;
-	listen 80;
 	server_name server_name server;
 }

--- a/test/unit/config_parse/test_file_error/error_test17.conf
+++ b/test/unit/config_parse/test_file_error/error_test17.conf
@@ -1,0 +1,9 @@
+server {
+	listen 8080;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test18.conf
+++ b/test/unit/config_parse/test_file_error/error_test18.conf
@@ -1,0 +1,7 @@
+server {
+	server_name localhost;
+	error_page 099 /404.html;
+	location / {
+		alias /data/;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test19.conf
+++ b/test/unit/config_parse/test_file_error/error_test19.conf
@@ -1,0 +1,9 @@
+server {
+	listen 8080;
+	server_name localhost;
+	location / {
+		alias /data/;
+		index index.html;
+		allowed_methods GET POST TEST;
+	}
+}


### PR DESCRIPTION
## Implement
- [x] portをunsigned intに
- [x] 同じserver_name
- [x] portのバリデーション(同じもの、範囲)
- [x] allowed_methodsのバリデーション(無効なもの、同じもの)
- [x] error_page, returnディレクティブのstatus codeのバリデーション(範囲)
- [x] atoiをutilsのConvertStr関数に
- [x] 簡単なテストの追加

を行いました。

## Further
- [ ] endチェックを簡単にするためにカスタムイテレーターを実装 -> #291 
- [ ] 未実装のディレクティブへの対応(CGI等)
- [ ] エラーテストの追加 -> #288 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 配列内のリスト要素の存在チェックができるユーティリティ関数を追加しました。
  - 有効なHTTPメソッドを定義する定数が追加され、コードの保守性が向上しました。
  - サーバーの設定におけるポート番号の取り扱いが強化されました。

- **バグ修正**
  - サーバー名の重複検出機能が追加され、設定の整合性が向上しました。

- **ドキュメント**
  - 新しい構成ファイルが追加され、エラーハンドリングとリソース提供の機能が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->