### PR TITLE
[add] テストしたいrequestのファイルを少し追加

### DIFF
--- a/test/client/request_messages/200_get_sub.txt
+++ b/test/client/request_messages/200_get_sub.txt
@@ -1,4 +1,0 @@
-GET /sub HTTP/1.1
-Connection: close 
-
-

--- a/test/client/request_messages/404_get_not_exist_path.txt
+++ b/test/client/request_messages/404_get_not_exist_path.txt
@@ -1,4 +1,0 @@
-GET /not-exist-path HTTP/1.1
-Connection: close 
-
-

--- a/test/request_messages/apache_root/delete/405_connection-close.txt
+++ b/test/request_messages/apache_root/delete/405_connection-close.txt
@@ -1,0 +1,5 @@
+DELETE / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_200_connection-keep_close.txt
+++ b/test/request_messages/apache_root/get/200_200_connection-keep_close.txt
@@ -1,0 +1,9 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_200_connection-keep_correct-content_close.txt
+++ b/test/request_messages/apache_root/get/200_200_connection-keep_correct-content_close.txt
@@ -1,0 +1,11 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcdeGET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_200_connection-keep_keep.txt
+++ b/test/request_messages/apache_root/get/200_200_connection-keep_keep.txt
@@ -1,0 +1,9 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+

--- a/test/request_messages/apache_root/get/200_501_connection-keep_wrong-content1_close.txt
+++ b/test/request_messages/apache_root/get/200_501_connection-keep_wrong-content1_close.txt
@@ -1,0 +1,11 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcdezzzzzGET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_501_connection-keep_wrong-content2_close.txt
+++ b/test/request_messages/apache_root/get/200_501_connection-keep_wrong-content2_close.txt
@@ -1,0 +1,11 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcGET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_connection-close.txt
+++ b/test/request_messages/apache_root/get/200_connection-close.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_connection-close_close.txt
+++ b/test/request_messages/apache_root/get/200_connection-close_close.txt
@@ -1,0 +1,9 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_connection-close_keep.txt
+++ b/test/request_messages/apache_root/get/200_connection-close_keep.txt
@@ -1,0 +1,9 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+

--- a/test/request_messages/apache_root/get/200_connection-close_wrong-content_close.txt
+++ b/test/request_messages/apache_root/get/200_connection-close_wrong-content_close.txt
@@ -1,0 +1,11 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcGET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/apache_root/get/200_connection-keep.txt
+++ b/test/request_messages/apache_root/get/200_connection-keep.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+

--- a/test/request_messages/apache_root/get/400_connection-close_no-host.txt
+++ b/test/request_messages/apache_root/get/400_connection-close_no-host.txt
@@ -1,4 +1,4 @@
 GET / HTTP/1.1
-Connection: close 
+Connection: close
 
 

--- a/test/request_messages/apache_root/get/408_connection-keep_wrong-content.txt
+++ b/test/request_messages/apache_root/get/408_connection-keep_wrong-content.txt
@@ -1,0 +1,7 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abc

--- a/test/request_messages/apache_root/mix/200_200_get_keep_correct-content_post_close_correct-content.txt
+++ b/test/request_messages/apache_root/mix/200_200_get_keep_correct-content_post_close_correct-content.txt
@@ -1,0 +1,13 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcdePOST / HTTP/1.1
+Host: localhost
+Connection: close
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abcde

--- a/test/request_messages/apache_root/post/200_connection-keep_wrong-content-length.txt
+++ b/test/request_messages/apache_root/post/200_connection-keep_wrong-content-length.txt
@@ -1,0 +1,7 @@
+POST / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+abc

--- a/test/request_messages/webserv/get/200_root_connection-close.txt
+++ b/test/request_messages/webserv/get/200_root_connection-close.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/webserv/get/200_root_connection-keep.txt
+++ b/test/request_messages/webserv/get/200_root_connection-keep.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+
+

--- a/test/request_messages/webserv/get/200_sub_connection-close.txt
+++ b/test/request_messages/webserv/get/200_sub_connection-close.txt
@@ -1,0 +1,5 @@
+GET /sub HTTP/1.1
+Host: localhost
+Connection: close
+
+

--- a/test/request_messages/webserv/get/404_not-exist-path_connection-close.txt
+++ b/test/request_messages/webserv/get/404_not-exist-path_connection-close.txt
@@ -1,0 +1,5 @@
+GET /not-exist-path HTTP/1.1
+Host: localhost
+Connection: close
+
+


### PR DESCRIPTION
## したこと
軽い気持ちで将来的に integratoin test で試したいシンプルな request をファイルで追加してみました
ファイル名の先頭は apache で試した場合の status code です。nginx はオリジナルの status code を返してくることが多かったので、より RFC に近い apache の方にしてみました

webserv がまだ対応してないものについても追加してます

## 今後
全然網羅はしてないので、順次追加したい

## 実行
test/client で、port と送りたいリクエストのファイルパスを渡すと試せます
```sh
cd test/client
make run PORT=<port> INFILE_PATH=<file path>
```

ex) apache で試したい場合
```sh
# apache 起動した状態で
cd test/client
make run PORT=4242 INFILE_PATH=../request_messages/apache_root/get/200_connection-close.txt
```
ex) webserv で試したい場合
```sh
# webserv 起動した状態で
cd test/client
make run PORT=8080 INFILE_PATH=../request_messages/webserv/get/200_root_connection-close.txt
make run PORT=9999 INFILE_PATH=../request_messages/webserv/get/200_sub_connection-close.txt
make run PORT=12345 INFILE_PATH=../request_messages/webserv/get/404_not-exist-path_connection-close.txt 
```