### PR TITLE
[server] timeout / Message class, MessageManager class 作成

### DIFF
--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -85,9 +85,7 @@ int Epoll::CreateReadyList() {
 }
 
 // update epoll's interest list with new_type
-void Epoll::Update(const event::Event &event, const event::Type new_type) {
-	const int socket_fd = event.fd;
-
+void Epoll::Update(int socket_fd, const event::Type new_type) {
 	struct epoll_event ev = {};
 	ev.events             = ConvertToEpollEventType(new_type);
 	ev.data.fd            = socket_fd;

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -13,7 +13,7 @@ class Epoll {
 	~Epoll();
 	void Add(int socket_fd, event::Type type);
 	void Delete(int socket_fd);
-	void Update(const event::Event &event, event::Type new_type);
+	void Update(int socket_fd, event::Type new_type);
 	int  CreateReadyList();
 	// getter
 	event::Event GetEvent(std::size_t index) const;

--- a/srcs/http/IHttp.hpp
+++ b/srcs/http/IHttp.hpp
@@ -26,6 +26,7 @@ class IHttp {
 	 */
 	virtual HttpResult
 	Run(const server::DtoClientInfos &client_infos, const server::DtoServerInfos &server_infos) = 0;
+	virtual std::string GetTimeoutResponse(int client_fd)                                       = 0;
 };
 
 } // namespace http

--- a/srcs/http/mock_http.cpp
+++ b/srcs/http/mock_http.cpp
@@ -117,4 +117,16 @@ HttpResult MockHttp::Run(
 	return result;
 }
 
+std::string MockHttp::GetTimeoutResponse(int client_fd) {
+	(void)client_fd;
+
+	std::ostringstream oss;
+	oss << "HTTP/1.1 408 Request Timeout" << CRLF << "Content-Type: text/html" << SP << CRLF
+		<< "Connection: close" << SP << CRLF << "Content-Length: " << 170 << SP << CRLF << CRLF
+		<< "<html><head><title>408 Request Timeout</title></head><body><h1>Request "
+		   "Timeout</h1><p>Server timeout waiting for the HTTP request from the "
+		   "client.</p></body></html>";
+	return oss.str();
+}
+
 } // namespace http

--- a/srcs/http/mock_http.hpp
+++ b/srcs/http/mock_http.hpp
@@ -24,6 +24,7 @@ class MockHttp : public IHttp {
 	// override
 	HttpResult
 	Run(const server::DtoClientInfos &client_infos, const server::DtoServerInfos &server_infos);
+	std::string GetTimeoutResponse(int client_fd);
 
   private:
 	// prohibit copy

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -18,6 +18,12 @@ Message &Message::operator=(const Message &other) {
 	return *this;
 }
 
+bool Message::IsTimeoutExceeded(double timeout_sec) const {
+	const Time   current_time  = GetCurrentTime();
+	const double diff_time_sec = std::difftime(current_time, start_time_);
+	return diff_time_sec >= timeout_sec;
+}
+
 Message::Time Message::GetCurrentTime() {
 	return std::time(NULL);
 }

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -1,6 +1,7 @@
 #include "message.hpp"
 
 namespace server {
+namespace message {
 
 Message::Message(int client_fd) : client_fd_(client_fd), start_time_(GetCurrentTime()) {}
 
@@ -28,4 +29,5 @@ Message::Time Message::GetCurrentTime() {
 	return std::time(NULL);
 }
 
+} // namespace message
 } // namespace server

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -2,7 +2,7 @@
 
 namespace server {
 
-Message::Message() {}
+Message::Message(int client_fd) : client_fd_(client_fd), start_time_(GetCurrentTime()) {}
 
 Message::~Message() {}
 
@@ -12,8 +12,14 @@ Message::Message(const Message &other) {
 
 Message &Message::operator=(const Message &other) {
 	if (this != &other) {
+		client_fd_  = other.client_fd_;
+		start_time_ = other.start_time_;
 	}
 	return *this;
+}
+
+Message::Time Message::GetCurrentTime() {
+	return std::time(NULL);
 }
 
 } // namespace server

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -25,6 +25,10 @@ bool Message::IsTimeoutExceeded(double timeout_sec) const {
 	return diff_time_sec >= timeout_sec;
 }
 
+int Message::GetFd() const {
+	return client_fd_;
+}
+
 Message::Time Message::GetCurrentTime() {
 	return std::time(NULL);
 }

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -1,0 +1,19 @@
+#include "message.hpp"
+
+namespace server {
+
+Message::Message() {}
+
+Message::~Message() {}
+
+Message::Message(const Message &other) {
+	*this = other;
+}
+
+Message &Message::operator=(const Message &other) {
+	if (this != &other) {
+	}
+	return *this;
+}
+
+} // namespace server

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -16,6 +16,8 @@ class Message {
 	Message &operator=(const Message &other);
 	// function
 	bool IsTimeoutExceeded(double timeout_sec) const;
+	// getter
+	int GetFd() const;
 
   private:
 	Message();

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -1,14 +1,26 @@
 #ifndef SERVER_MESSAGE_HPP_
 #define SERVER_MESSAGE_HPP_
 
+#include <ctime>
+
 namespace server {
 
 class Message {
   public:
-	Message();
+	typedef std::time_t Time;
+
+	Message(int client_fd);
 	~Message();
 	Message(const Message &other);
 	Message &operator=(const Message &other);
+
+  private:
+	Message();
+	// functions
+	static Time GetCurrentTime();
+	// variables
+	int  client_fd_;
+	Time start_time_;
 };
 
 } // namespace server

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -13,6 +13,8 @@ class Message {
 	~Message();
 	Message(const Message &other);
 	Message &operator=(const Message &other);
+	// function
+	bool IsTimeoutExceeded(double timeout_sec) const;
 
   private:
 	Message();

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -1,0 +1,16 @@
+#ifndef SERVER_MESSAGE_HPP_
+#define SERVER_MESSAGE_HPP_
+
+namespace server {
+
+class Message {
+  public:
+	Message();
+	~Message();
+	Message(const Message &other);
+	Message &operator=(const Message &other);
+};
+
+} // namespace server
+
+#endif /* SERVER_MESSAGE_HPP_ */

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -26,6 +26,10 @@ class Message {
 	// variables
 	int  client_fd_;
 	Time start_time_;
+	// todo: add variables
+	// bool is_connection_keep_;
+	// std::string request_buf;
+	// std::string response;
 };
 
 } // namespace message

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -4,6 +4,7 @@
 #include <ctime>
 
 namespace server {
+namespace message {
 
 class Message {
   public:
@@ -25,6 +26,7 @@ class Message {
 	Time start_time_;
 };
 
+} // namespace message
 } // namespace server
 
 #endif /* SERVER_MESSAGE_HPP_ */

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -17,4 +17,9 @@ MessageManager &MessageManager::operator=(const MessageManager &other) {
 	return *this;
 }
 
+void MessageManager::AddNewMessage(int client_fd) {
+	message::Message message(client_fd);
+	messages_.push_back(message);
+}
+
 } // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -12,6 +12,7 @@ MessageManager::MessageManager(const MessageManager &other) {
 
 MessageManager &MessageManager::operator=(const MessageManager &other) {
 	if (this != &other) {
+		messages_ = other.messages_;
 	}
 	return *this;
 }

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -2,6 +2,9 @@
 
 namespace server {
 
+// todo: tmp
+const double MessageManager::TIMEOUT = 3.0;
+
 MessageManager::MessageManager() {}
 
 MessageManager::~MessageManager() {}
@@ -20,6 +23,30 @@ MessageManager &MessageManager::operator=(const MessageManager &other) {
 void MessageManager::AddNewMessage(int client_fd) {
 	message::Message message(client_fd);
 	messages_.push_back(message);
+}
+
+// before: MessageList{3,4,5}
+// (if timeout fd 3,4)
+// return: TimeoutFds{3,4}
+// after : MessageList{5}
+MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
+	TimeoutFds timeout_fds_;
+
+	typedef MessageList::const_iterator Itr;
+	Itr                                 it = messages_.begin();
+	while (it != messages_.end()) {
+		const Itr next = ++Itr(it);
+
+		const message::Message &message = *it;
+		if (!message.IsTimeoutExceeded(TIMEOUT)) {
+			break;
+		}
+		timeout_fds_.push_back(message.GetFd());
+		messages_.pop_front();
+
+		it = next;
+	}
+	return timeout_fds_;
 }
 
 } // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -38,6 +38,13 @@ void MessageManager::DeleteMessage(int client_fd) {
 	}
 }
 
+// Look from the beginning of the MessageList,
+// delete all messages that have timed out, and return TimeoutFds list.
+// ex)
+//   before: MessageList{3,4,5}
+//   (if timeout fd 3,4)
+//   return: TimeoutFds{3,4}
+//   after : MessageList{5}
 MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
 	TimeoutFds timeout_fds_;
 

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -58,4 +58,20 @@ MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
 	return timeout_fds_;
 }
 
+// todo:
+//   connection keep用。残request_bufなど保持するようになったら変更する。
+//   まだServerからは呼ばれていない、unit testだけある
+// Remove one message from the beginning and add a new message to the end.
+void MessageManager::UpdateMessage(int client_fd) {
+	typedef MessageList::iterator Itr;
+	for (Itr it = messages_.begin(); it != messages_.end(); ++it) {
+		const message::Message &message = *it;
+		if (message.GetFd() == client_fd) {
+			messages_.erase(it);
+			AddNewMessage(client_fd);
+			return;
+		}
+	}
+}
+
 } // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -25,10 +25,19 @@ void MessageManager::AddNewMessage(int client_fd) {
 	messages_.push_back(message);
 }
 
