### PR TITLE
[add] MessageManager class の unit test 追加

### DIFF
--- a/.github/workflows/unit_test_message_manager.yml
+++ b/.github/workflows/unit_test_message_manager.yml
@@ -1,0 +1,19 @@
+name: unit-test-message-manager
+
+on:
+  push:
+    branches: [ ab/302-add-unit-test-message_manager ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run unit test message_manager
+        run:
+          make -C test/unit/message_manager run

--- a/.github/workflows/unit_test_message_manager.yml
+++ b/.github/workflows/unit_test_message_manager.yml
@@ -2,7 +2,7 @@ name: unit-test-message-manager
 
 on:
   push:
-    branches: [ ab/302-add-unit-test-message_manager ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/test/unit/message_manager/Makefile
+++ b/test/unit/message_manager/Makefile
@@ -1,0 +1,75 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	message_manager
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR		:=	../../../srcs
+WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
+SRCS			+=	$(WS_UTILS_DIR)/color.cpp
+WS_LIFETIME_DIR	:=	../../../srcs/server/message_manager
+SRCS			+=	$(WS_LIFETIME_DIR)/message.cpp \
+					$(WS_LIFETIME_DIR)/message_manager.cpp
+
+# 3. Add unit test files
+SRCS	+=	test_message_manager.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_UTILS_DIR) $(WS_LIFETIME_DIR) 
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/unit/message_manager/Makefile
+++ b/test/unit/message_manager/Makefile
@@ -11,15 +11,15 @@ LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
 WS_SRCS_DIR		:=	../../../srcs
 WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
 SRCS			+=	$(WS_UTILS_DIR)/color.cpp
-WS_LIFETIME_DIR	:=	../../../srcs/server/message_manager
-SRCS			+=	$(WS_LIFETIME_DIR)/message.cpp \
-					$(WS_LIFETIME_DIR)/message_manager.cpp
+WS_MESSAGE_MANAGER_DIR	:=	../../../srcs/server/message_manager
+SRCS					+=	$(WS_MESSAGE_MANAGER_DIR)/message.cpp \
+							$(WS_MESSAGE_MANAGER_DIR)/message_manager.cpp
 
 # 3. Add unit test files
-SRCS	+=	test_message_manager.cpp
+SRCS		+=	test_message_manager.cpp
 
 # 4. Add directory for INCLUDE
-SRCS_DIR	:=	$(WS_UTILS_DIR) $(WS_LIFETIME_DIR) 
+SRCS_DIR	:=	$(WS_UTILS_DIR) $(WS_MESSAGE_MANAGER_DIR) 
 
 #--------------------------------------------
 OBJ_DIR		:=	objs

--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -8,6 +8,10 @@
 
 namespace {
 
+// このunit testがtimeout 3sであること前提で作られているので、
+// Server::REQUEST_TIMEOUT を直に呼ばない
+static const double REQUEST_TIMEOUT = 3.0;
+
 typedef server::MessageManager::TimeoutFds TimeoutFds;
 
 struct Result {
@@ -77,7 +81,7 @@ RunIsSameTimeoutFds(server::MessageManager &manager, const TimeoutFds &expected_
 	Result             result;
 	std::ostringstream oss;
 
-	const TimeoutFds &timeout_fds = manager.GetTimeoutFds();
+	const TimeoutFds &timeout_fds = manager.GetTimeoutFds(REQUEST_TIMEOUT);
 	if (!IsSame(timeout_fds, expected_timeout_fds)) {
 		result.is_success = false;
 		oss << "timeout_fds" << std::endl;

--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -4,8 +4,11 @@
 #include <iostream>
 #include <list>
 #include <sstream>  // ostringstream
+#include <unistd.h> // sleep
 
 namespace {
+
+typedef server::MessageManager::TimeoutFds TimeoutFds;
 
 struct Result {
 	Result() : is_success(true) {}
@@ -48,9 +51,89 @@ int Test(Result result) {
 	return EXIT_FAILURE;
 }
 
+// -----------------------------------------------------------------------------
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::list<T> &lst) {
+	typedef typename std::list<T>::const_iterator It;
+	for (It it = lst.begin(); it != lst.end(); ++it) {
+		os << "[" << *it << "]";
+	}
+	return os;
+}
+
+Result
+RunIsSameTimeoutFds(server::MessageManager &manager, const TimeoutFds &expected_timeout_fds) {
+	Result             result;
+	std::ostringstream oss;
+
+	const TimeoutFds &timeout_fds = manager.GetTimeoutFds();
+	if (!IsSame(timeout_fds, expected_timeout_fds)) {
+		result.is_success = false;
+		oss << "timeout_fds" << std::endl;
+		oss << "- result  : " << timeout_fds << std::endl;
+		oss << "- expected: " << expected_timeout_fds << std::endl;
+	}
+	result.error_log = oss.str();
+	return result;
+}
+
+// -----------------------------------------------------------------------------
+// add fd         : 4 5         6
+// timeout(3s)    :       4 5         6
+// current time   : 0 1 2 3 4 5 6 7 8 9 10
+// GetTimeoutFds():           *   *     *
+// -----------------------------------------------------------------------------
+int RunTestGetTimeoutFds() {
+	int ret_code = EXIT_SUCCESS;
+
+	server::MessageManager manager;
+	TimeoutFds             expected_timeout_fds;
+
+	// time(0), add fd: 4
+	manager.AddNewMessage(4);
+
+	sleep(1);
+	// time(1), add fd: 5
+	manager.AddNewMessage(5);
+
+	sleep(2);
+	// time(3), timeout fd: 4
+	expected_timeout_fds.push_back(4);
+
+	sleep(1);
+	// time(4), timeout fd: 5
+	expected_timeout_fds.push_back(5);
+
+	sleep(1);
+	// time(5), GetTimeoutFds: {4, 5}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test1
+	expected_timeout_fds.clear();
+
+	sleep(1);
+	// time(6), add fd: 6
+	manager.AddNewMessage(6);
+
+	sleep(1);
+	// time(7), GetTimeoutFds: {}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test2
+
+	sleep(3);
+	// time(9), timeout fd: 6
+	expected_timeout_fds.push_back(6);
+
+	sleep(1);
+	// time(10), GetTimeoutFds: {6}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test3
+
+	return ret_code;
+}
+
 } // namespace
 
 int main() {
 	int ret_code = EXIT_SUCCESS;
+
+	ret_code |= RunTestGetTimeoutFds();
+
 	return ret_code;
 }

--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -1,0 +1,56 @@
+#include "color.hpp"
+#include "message_manager.hpp"
+#include <cstdlib>
+#include <iostream>
+#include <list>
+#include <sstream>  // ostringstream
+
+namespace {
+
+struct Result {
+	Result() : is_success(true) {}
+	bool        is_success;
+	std::string error_log;
+};
+
+int GetTestCaseNum() {
+	static int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+void PrintOk() {
+	std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintNg() {
+	std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintError(const std::string &message) {
+	std::cerr << utils::color::RED << message << utils::color::RESET << std::endl;
+}
+
+template <typename T>
+bool IsSame(const T &result, const T &expected) {
+	return result == expected;
+}
+
+int Test(Result result) {
+	if (result.is_success) {
+		PrintOk();
+		return EXIT_SUCCESS;
+	}
+	PrintNg();
+	PrintError(result.error_log);
+	return EXIT_FAILURE;
+}
+
+} // namespace
+
+int main() {
+	int ret_code = EXIT_SUCCESS;
+	return ret_code;
+}


### PR DESCRIPTION
PR #295 merge 後に main merge

---
client の request に対する timeout ・関連した構成変更の実装工程の 2
1.  `Message class`, `MessageManager class` 作成
2. `MessageManager class` unit test 追加 <- この PR はここだけ
3. `Message class` に request_buf と response も持たせる
4. Connection: keep-alive の実装ができたら？ `send()` 後に `MessageManager` の処理を分ける

## したこと
MassageManager class の中の timeout に関係する関数の unit test を追加しました

## 実行
テストに少し時間がかかるので make unit で走る `TEST_DIR` の中に入れずに、actions の job を分けてみました
その為、root からの実行は以下のようになってしまってるのですが、良いのか…？
```sh
make -C test/unit/message_manager run
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `message_manager` コンポーネント用のユニットテストを自動的に実行する GitHub Actions ワークフローを追加しました。
  
- **テスト**
  - `MessageManager` クラスの機能を検証するための包括的なユニットテストが追加されました。タイムアウトファイルディスクリプタの管理機能が対象です。 

- **リファクタ**
  - テスト実行のための Makefile が追加され、ビルドプロセスが整理されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->