### PR TITLE
[add] timeout / request_buf-response を Message class 内に移動 

### DIFF
--- a/srcs/server/buffer.cpp
+++ b/srcs/server/buffer.cpp
@@ -9,18 +9,25 @@ Buffer::Buffer() {}
 
 Buffer::~Buffer() {}
 
-ssize_t Buffer::ReadRequest(int client_fd) {
-	char buffer[BUFFER_SIZE];
+Buffer::ReadResult Buffer::ReadRequest(int client_fd) {
+	ReadResult read_result;
 
+	char    buffer[BUFFER_SIZE];
 	ssize_t read_ret = read(client_fd, buffer, BUFFER_SIZE);
 	if (read_ret <= 0) {
 		if (read_ret == SYSTEM_ERROR) {
 			perror("read failed");
+			read_result.Set(false);
 		}
-		return read_ret;
+		const ReadBuf read_buf = {read_ret, ""};
+		read_result.SetValue(read_buf);
+		return read_result;
 	}
 	requests_[client_fd] += std::string(buffer, read_ret);
-	return read_ret;
+
+	const ReadBuf read_buf = {read_ret, std::string(buffer, read_ret)};
+	read_result.SetValue(read_buf);
+	return read_result;
 }
 
 void Buffer::Delete(int client_fd) {

--- a/srcs/server/buffer.cpp
+++ b/srcs/server/buffer.cpp
@@ -25,7 +25,6 @@ ssize_t Buffer::ReadRequest(int client_fd) {
 
 void Buffer::Delete(int client_fd) {
 	requests_.erase(client_fd);
-	responses_.erase(client_fd);
 }
 
 const std::string &Buffer::GetRequest(int client_fd) const {
@@ -33,22 +32,6 @@ const std::string &Buffer::GetRequest(int client_fd) const {
 		return requests_.at(client_fd);
 	} catch (const std::exception &e) {
 		throw std::logic_error("GetRequest() : client_fd doesn't exists");
-	}
-}
-
-void Buffer::AddResponse(int client_fd, const std::string &response) {
-	typedef std::pair<ResponseMap::const_iterator, bool> InsertResult;
-	InsertResult result = responses_.insert(std::make_pair(client_fd, response));
-	if (result.second == false) {
-		throw std::logic_error("AddResponse() : client_fd is already added");
-	}
-}
-
-const std::string &Buffer::GetResponse(int client_fd) const {
-	try {
-		return responses_.at(client_fd);
-	} catch (const std::exception &e) {
-		throw std::logic_error("GetResponse() : client_fd doesn't exists");
 	}
 }
 

--- a/srcs/server/buffer.cpp
+++ b/srcs/server/buffer.cpp
@@ -1,7 +1,6 @@
 #include "buffer.hpp"
-#include <cstdio>    // perror
-#include <stdexcept> // logic_error
-#include <unistd.h>  // read
+#include <cstdio>   // perror
+#include <unistd.h> // read
 
 namespace server {
 
@@ -23,23 +22,9 @@ Buffer::ReadResult Buffer::ReadRequest(int client_fd) {
 		read_result.SetValue(read_buf);
 		return read_result;
 	}
-	requests_[client_fd] += std::string(buffer, read_ret);
-
 	const ReadBuf read_buf = {read_ret, std::string(buffer, read_ret)};
 	read_result.SetValue(read_buf);
 	return read_result;
-}
-
-void Buffer::Delete(int client_fd) {
-	requests_.erase(client_fd);
-}
-
-const std::string &Buffer::GetRequest(int client_fd) const {
-	try {
-		return requests_.at(client_fd);
-	} catch (const std::exception &e) {
-		throw std::logic_error("GetRequest() : client_fd doesn't exists");
-	}
 }
 
 } // namespace server

--- a/srcs/server/buffer.hpp
+++ b/srcs/server/buffer.hpp
@@ -15,12 +15,12 @@ class Buffer {
 	};
 	typedef utils::Result<ReadBuf> ReadResult;
 
-	Buffer();
-	~Buffer();
 	// function
-	ReadResult ReadRequest(int client_fd);
+	static ReadResult ReadRequest(int client_fd);
 
   private:
+	Buffer();
+	~Buffer();
 	// prohibit copy
 	Buffer(const Buffer &other);
 	Buffer &operator=(const Buffer &other);

--- a/srcs/server/buffer.hpp
+++ b/srcs/server/buffer.hpp
@@ -2,13 +2,11 @@
 #define SERVER_BUFFER_HPP_
 
 #include "utils.hpp"
-#include <map>
 #include <string>
 #include <sys/types.h> // ssize_t
 
 namespace server {
 
-// todo: requestを保持してるのは仮。Httpに渡して任せる予定
 class Buffer {
   public:
 	struct ReadBuf {
@@ -17,15 +15,10 @@ class Buffer {
 	};
 	typedef utils::Result<ReadBuf> ReadResult;
 
-	// int: client_fd, string: request_buf
-	typedef std::map<int, std::string> RequestMap;
 	Buffer();
 	~Buffer();
-	// functions
+	// function
 	ReadResult ReadRequest(int client_fd);
-	void       Delete(int client_fd);
-	// getter
-	const std::string &GetRequest(int client_fd) const;
 
   private:
 	// prohibit copy
@@ -34,8 +27,6 @@ class Buffer {
 	// const
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int BUFFER_SIZE  = 1024;
-	// request buffers
-	RequestMap requests_;
 };
 
 } // namespace server

--- a/srcs/server/buffer.hpp
+++ b/srcs/server/buffer.hpp
@@ -12,16 +12,13 @@ class Buffer {
   public:
 	// int: client_fd, string: request_buf
 	typedef std::map<int, std::string> RequestMap;
-	typedef std::map<int, std::string> ResponseMap;
 	Buffer();
 	~Buffer();
 	// functions
 	ssize_t ReadRequest(int client_fd);
 	void    Delete(int client_fd);
-	void    AddResponse(int client_fd, const std::string &response);
 	// getter
 	const std::string &GetRequest(int client_fd) const;
-	const std::string &GetResponse(int client_fd) const;
 
   private:
 	// prohibit copy
@@ -31,8 +28,7 @@ class Buffer {
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int BUFFER_SIZE  = 1024;
 	// request buffers
-	RequestMap  requests_;
-	ResponseMap responses_;
+	RequestMap requests_;
 };
 
 } // namespace server

--- a/srcs/server/buffer.hpp
+++ b/srcs/server/buffer.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_BUFFER_HPP_
 #define SERVER_BUFFER_HPP_
 
+#include "utils.hpp"
 #include <map>
 #include <string>
 #include <sys/types.h> // ssize_t
@@ -10,13 +11,19 @@ namespace server {
 // todo: requestを保持してるのは仮。Httpに渡して任せる予定
 class Buffer {
   public:
+	struct ReadBuf {
+		ssize_t     read_size;
+		std::string read_buf;
+	};
+	typedef utils::Result<ReadBuf> ReadResult;
+
 	// int: client_fd, string: request_buf
 	typedef std::map<int, std::string> RequestMap;
 	Buffer();
 	~Buffer();
 	// functions
-	ssize_t ReadRequest(int client_fd);
-	void    Delete(int client_fd);
+	ReadResult ReadRequest(int client_fd);
+	void       Delete(int client_fd);
 	// getter
 	const std::string &GetRequest(int client_fd) const;
 

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -13,8 +13,10 @@ Message::Message(const Message &other) {
 
 Message &Message::operator=(const Message &other) {
 	if (this != &other) {
-		client_fd_  = other.client_fd_;
-		start_time_ = other.start_time_;
+		client_fd_   = other.client_fd_;
+		start_time_  = other.start_time_;
+		request_buf_ = other.request_buf_;
+		response_    = other.response_;
 	}
 	return *this;
 }
@@ -27,6 +29,23 @@ bool Message::IsTimeoutExceeded(double timeout_sec) const {
 
 int Message::GetFd() const {
 	return client_fd_;
+}
+
+const std::string &Message::GetRequestBuf() const {
+	return request_buf_;
+}
+
+const std::string &Message::GetResponse() const {
+	return response_;
+}
+
+// todo: Httpと繋がったら += ではなく = になる
+void Message::SetRequestBuf(const std::string &request_buf) {
+	request_buf_ += request_buf;
+}
+
+void Message::SetResponse(const std::string &response) {
+	response_ = response;
 }
 
 Message::Time Message::GetCurrentTime() {

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -2,6 +2,7 @@
 #define SERVER_MESSAGE_HPP_
 
 #include <ctime>
+#include <string>
 
 namespace server {
 namespace message {
@@ -17,7 +18,12 @@ class Message {
 	// function
 	bool IsTimeoutExceeded(double timeout_sec) const;
 	// getter
-	int GetFd() const;
+	int                GetFd() const;
+	const std::string &GetRequestBuf() const;
+	const std::string &GetResponse() const;
+	// setter
+	void SetRequestBuf(const std::string &request_buf);
+	void SetResponse(const std::string &response);
 
   private:
 	Message();
@@ -28,8 +34,8 @@ class Message {
 	Time start_time_;
 	// todo: add variables
 	// bool is_connection_keep_;
-	// std::string request_buf;
-	// std::string response;
+	std::string request_buf_;
+	std::string response_;
 };
 
 } // namespace message

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -11,7 +11,7 @@ class Message {
   public:
 	typedef std::time_t Time;
 
-	Message(int client_fd);
+	explicit Message(int client_fd);
 	~Message();
 	Message(const Message &other);
 	Message &operator=(const Message &other);

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -19,41 +19,35 @@ MessageManager &MessageManager::operator=(const MessageManager &other) {
 
 void MessageManager::AddNewMessage(int client_fd) {
 	message::Message message(client_fd);
-	messages_.push_back(message);
+	// todo: add logic_error
+	messages_.insert(std::make_pair(client_fd, message));
 }
 
-// todo: map併用して高速化する？
 // Remove one message that matches fd from the beginning of MessageList.
 void MessageManager::DeleteMessage(int client_fd) {
-	typedef MessageList::iterator Itr;
-	for (Itr it = messages_.begin(); it != messages_.end(); ++it) {
-		const message::Message &message = *it;
-		if (message.GetFd() == client_fd) {
-			messages_.erase(it);
-			return;
-		}
-	}
+	messages_.erase(client_fd);
 }
 
-// Look from the beginning of the MessageList,
-// delete all messages that have timed out, and return TimeoutFds list.
+// Delete all messages that have timed out, and return TimeoutFds list.
 // ex)
-//   before: MessageList{3,4,5}
-//   (if timeout fd 3,4)
-//   return: TimeoutFds{3,4}
-//   after : MessageList{5}
+//   before: MessageMap{3,4,5}
+//   (if timeout fd 3,5)
+//   return: TimeoutFds{3,5}
+//   after : MessageMap{4}
 MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
 	TimeoutFds timeout_fds_;
 
-	typedef MessageList::iterator Itr;
-	Itr                           it = messages_.begin();
-	while (it != messages_.end()) {
-		const message::Message &message = *it;
-		if (!message.IsTimeoutExceeded(timeout)) {
-			break;
+	typedef MessageMap::iterator Itr;
+	for (Itr it = messages_.begin(); it != messages_.end();) {
+		const message::Message &message = it->second;
+		if (message.IsTimeoutExceeded(timeout)) {
+			timeout_fds_.push_back(message.GetFd());
+			const Itr it_erase = it;
+			++it;
+			messages_.erase(it_erase);
+			continue;
 		}
-		timeout_fds_.push_back(message.GetFd());
-		it = messages_.erase(it);
+		++it;
 	}
 	return timeout_fds_;
 }
@@ -63,15 +57,10 @@ MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
 //   まだServerからは呼ばれていない、unit testだけある
 // Remove one message from the beginning and add a new message to the end.
 void MessageManager::UpdateMessage(int client_fd) {
-	typedef MessageList::iterator Itr;
-	for (Itr it = messages_.begin(); it != messages_.end(); ++it) {
-		const message::Message &message = *it;
-		if (message.GetFd() == client_fd) {
-			messages_.erase(it);
-			AddNewMessage(client_fd);
-			return;
-		}
-	}
+	// todo: connection keepができたらmessageのstart_time,request_buf更新
+	// todo: 今は削除・新規追加(start_time更新)してるだけ
+	DeleteMessage(client_fd);
+	AddNewMessage(client_fd);
 }
 
 } // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -63,4 +63,24 @@ void MessageManager::UpdateMessage(int client_fd) {
 	AddNewMessage(client_fd);
 }
 
+const std::string &MessageManager::GetRequestBuf(int client_fd) const {
+	const message::Message &message = messages_.at(client_fd);
+	return message.GetRequestBuf();
+}
+
+const std::string &MessageManager::GetResponse(int client_fd) const {
+	const message::Message &message = messages_.at(client_fd);
+	return message.GetResponse();
+}
+
+void MessageManager::SetRequestBuf(int client_fd, const std::string &request_buf) {
+	message::Message &message = messages_.at(client_fd);
+	message.SetRequestBuf(request_buf);
+}
+
+void MessageManager::SetResponse(int client_fd, const std::string &response) {
+	message::Message &message = messages_.at(client_fd);
+	message.SetResponse(response);
+}
+
 } // namespace server

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -22,6 +22,12 @@ class MessageManager {
 	void       DeleteMessage(int client_fd);
 	TimeoutFds GetTimeoutFds(double timeout);
 	void       UpdateMessage(int client_fd);
+	// getter
+	const std::string &GetRequestBuf(int client_fd) const;
+	const std::string &GetResponse(int client_fd) const;
+	// setter
+	void SetRequestBuf(int client_fd, const std::string &request_buf);
+	void SetResponse(int client_fd, const std::string &response);
 
   private:
 	// variable

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -3,14 +3,15 @@
 
 #include "message.hpp"
 #include <list>
+#include <map>
 
 namespace server {
 
 class MessageManager {
   public:
-	// The order in which requests received
-	typedef std::list<message::Message> MessageList;
-	typedef std::list<int>              TimeoutFds;
+	// Message for each fd
+	typedef std::map<int, message::Message> MessageMap;
+	typedef std::list<int>                  TimeoutFds;
 
 	MessageManager();
 	~MessageManager();
@@ -24,7 +25,7 @@ class MessageManager {
 
   private:
 	// variable
-	MessageList messages_;
+	MessageMap messages_;
 };
 
 } // namespace server

--- a/srcs/server/read.cpp
+++ b/srcs/server/read.cpp
@@ -1,14 +1,14 @@
-#include "buffer.hpp"
+#include "read.hpp"
 #include <cstdio>   // perror
 #include <unistd.h> // read
 
 namespace server {
 
-Buffer::Buffer() {}
+Read::Read() {}
 
-Buffer::~Buffer() {}
+Read::~Read() {}
 
-Buffer::ReadResult Buffer::ReadRequest(int client_fd) {
+Read::ReadResult Read::ReadRequest(int client_fd) {
 	ReadResult read_result;
 
 	char    buffer[BUFFER_SIZE];

--- a/srcs/server/read.hpp
+++ b/srcs/server/read.hpp
@@ -1,5 +1,5 @@
-#ifndef SERVER_BUFFER_HPP_
-#define SERVER_BUFFER_HPP_
+#ifndef SERVER_READ_HPP_
+#define SERVER_READ_HPP_
 
 #include "utils.hpp"
 #include <string>
@@ -7,7 +7,7 @@
 
 namespace server {
 
-class Buffer {
+class Read {
   public:
 	struct ReadBuf {
 		ssize_t     read_size;
@@ -19,11 +19,11 @@ class Buffer {
 	static ReadResult ReadRequest(int client_fd);
 
   private:
-	Buffer();
-	~Buffer();
+	Read();
+	~Read();
 	// prohibit copy
-	Buffer(const Buffer &other);
-	Buffer &operator=(const Buffer &other);
+	Read(const Read &other);
+	Read &operator=(const Read &other);
 	// const
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int BUFFER_SIZE  = 1024;
@@ -31,4 +31,4 @@ class Buffer {
 
 } // namespace server
 
-#endif /* SERVER_BUFFER_HPP_ */
+#endif /* SERVER_READ_HPP_ */

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -1,4 +1,5 @@
 #include "server.hpp"
+#include "buffer.hpp"
 #include "client_info.hpp"
 #include "dto_server_to_http.hpp"
 #include "event.hpp"
@@ -156,7 +157,7 @@ DtoServerInfos Server::GetServerInfos(int client_fd) const {
 }
 
 void Server::ReadRequest(int client_fd) {
-	const Buffer::ReadResult read_result = buffers_.ReadRequest(client_fd);
+	const Buffer::ReadResult read_result = Buffer::ReadRequest(client_fd);
 	if (!read_result.IsOk()) {
 		throw std::runtime_error("read failed");
 	}

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -156,11 +156,11 @@ DtoServerInfos Server::GetServerInfos(int client_fd) const {
 }
 
 void Server::ReadRequest(int client_fd) {
-	ssize_t read_ret = buffers_.ReadRequest(client_fd);
-	if (read_ret <= 0) {
-		if (read_ret == SYSTEM_ERROR) {
-			throw std::runtime_error("read failed");
-		}
+	const Buffer::ReadResult read_result = buffers_.ReadRequest(client_fd);
+	if (!read_result.IsOk()) {
+		throw std::runtime_error("read failed");
+	}
+	if (read_result.GetValue().read_size == 0) {
 		// todo: need?
 		// buffers_.Delete(client_fd);
 		// event_monitor_.Delete(client_fd);

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -1,8 +1,8 @@
 #include "server.hpp"
-#include "buffer.hpp"
 #include "client_info.hpp"
 #include "dto_server_to_http.hpp"
 #include "event.hpp"
+#include "read.hpp"
 #include "server_info.hpp"
 #include "utils.hpp"
 #include "virtual_server.hpp"
@@ -157,7 +157,7 @@ DtoServerInfos Server::GetServerInfos(int client_fd) const {
 }
 
 void Server::ReadRequest(int client_fd) {
-	const Buffer::ReadResult read_result = Buffer::ReadRequest(client_fd);
+	const Read::ReadResult read_result = Read::ReadRequest(client_fd);
 	if (!read_result.IsOk()) {
 		throw std::runtime_error("read failed");
 	}

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -184,12 +184,12 @@ void Server::RunHttp(const event::Event &event) {
 	}
 	utils::Debug("server", "received all request from client", client_fd);
 	std::cerr << buffers_.GetRequest(client_fd) << std::endl;
-	buffers_.AddResponse(client_fd, http_result.response);
+	message_manager_.SetResponse(client_fd, http_result.response);
 	event_monitor_.Update(event.fd, event::EVENT_WRITE);
 }
 
 void Server::SendResponse(int client_fd) {
-	const std::string &response = buffers_.GetResponse(client_fd);
+	const std::string &response = message_manager_.GetResponse(client_fd);
 
 	send(client_fd, response.c_str(), response.size(), 0);
 	utils::Debug("server", "send response to client", client_fd);
@@ -212,7 +212,7 @@ void Server::HandleTimeoutMessages() {
 	for (Itr it = timeout_fds.begin(); it != timeout_fds.end(); ++it) {
 		const int          client_fd        = *it;
 		const std::string &timeout_response = mock_http_.GetTimeoutResponse(client_fd);
-		buffers_.AddResponse(client_fd, timeout_response);
+		message_manager_.SetResponse(client_fd, timeout_response);
 		event_monitor_.Update(client_fd, event::EVENT_WRITE);
 	}
 }

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -1,7 +1,6 @@
 #ifndef SERVER_SERVER_HPP_
 #define SERVER_SERVER_HPP_
 
-#include "buffer.hpp"
 #include "config_parse/context.hpp"
 #include "connection.hpp"
 #include "context_manager.hpp"
@@ -53,8 +52,6 @@ class Server {
 	Connection connection_;
 	// event poll
 	epoll::Epoll event_monitor_;
-	// request buffers
-	Buffer buffers_;
 	// http
 	http::MockHttp mock_http_;
 	// message manager with time control


### PR DESCRIPTION

client の request に対する timeout ・関連した構成変更の実装工程の 3
1.  `Message class`, `MessageManager class` 作成
2. `MessageManager class` unit test 追加
3. `Message class` に request_buf と response も持たせる <- この PR はここだけ
4. Connection: keep-alive の実装ができたら？ `send()` 後に `MessageManager` の処理を分ける


## したこと
- `MessageManager class` の Message を list で管理していたのを map に変更
request, response は頻繁に追加・削除・更新が行われると想定されるため。
- `Buffer class` が管理してた `request`, `response` を `MessageManager class` に移動
- `Buffer class` は `Read class` に命名変更 (もっと良いのがあれば…)、static な class に変更


## 実行
挙動に変更はないです
現状全て Connection: close として処理します -> 工程 4 で Connection: keep-alive にも対応予定
```sh
make run
make test
```
MessageManager unit test
```sh
make -C test/unit/message_manager run
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - メッセージの管理を向上させるために、リクエストおよびレスポンスバッファにアクセスするための新しいメソッドを追加しました。
  - メッセージクラスにおけるバッファの取得と設定が可能になりました。

- **バグ修正**
  - クライアントファイルディスクリプタに関連するメッセージの取得と削除のロジックを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->