-// before: MessageList{3,4,5}
-// (if timeout fd 3,4)
-// return: TimeoutFds{3,4}
-// after : MessageList{5}
+// todo: map併用して高速化する？
+// Remove one message that matches fd from the beginning of MessageList.
+void MessageManager::DeleteMessage(int client_fd) {
+	typedef MessageList::iterator Itr;
+	for (Itr it = messages_.begin(); it != messages_.end(); ++it) {
+		const message::Message &message = *it;
+		if (message.GetFd() == client_fd) {
+			messages_.erase(it);
+			return;
+		}
+	}
+}
+
 MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
 	TimeoutFds timeout_fds_;
 

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -1,0 +1,19 @@
+#include "message_manager.hpp"
+
+namespace server {
+
+MessageManager::MessageManager() {}
+
+MessageManager::~MessageManager() {}
+
+MessageManager::MessageManager(const MessageManager &other) {
+	*this = other;
+}
+
+MessageManager &MessageManager::operator=(const MessageManager &other) {
+	if (this != &other) {
+	}
+	return *this;
+}
+
+} // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -48,19 +48,15 @@ void MessageManager::DeleteMessage(int client_fd) {
 MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
 	TimeoutFds timeout_fds_;
 
-	typedef MessageList::const_iterator Itr;
-	Itr                                 it = messages_.begin();
+	typedef MessageList::iterator Itr;
+	Itr                           it = messages_.begin();
 	while (it != messages_.end()) {
-		const Itr next = ++Itr(it);
-
 		const message::Message &message = *it;
 		if (!message.IsTimeoutExceeded(TIMEOUT)) {
 			break;
 		}
 		timeout_fds_.push_back(message.GetFd());
-		messages_.pop_front();
-
-		it = next;
+		it = messages_.erase(it);
 	}
 	return timeout_fds_;
 }

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -2,9 +2,6 @@
 
 namespace server {
 
-// todo: tmp
-const double MessageManager::TIMEOUT = 3.0;
-
 MessageManager::MessageManager() {}
 
 MessageManager::~MessageManager() {}
@@ -45,14 +42,14 @@ void MessageManager::DeleteMessage(int client_fd) {
 //   (if timeout fd 3,4)
 //   return: TimeoutFds{3,4}
 //   after : MessageList{5}
-MessageManager::TimeoutFds MessageManager::GetTimeoutFds() {
+MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
 	TimeoutFds timeout_fds_;
 
 	typedef MessageList::iterator Itr;
 	Itr                           it = messages_.begin();
 	while (it != messages_.end()) {
 		const message::Message &message = *it;
-		if (!message.IsTimeoutExceeded(TIMEOUT)) {
+		if (!message.IsTimeoutExceeded(timeout)) {
 			break;
 		}
 		timeout_fds_.push_back(message.GetFd());

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -18,6 +18,7 @@ class MessageManager {
 	MessageManager &operator=(const MessageManager &other);
 	// functions
 	void       AddNewMessage(int client_fd);
+	void       DeleteMessage(int client_fd);
 	TimeoutFds GetTimeoutFds();
 
   private:

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -19,12 +19,10 @@ class MessageManager {
 	// functions
 	void       AddNewMessage(int client_fd);
 	void       DeleteMessage(int client_fd);
-	TimeoutFds GetTimeoutFds();
+	TimeoutFds GetTimeoutFds(double timeout);
 	void       UpdateMessage(int client_fd);
 
   private:
-	// const
-	static const double TIMEOUT;
 	// variable
 	MessageList messages_;
 };

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -15,6 +15,8 @@ class MessageManager {
 	~MessageManager();
 	MessageManager(const MessageManager &other);
 	MessageManager &operator=(const MessageManager &other);
+	// functions
+	void AddNewMessage(int client_fd);
 
   private:
 	// variable

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -1,0 +1,16 @@
+#ifndef SERVER_MESSAGE_MANAGER_HPP_
+#define SERVER_MESSAGE_MANAGER_HPP_
+
+namespace server {
+
+class MessageManager {
+  public:
+	MessageManager();
+	~MessageManager();
+	MessageManager(const MessageManager &other);
+	MessageManager &operator=(const MessageManager &other);
+};
+
+} // namespace server
+
+#endif /* SERVER_MESSAGE_MANAGER_HPP_ */

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -10,15 +10,19 @@ class MessageManager {
   public:
 	// The order in which requests received
 	typedef std::list<message::Message> MessageList;
+	typedef std::list<int>              TimeoutFds;
 
 	MessageManager();
 	~MessageManager();
 	MessageManager(const MessageManager &other);
 	MessageManager &operator=(const MessageManager &other);
 	// functions
-	void AddNewMessage(int client_fd);
+	void       AddNewMessage(int client_fd);
+	TimeoutFds GetTimeoutFds();
 
   private:
+	// const
+	static const double TIMEOUT;
 	// variable
 	MessageList messages_;
 };

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -1,14 +1,24 @@
 #ifndef SERVER_MESSAGE_MANAGER_HPP_
 #define SERVER_MESSAGE_MANAGER_HPP_
 
+#include "message.hpp"
+#include <list>
+
 namespace server {
 
 class MessageManager {
   public:
+	// The order in which requests received
+	typedef std::list<message::Message> MessageList;
+
 	MessageManager();
 	~MessageManager();
 	MessageManager(const MessageManager &other);
 	MessageManager &operator=(const MessageManager &other);
+
+  private:
+	// variable
+	MessageList messages_;
 };
 
 } // namespace server

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -20,6 +20,7 @@ class MessageManager {
 	void       AddNewMessage(int client_fd);
 	void       DeleteMessage(int client_fd);
 	TimeoutFds GetTimeoutFds();
+	void       UpdateMessage(int client_fd);
 
   private:
 	// const

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -196,15 +196,7 @@ void Server::SendResponse(int client_fd) {
 	// - event_monitor_.Update(event.fd, event::EVENT_READ); でevent監視をREADに更新
 
 	// todo: closeの場合こっち
-	// disconnect
-	// delete buffer, client_info, event, message
-	buffers_.Delete(client_fd);
-	context_.DeleteClientInfo(client_fd);
-	event_monitor_.Delete(client_fd);
-	message_manager_.DeleteMessage(client_fd);
-	close(client_fd);
-	utils::Debug("server", "disconnected client", client_fd);
-	utils::Debug("------------------------------------------");
+	Disconnect(client_fd);
 }
 
 void Server::HandleTimeoutMessages() {
@@ -219,6 +211,17 @@ void Server::HandleTimeoutMessages() {
 		buffers_.AddResponse(client_fd, timeout_response);
 		event_monitor_.Update(client_fd, event::EVENT_WRITE);
 	}
+}
+
+// delete from buffer, client_info, event, message
+void Server::Disconnect(int client_fd) {
+	buffers_.Delete(client_fd);
+	context_.DeleteClientInfo(client_fd);
+	event_monitor_.Delete(client_fd);
+	message_manager_.DeleteMessage(client_fd);
+	close(client_fd);
+	utils::Debug("server", "disconnected client", client_fd);
+	utils::Debug("------------------------------------------");
 }
 
 void Server::Init() {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -181,7 +181,7 @@ void Server::RunHttp(const event::Event &event) {
 	utils::Debug("server", "received all request from client", client_fd);
 	std::cerr << buffers_.GetRequest(client_fd) << std::endl;
 	buffers_.AddResponse(client_fd, http_result.response);
-	event_monitor_.Update(event, event::EVENT_WRITE);
+	event_monitor_.Update(event.fd, event::EVENT_WRITE);
 }
 
 void Server::SendResponse(int client_fd) {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -10,6 +10,10 @@
 #include <unistd.h>     // close
 
 namespace server {
+
+// todo: tmp
+const double Server::REQUEST_TIMEOUT = 3.0;
+
 namespace {
 
 VirtualServer::LocationList ConvertLocations(const config::context::LocationList &config_locations
@@ -201,7 +205,7 @@ void Server::SendResponse(int client_fd) {
 
 void Server::HandleTimeoutMessages() {
 	// timeoutした全fdを取得
-	const MessageManager::TimeoutFds &timeout_fds = message_manager_.GetTimeoutFds();
+	const MessageManager::TimeoutFds &timeout_fds = message_manager_.GetTimeoutFds(REQUEST_TIMEOUT);
 
 	// timeout用のresponseをセットしてevent監視をWRITEに変更
 	typedef MessageManager::TimeoutFds::const_iterator Itr;

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -197,9 +197,11 @@ void Server::SendResponse(int client_fd) {
 
 	// todo: closeの場合こっち
 	// disconnect
+	// delete buffer, client_info, event, message
 	buffers_.Delete(client_fd);
 	context_.DeleteClientInfo(client_fd);
 	event_monitor_.Delete(client_fd);
+	message_manager_.DeleteMessage(client_fd);
 	close(client_fd);
 	utils::Debug("server", "disconnected client", client_fd);
 	utils::Debug("------------------------------------------");

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -172,7 +172,7 @@ void Server::RunHttp(const event::Event &event) {
 	const DtoServerInfos &server_infos = GetServerInfos(client_fd);
 	DebugDto(client_infos, server_infos);
 
-	http::HttpResult http_result = mock_http.Run(client_infos, server_infos);
+	http::HttpResult http_result = mock_http_.Run(client_infos, server_infos);
 	// Check if it's ready to start write/send.
 	// If not completed, the request will be re-read by the event_monitor.
 	if (!http_result.is_response_complete) {
@@ -207,7 +207,7 @@ void Server::HandleTimeoutMessages() {
 	typedef MessageManager::TimeoutFds::const_iterator Itr;
 	for (Itr it = timeout_fds.begin(); it != timeout_fds.end(); ++it) {
 		const int          client_fd        = *it;
-		const std::string &timeout_response = mock_http.GetTimeoutResponse(client_fd);
+		const std::string &timeout_response = mock_http_.GetTimeoutResponse(client_fd);
 		buffers_.AddResponse(client_fd, timeout_response);
 		event_monitor_.Update(client_fd, event::EVENT_WRITE);
 	}

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -7,6 +7,7 @@
 #include "context_manager.hpp"
 #include "epoll.hpp"
 #include "http_result.hpp"
+#include "message_manager.hpp"
 #include "mock_http.hpp"
 #include <list>
 #include <string>
@@ -53,6 +54,8 @@ class Server {
 	Buffer buffers_;
 	// http
 	http::MockHttp mock_http;
+	// message manager with time control
+	MessageManager message_manager_;
 };
 
 } // namespace server

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -55,7 +55,7 @@ class Server {
 	// request buffers
 	Buffer buffers_;
 	// http
-	http::MockHttp mock_http;
+	http::MockHttp mock_http_;
 	// message manager with time control
 	MessageManager message_manager_;
 };

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -39,6 +39,7 @@ class Server {
 	void RunHttp(const event::Event &event);
 	void SendResponse(int client_fd);
 	void HandleTimeoutMessages();
+	void Disconnect(int client_fd);
 	// for Server to Http
 	DtoClientInfos GetClientInfos(int client_fd) const;
 	DtoServerInfos GetServerInfos(int client_fd) const;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -38,6 +38,7 @@ class Server {
 	void ReadRequest(int client_fd);
 	void RunHttp(const event::Event &event);
 	void SendResponse(int client_fd);
+	void HandleTimeoutMessages();
 	// for Server to Http
 	DtoClientInfos GetClientInfos(int client_fd) const;
 	DtoServerInfos GetServerInfos(int client_fd) const;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -45,7 +45,8 @@ class Server {
 	DtoServerInfos GetServerInfos(int client_fd) const;
 
 	// const
-	static const int SYSTEM_ERROR = -1;
+	static const int    SYSTEM_ERROR = -1;
+	static const double REQUEST_TIMEOUT;
 	// context(virtual server,client)
 	ContextManager context_;
 	// connection


### PR DESCRIPTION
client の request に対する timeout ・関連した構成変更の実装工程の 1
1.  `Message class`, `MessageManager class` 作成 <- この PR はここだけ
2. `MessageManager class` unit test 追加
3. `Message class` に request_buf と response も持たせる
4. Connection: keep-alive の実装ができたら？ `send()` 後に `MessageManager` の処理を分ける

## したこと
vc で話した、timeout check にも使う `Message class`, `MessageManager class` の実装を追加しました
今は時間だけしかもってないですが、工程 3 で Buffer class が消滅して Message class に request, response が移動する予定です
(unit test からしか使ってない関数は make check で怒られますが無視していただければ…)

## 実行
既存の機能に変更なしです
```sh
make run
make test
```
timeout に関する unit test は工程 2 の PR #305 で追加済みです


<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
  - `Epoll` クラスの `Update` メソッドの引数を簡素化し、パフォーマンスを向上。
  - `IHttp` インターフェースに `GetTimeoutResponse` メソッドを追加し、タイムアウト処理を強化。
  - 新しい `Message` クラスと `MessageManager` クラスを導入し、メッセージ管理機能を追加。
  - `Server` クラスにクライアントのタイムアウトメッセージ処理を行う `HandleTimeoutMessages` メソッドを追加。
  - `Server` クラスにクライアント接続の切断処理を行う `Disconnect` メソッドを追加。

- **バグ修正**
  - 特定のクライアント接続のタイムアウト処理を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->