### PR TITLE
[add] timeout / connection keep-alive の場合, send() 後の処理を分ける

### DIFF
--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -72,8 +72,9 @@ void Epoll::Delete(int socket_fd) {
 }
 
 int Epoll::CreateReadyList() {
-	errno           = 0;
-	const int ready = epoll_wait(epoll_fd_, evlist_, MAX_EVENTS, -1);
+	errno = 0;
+	// todo: set timeout(ms)
+	const int ready = epoll_wait(epoll_fd_, evlist_, MAX_EVENTS, 500);
 
 	if (ready == SYSTEM_ERROR) {
 		if (errno == EINTR) {

--- a/srcs/http/http_result.hpp
+++ b/srcs/http/http_result.hpp
@@ -6,9 +6,10 @@
 namespace http {
 
 struct HttpResult {
-	HttpResult() : is_response_complete(false) {}
+	HttpResult() : is_response_complete(false), is_connection_keep(true) {}
 
 	bool        is_response_complete;
+	bool        is_connection_keep;
 	std::string request_buf;
 	std::string response;
 };

--- a/srcs/http/http_result.hpp
+++ b/srcs/http/http_result.hpp
@@ -9,6 +9,7 @@ struct HttpResult {
 	HttpResult() : is_response_complete(false) {}
 
 	bool        is_response_complete;
+	std::string request_buf;
 	std::string response;
 };
 

--- a/srcs/http/mock_http.cpp
+++ b/srcs/http/mock_http.cpp
@@ -91,6 +91,10 @@ void CreateBody(std::ostream &response_stream, const MockHttp::RequestMessage &r
 	response_stream << request.at(MockHttp::HTTP_CONTENT);
 }
 
+bool IsConnectionKeep(const std::string &buffer) {
+	return buffer.find("Connection: keep-alive\r\n") != std::string::npos;
+}
+
 bool IsRequestReceivedComplete(const std::string &buffer) {
 	return buffer.find("\r\n\r\n") != std::string::npos;
 }
@@ -112,6 +116,7 @@ HttpResult MockHttp::Run(
 	CreateBody(response_stream, this->request_);
 
 	HttpResult result;
+	result.is_connection_keep   = IsConnectionKeep(client_infos.request_buf);
 	result.is_response_complete = IsRequestReceivedComplete(client_infos.request_buf);
 	// parseで使わなかった余り分のrequest_bufを返す
 	result.request_buf = client_infos.request_buf;

--- a/srcs/http/mock_http.cpp
+++ b/srcs/http/mock_http.cpp
@@ -113,7 +113,9 @@ HttpResult MockHttp::Run(
 
 	HttpResult result;
 	result.is_response_complete = IsRequestReceivedComplete(client_infos.request_buf);
-	result.response             = response_stream.str();
+	// parseで使わなかった余り分のrequest_bufを返す
+	result.request_buf = client_infos.request_buf;
+	result.response    = response_stream.str();
 	return result;
 }
 

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -58,8 +58,9 @@ void Message::SetNewRequestBuf(const std::string &request_buf) {
 	request_buf_ = request_buf;
 }
 
-void Message::SetResponse(const std::string &response) {
-	response_ = response;
+void Message::SetResponse(bool is_connection_keep, const std::string &response) {
+	is_connection_keep_ = is_connection_keep;
+	response_           = response;
 }
 
 Message::Time Message::GetCurrentTime() {

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -4,12 +4,12 @@ namespace server {
 namespace message {
 
 Message::Message(int client_fd)
-	: client_fd_(client_fd), start_time_(GetCurrentTime()), is_connection_keep_(true) {}
+	: client_fd_(client_fd), start_time_(GetCurrentTime()), connection_state_(KEEP) {}
 
 Message::Message(int client_fd, const std::string &request_buf)
 	: client_fd_(client_fd),
 	  start_time_(GetCurrentTime()),
-	  is_connection_keep_(true),
+	  connection_state_(KEEP),
 	  request_buf_(request_buf) {}
 
 Message::~Message() {}
@@ -38,8 +38,8 @@ int Message::GetFd() const {
 	return client_fd_;
 }
 
-bool Message::GetIsConnectionKeep() const {
-	return is_connection_keep_;
+ConnectionState Message::GetConnectionState() const {
+	return connection_state_;
 }
 
 const std::string &Message::GetRequestBuf() const {
@@ -58,9 +58,9 @@ void Message::SetNewRequestBuf(const std::string &request_buf) {
 	request_buf_ = request_buf;
 }
 
-void Message::SetResponse(bool is_connection_keep, const std::string &response) {
-	is_connection_keep_ = is_connection_keep;
-	response_           = response;
+void Message::SetResponse(ConnectionState connection_state, const std::string &response) {
+	connection_state_ = connection_state;
+	response_         = response;
 }
 
 Message::Time Message::GetCurrentTime() {

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -33,7 +33,10 @@ Message &Message::operator=(const Message &other) {
 	return *this;
 }
 
-bool Message::IsTimeoutExceeded(double timeout_sec) const {
+bool Message::IsNewTimeoutExceeded(double timeout_sec) const {
+	if (is_timeout_) {
+		return false;
+	}
 	const Time   current_time  = GetCurrentTime();
 	const double diff_time_sec = std::difftime(current_time, start_time_);
 	return diff_time_sec >= timeout_sec;

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -4,11 +4,15 @@ namespace server {
 namespace message {
 
 Message::Message(int client_fd)
-	: client_fd_(client_fd), start_time_(GetCurrentTime()), connection_state_(KEEP) {}
+	: client_fd_(client_fd),
+	  start_time_(GetCurrentTime()),
+	  is_timeout_(false),
+	  connection_state_(KEEP) {}
 
 Message::Message(int client_fd, const std::string &request_buf)
 	: client_fd_(client_fd),
 	  start_time_(GetCurrentTime()),
+	  is_timeout_(false),
 	  connection_state_(KEEP),
 	  request_buf_(request_buf) {}
 
@@ -22,6 +26,7 @@ Message &Message::operator=(const Message &other) {
 	if (this != &other) {
 		client_fd_   = other.client_fd_;
 		start_time_  = other.start_time_;
+		is_timeout_  = other.is_timeout_;
 		request_buf_ = other.request_buf_;
 		response_    = other.response_;
 	}
@@ -52,6 +57,10 @@ const std::string &Message::GetResponse() const {
 
 void Message::AddRequestBuf(const std::string &request_buf) {
 	request_buf_ += request_buf;
+}
+
+void Message::SetTimeout() {
+	is_timeout_ = true;
 }
 
 void Message::SetNewRequestBuf(const std::string &request_buf) {

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -39,9 +39,12 @@ const std::string &Message::GetResponse() const {
 	return response_;
 }
 
-// todo: Httpと繋がったら += ではなく = になる
-void Message::SetRequestBuf(const std::string &request_buf) {
+void Message::AddRequestBuf(const std::string &request_buf) {
 	request_buf_ += request_buf;
+}
+
+void Message::SetNewRequestBuf(const std::string &request_buf) {
+	request_buf_ = request_buf;
 }
 
 void Message::SetResponse(const std::string &response) {

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -3,10 +3,14 @@
 namespace server {
 namespace message {
 
-Message::Message(int client_fd) : client_fd_(client_fd), start_time_(GetCurrentTime()) {}
+Message::Message(int client_fd)
+	: client_fd_(client_fd), start_time_(GetCurrentTime()), is_connection_keep_(true) {}
 
 Message::Message(int client_fd, const std::string &request_buf)
-	: client_fd_(client_fd), start_time_(GetCurrentTime()), request_buf_(request_buf) {}
+	: client_fd_(client_fd),
+	  start_time_(GetCurrentTime()),
+	  is_connection_keep_(true),
+	  request_buf_(request_buf) {}
 
 Message::~Message() {}
 
@@ -32,6 +36,10 @@ bool Message::IsTimeoutExceeded(double timeout_sec) const {
 
 int Message::GetFd() const {
 	return client_fd_;
+}
+
+bool Message::GetIsConnectionKeep() const {
+	return is_connection_keep_;
 }
 
 const std::string &Message::GetRequestBuf() const {

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -5,6 +5,9 @@ namespace message {
 
 Message::Message(int client_fd) : client_fd_(client_fd), start_time_(GetCurrentTime()) {}
 
+Message::Message(int client_fd, const std::string &request_buf)
+	: client_fd_(client_fd), start_time_(GetCurrentTime()), request_buf_(request_buf) {}
+
 Message::~Message() {}
 
 Message::Message(const Message &other) {

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -21,6 +21,7 @@ class Message {
 	void AddRequestBuf(const std::string &request_buf);
 	// getter
 	int                GetFd() const;
+	bool               GetIsConnectionKeep() const;
 	const std::string &GetRequestBuf() const;
 	const std::string &GetResponse() const;
 	// setter
@@ -32,10 +33,9 @@ class Message {
 	// functions
 	static Time GetCurrentTime();
 	// variables
-	int  client_fd_;
-	Time start_time_;
-	// todo: add variables
-	// bool is_connection_keep_;
+	int         client_fd_;
+	Time        start_time_;
+	bool        is_connection_keep_;
 	std::string request_buf_;
 	std::string response_;
 };

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -17,12 +17,13 @@ class Message {
 	Message &operator=(const Message &other);
 	// function
 	bool IsTimeoutExceeded(double timeout_sec) const;
+	void AddRequestBuf(const std::string &request_buf);
 	// getter
 	int                GetFd() const;
 	const std::string &GetRequestBuf() const;
 	const std::string &GetResponse() const;
 	// setter
-	void SetRequestBuf(const std::string &request_buf);
+	void SetNewRequestBuf(const std::string &request_buf);
 	void SetResponse(const std::string &response);
 
   private:

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -12,6 +12,7 @@ class Message {
 	typedef std::time_t Time;
 
 	explicit Message(int client_fd);
+	Message(int client_fd, const std::string &request_buf);
 	~Message();
 	Message(const Message &other);
 	Message &operator=(const Message &other);

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -26,7 +26,7 @@ class Message {
 	const std::string &GetResponse() const;
 	// setter
 	void SetNewRequestBuf(const std::string &request_buf);
-	void SetResponse(const std::string &response);
+	void SetResponse(bool is_connection_keep, const std::string &response);
 
   private:
 	Message();

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -30,6 +30,7 @@ class Message {
 	const std::string &GetRequestBuf() const;
 	const std::string &GetResponse() const;
 	// setter
+	void SetTimeout();
 	void SetNewRequestBuf(const std::string &request_buf);
 	void SetResponse(ConnectionState connection_state, const std::string &response);
 
@@ -40,6 +41,7 @@ class Message {
 	// variables
 	int             client_fd_;
 	Time            start_time_;
+	bool            is_timeout_;
 	ConnectionState connection_state_;
 	std::string     request_buf_;
 	std::string     response_;

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -22,7 +22,7 @@ class Message {
 	Message(const Message &other);
 	Message &operator=(const Message &other);
 	// function
-	bool IsTimeoutExceeded(double timeout_sec) const;
+	bool IsNewTimeoutExceeded(double timeout_sec) const;
 	void AddRequestBuf(const std::string &request_buf);
 	// getter
 	int                GetFd() const;

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -7,6 +7,11 @@
 namespace server {
 namespace message {
 
+enum ConnectionState {
+	KEEP,
+	CLOSE
+};
+
 class Message {
   public:
 	typedef std::time_t Time;
@@ -21,23 +26,23 @@ class Message {
 	void AddRequestBuf(const std::string &request_buf);
 	// getter
 	int                GetFd() const;
-	bool               GetIsConnectionKeep() const;
+	ConnectionState    GetConnectionState() const;
 	const std::string &GetRequestBuf() const;
 	const std::string &GetResponse() const;
 	// setter
 	void SetNewRequestBuf(const std::string &request_buf);
-	void SetResponse(bool is_connection_keep, const std::string &response);
+	void SetResponse(ConnectionState connection_state, const std::string &response);
 
   private:
 	Message();
 	// functions
 	static Time GetCurrentTime();
 	// variables
-	int         client_fd_;
-	Time        start_time_;
-	bool        is_connection_keep_;
-	std::string request_buf_;
-	std::string response_;
+	int             client_fd_;
+	Time            start_time_;
+	ConnectionState connection_state_;
+	std::string     request_buf_;
+	std::string     response_;
 };
 
 } // namespace message

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -34,14 +34,15 @@ void MessageManager::DeleteMessage(int client_fd) {
 	messages_.erase(client_fd);
 }
 
-MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) const {
+MessageManager::TimeoutFds MessageManager::GetNewTimeoutFds(double timeout) {
 	TimeoutFds timeout_fds_;
 
-	typedef MessageMap::const_iterator Itr;
+	typedef MessageMap::iterator Itr;
 	for (Itr it = messages_.begin(); it != messages_.end();) {
-		const message::Message &message = it->second;
-		if (message.IsTimeoutExceeded(timeout)) {
+		message::Message &message = it->second;
+		if (message.IsNewTimeoutExceeded(timeout)) {
 			timeout_fds_.push_back(message.GetFd());
+			message.SetTimeout();
 		}
 		++it;
 	}

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -59,14 +59,14 @@ MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
 }
 
 // todo:
-//   connection keep用。残request_bufなど保持するようになったら変更する。
 //   まだServerからは呼ばれていない、unit testだけある
-// Remove one message from the beginning and add a new message to the end.
+// For Connection: keep-alive
+// Copy only the read_buf from the old message, delete the old message, and add it as a new message.
 void MessageManager::UpdateMessage(int client_fd) {
-	// todo: connection keepができたらmessageのstart_time,request_buf更新
-	// todo: 今は削除・新規追加(start_time更新)してるだけ
+	const message::Message &old_message = messages_.at(client_fd);
+	const std::string       request_buf = old_message.GetRequestBuf();
 	DeleteMessage(client_fd);
-	AddNewMessage(client_fd);
+	AddNewMessage(client_fd, request_buf);
 }
 
 const std::string &MessageManager::GetRequestBuf(int client_fd) const {

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -69,6 +69,11 @@ void MessageManager::UpdateMessage(int client_fd) {
 	AddNewMessage(client_fd, request_buf);
 }
 
+bool MessageManager::GetIsConnectionKeep(int client_fd) const {
+	const message::Message &message = messages_.at(client_fd);
+	return message.GetIsConnectionKeep();
+}
+
 const std::string &MessageManager::GetRequestBuf(int client_fd) const {
 	const message::Message &message = messages_.at(client_fd);
 	return message.GetRequestBuf();

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -58,8 +58,6 @@ MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
 	return timeout_fds_;
 }
 
-// todo:
-//   まだServerからは呼ばれていない、unit testだけある
 // For Connection: keep-alive
 // Copy only the read_buf from the old message, delete the old message, and add it as a new message.
 void MessageManager::UpdateMessage(int client_fd) {

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -34,24 +34,14 @@ void MessageManager::DeleteMessage(int client_fd) {
 	messages_.erase(client_fd);
 }
 
-// Delete all messages that have timed out, and return TimeoutFds list.
-// ex)
-//   before: MessageMap{3,4,5}
-//   (if timeout fd 3,5)
-//   return: TimeoutFds{3,5}
-//   after : MessageMap{4}
-MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) {
+MessageManager::TimeoutFds MessageManager::GetTimeoutFds(double timeout) const {
 	TimeoutFds timeout_fds_;
 
-	typedef MessageMap::iterator Itr;
+	typedef MessageMap::const_iterator Itr;
 	for (Itr it = messages_.begin(); it != messages_.end();) {
 		const message::Message &message = it->second;
 		if (message.IsTimeoutExceeded(timeout)) {
 			timeout_fds_.push_back(message.GetFd());
-			const Itr it_erase = it;
-			++it;
-			messages_.erase(it_erase);
-			continue;
 		}
 		++it;
 	}

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -23,6 +23,12 @@ void MessageManager::AddNewMessage(int client_fd) {
 	messages_.insert(std::make_pair(client_fd, message));
 }
 
+void MessageManager::AddNewMessage(int client_fd, const std::string &request_buf) {
+	message::Message message(client_fd, request_buf);
+	// todo: add logic_error
+	messages_.insert(std::make_pair(client_fd, message));
+}
+
 // Remove one message that matches fd from the beginning of MessageList.
 void MessageManager::DeleteMessage(int client_fd) {
 	messages_.erase(client_fd);

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -73,9 +73,14 @@ const std::string &MessageManager::GetResponse(int client_fd) const {
 	return message.GetResponse();
 }
 
-void MessageManager::SetRequestBuf(int client_fd, const std::string &request_buf) {
+void MessageManager::AddRequestBuf(int client_fd, const std::string &request_buf) {
 	message::Message &message = messages_.at(client_fd);
-	message.SetRequestBuf(request_buf);
+	message.AddRequestBuf(request_buf);
+}
+
+void MessageManager::SetNewRequestBuf(int client_fd, const std::string &request_buf) {
+	message::Message &message = messages_.at(client_fd);
+	message.SetNewRequestBuf(request_buf);
 }
 
 void MessageManager::SetResponse(int client_fd, const std::string &response) {

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -94,9 +94,11 @@ void MessageManager::SetNewRequestBuf(int client_fd, const std::string &request_
 	message.SetNewRequestBuf(request_buf);
 }
 
-void MessageManager::SetResponse(int client_fd, const std::string &response) {
+void MessageManager::SetResponse(
+	int client_fd, bool is_connection_keep, const std::string &response
+) {
 	message::Message &message = messages_.at(client_fd);
-	message.SetResponse(response);
+	message.SetResponse(is_connection_keep, response);
 }
 
 } // namespace server

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -67,9 +67,9 @@ void MessageManager::UpdateMessage(int client_fd) {
 	AddNewMessage(client_fd, request_buf);
 }
 
-bool MessageManager::GetIsConnectionKeep(int client_fd) const {
+message::ConnectionState MessageManager::GetConnectionState(int client_fd) const {
 	const message::Message &message = messages_.at(client_fd);
-	return message.GetIsConnectionKeep();
+	return message.GetConnectionState();
 }
 
 const std::string &MessageManager::GetRequestBuf(int client_fd) const {
@@ -93,10 +93,10 @@ void MessageManager::SetNewRequestBuf(int client_fd, const std::string &request_
 }
 
 void MessageManager::SetResponse(
-	int client_fd, bool is_connection_keep, const std::string &response
+	int client_fd, message::ConnectionState connection_state, const std::string &response
 ) {
 	message::Message &message = messages_.at(client_fd);
-	message.SetResponse(is_connection_keep, response);
+	message.SetResponse(connection_state, response);
 }
 
 } // namespace server

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -30,7 +30,7 @@ class MessageManager {
 	const std::string &GetResponse(int client_fd) const;
 	// setter
 	void SetNewRequestBuf(int client_fd, const std::string &request_buf);
-	void SetResponse(int client_fd, const std::string &response);
+	void SetResponse(int client_fd, bool is_connection_keep, const std::string &response);
 
   private:
 	// variable

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -21,7 +21,7 @@ class MessageManager {
 	void       AddNewMessage(int client_fd);
 	void       AddNewMessage(int client_fd, const std::string &request_buf);
 	void       DeleteMessage(int client_fd);
-	TimeoutFds GetTimeoutFds(double timeout) const;
+	TimeoutFds GetNewTimeoutFds(double timeout);
 	void       UpdateMessage(int client_fd);
 	void       AddRequestBuf(int client_fd, const std::string &request_buf);
 	// getter

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -25,12 +25,14 @@ class MessageManager {
 	void       UpdateMessage(int client_fd);
 	void       AddRequestBuf(int client_fd, const std::string &request_buf);
 	// getter
-	bool               GetIsConnectionKeep(int client_fd) const;
-	const std::string &GetRequestBuf(int client_fd) const;
-	const std::string &GetResponse(int client_fd) const;
+	message::ConnectionState GetConnectionState(int client_fd) const;
+	const std::string       &GetRequestBuf(int client_fd) const;
+	const std::string       &GetResponse(int client_fd) const;
 	// setter
 	void SetNewRequestBuf(int client_fd, const std::string &request_buf);
-	void SetResponse(int client_fd, bool is_connection_keep, const std::string &response);
+	void SetResponse(
+		int client_fd, message::ConnectionState connection_state, const std::string &response
+	);
 
   private:
 	// variable

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -19,6 +19,7 @@ class MessageManager {
 	MessageManager &operator=(const MessageManager &other);
 	// functions
 	void       AddNewMessage(int client_fd);
+	void       AddNewMessage(int client_fd, const std::string &request_buf);
 	void       DeleteMessage(int client_fd);
 	TimeoutFds GetTimeoutFds(double timeout);
 	void       UpdateMessage(int client_fd);

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -25,6 +25,7 @@ class MessageManager {
 	void       UpdateMessage(int client_fd);
 	void       AddRequestBuf(int client_fd, const std::string &request_buf);
 	// getter
+	bool               GetIsConnectionKeep(int client_fd) const;
 	const std::string &GetRequestBuf(int client_fd) const;
 	const std::string &GetResponse(int client_fd) const;
 	// setter

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -21,7 +21,7 @@ class MessageManager {
 	void       AddNewMessage(int client_fd);
 	void       AddNewMessage(int client_fd, const std::string &request_buf);
 	void       DeleteMessage(int client_fd);
-	TimeoutFds GetTimeoutFds(double timeout);
+	TimeoutFds GetTimeoutFds(double timeout) const;
 	void       UpdateMessage(int client_fd);
 	void       AddRequestBuf(int client_fd, const std::string &request_buf);
 	// getter

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -22,11 +22,12 @@ class MessageManager {
 	void       DeleteMessage(int client_fd);
 	TimeoutFds GetTimeoutFds(double timeout);
 	void       UpdateMessage(int client_fd);
+	void       AddRequestBuf(int client_fd, const std::string &request_buf);
 	// getter
 	const std::string &GetRequestBuf(int client_fd) const;
 	const std::string &GetResponse(int client_fd) const;
 	// setter
-	void SetRequestBuf(int client_fd, const std::string &request_buf);
+	void SetNewRequestBuf(int client_fd, const std::string &request_buf);
 	void SetResponse(int client_fd, const std::string &response);
 
   private:

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -188,7 +188,7 @@ void Server::RunHttp(const event::Event &event) {
 	}
 	utils::Debug("server", "received all request from client", client_fd);
 	std::cerr << message_manager_.GetRequestBuf(client_fd) << std::endl;
-	message_manager_.SetResponse(client_fd, http_result.response);
+	message_manager_.SetResponse(client_fd, http_result.is_connection_keep, http_result.response);
 	event_monitor_.Update(event.fd, event::EVENT_WRITE);
 }
 
@@ -216,7 +216,8 @@ void Server::HandleTimeoutMessages() {
 	for (Itr it = timeout_fds.begin(); it != timeout_fds.end(); ++it) {
 		const int          client_fd        = *it;
 		const std::string &timeout_response = mock_http_.GetTimeoutResponse(client_fd);
-		message_manager_.SetResponse(client_fd, timeout_response);
+		// todo: closeなのでfalse. enumにする
+		message_manager_.SetResponse(client_fd, false, timeout_response);
 		event_monitor_.Update(client_fd, event::EVENT_WRITE);
 	}
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -220,7 +220,8 @@ void Server::SendResponse(int client_fd) {
 
 void Server::HandleTimeoutMessages() {
 	// timeoutした全fdを取得
-	const MessageManager::TimeoutFds &timeout_fds = message_manager_.GetTimeoutFds(REQUEST_TIMEOUT);
+	const MessageManager::TimeoutFds &timeout_fds =
+		message_manager_.GetNewTimeoutFds(REQUEST_TIMEOUT);
 
 	// timeout用のresponseをセットしてevent監視をWRITEに変更
 	typedef MessageManager::TimeoutFds::const_iterator Itr;

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -167,7 +167,7 @@ void Server::ReadRequest(int client_fd) {
 		// event_monitor_.Delete(client_fd);
 		return;
 	}
-	message_manager_.SetRequestBuf(client_fd, read_result.GetValue().read_buf);
+	message_manager_.AddRequestBuf(client_fd, read_result.GetValue().read_buf);
 }
 
 void Server::RunHttp(const event::Event &event) {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -179,6 +179,8 @@ void Server::RunHttp(const event::Event &event) {
 	DebugDto(client_infos, server_infos);
 
 	http::HttpResult http_result = mock_http_.Run(client_infos, server_infos);
+	// Set the unused request_buf in Http.
+	message_manager_.SetNewRequestBuf(client_fd, http_result.request_buf);
 	// Check if it's ready to start write/send.
 	// If not completed, the request will be re-read by the event_monitor.
 	if (!http_result.is_response_complete) {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -198,6 +198,7 @@ void Server::RunHttp(const event::Event &event) {
 void Server::SendResponse(int client_fd) {
 	const std::string &response = message_manager_.GetResponse(client_fd);
 
+	// todo: handle return size
 	send(client_fd, response.c_str(), response.size(), 0);
 	utils::Debug("server", "send response to client", client_fd);
 
@@ -228,6 +229,7 @@ void Server::HandleTimeoutMessages() {
 		const std::string &timeout_response = mock_http_.GetTimeoutResponse(client_fd);
 		message_manager_.SetResponse(client_fd, message::CLOSE, timeout_response);
 		event_monitor_.Update(client_fd, event::EVENT_WRITE);
+		utils::Debug("server", "timeout client", client_fd);
 	}
 }
 

--- a/test/client/client.cpp
+++ b/test/client/client.cpp
@@ -30,9 +30,9 @@ void Client::SendRequestAndReceiveResponse(const std::string &message) {
 	send(sock_fd_, message.c_str(), message.size(), 0);
 	DebugPrint("Message sent.");
 
+	DebugPrint("Response from server:");
 	// receive response
-	char        buffer[BUFFER_SIZE];
-	std::string response;
+	char buffer[BUFFER_SIZE];
 	while (true) {
 		ssize_t read_ret = read(sock_fd_, buffer, BUFFER_SIZE);
 		if (read_ret == SYSTEM_ERROR) {
@@ -41,10 +41,9 @@ void Client::SendRequestAndReceiveResponse(const std::string &message) {
 		if (read_ret == 0) {
 			break;
 		}
-		response.append(std::string(buffer, read_ret));
+		const std::string response = std::string(buffer, read_ret);
+		std::cout << response << std::endl;
 	}
-	DebugPrint("Response from server:");
-	std::cout << response << std::endl;
 }
 
 void Client::Init() {

--- a/test/request_messages/apache_root/get/400_connection-keep_no-CRLF_no-content.txt
+++ b/test/request_messages/apache_root/get/400_connection-keep_no-CRLF_no-content.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5

--- a/test/request_messages/apache_root/get/408_connection-keep_CRLF_no-content.txt
+++ b/test/request_messages/apache_root/get/408_connection-keep_CRLF_no-content.txt
@@ -1,0 +1,7 @@
+GET / HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 5
+
+

--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -206,6 +206,37 @@ int RunTestUpdateMessage() {
 	return ret_code;
 }
 
+int RunTestDeleteMessage() {
+	int ret_code = EXIT_SUCCESS;
+
+	server::MessageManager manager;
+	TimeoutFds             expected_timeout_fds;
+
+	// time(0), add fd: 4,5
+	manager.AddNewMessage(4);
+	manager.AddNewMessage(5);
+
+	// time(0), delete fd: 5
+	manager.DeleteMessage(5);
+
+	// time(0), GetNewTimeoutFds: {}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test6
+
+	sleep(3);
+	// time(3), timeout fd: 4
+	expected_timeout_fds.push_back(4);
+
+	sleep(1);
+	// time(4), GetNewTimeoutFds: {4}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test7
+	expected_timeout_fds.clear();
+
+	// time(4), GetNewTimeoutFds: {}
+	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test8
+
+	return ret_code;
+}
+
 } // namespace
 
 int main() {
@@ -213,6 +244,7 @@ int main() {
 
 	ret_code |= RunTestGetTimeoutFds();
 	ret_code |= RunTestUpdateMessage();
+	ret_code |= RunTestDeleteMessage();
 
 	return ret_code;
 }

--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -81,7 +81,7 @@ RunIsSameTimeoutFds(server::MessageManager &manager, const TimeoutFds &expected_
 	Result             result;
 	std::ostringstream oss;
 
-	const TimeoutFds &timeout_fds = manager.GetTimeoutFds(REQUEST_TIMEOUT);
+	const TimeoutFds &timeout_fds = manager.GetNewTimeoutFds(REQUEST_TIMEOUT);
 	if (!IsSame(timeout_fds, expected_timeout_fds)) {
 		result.is_success = false;
 		oss << "timeout_fds" << std::endl;
@@ -93,10 +93,10 @@ RunIsSameTimeoutFds(server::MessageManager &manager, const TimeoutFds &expected_
 }
 
 // -----------------------------------------------------------------------------
-// add fd         : 4 5         6
-// timeout(3s)    :       4 5         6
-// current time   : 0 1 2 3 4 5 6 7 8 9 10
-// GetTimeoutFds():           *   *     *
+// add fd            : 4 5         6
+// timeout(3s)       :       4 5         6
+// current time      : 0 1 2 3 4 5 6 7 8 9 10
+// GetNewTimeoutFds():           *   *     *
 // -----------------------------------------------------------------------------
 int RunTestGetTimeoutFds() {
 	int ret_code = EXIT_SUCCESS;
@@ -120,7 +120,7 @@ int RunTestGetTimeoutFds() {
 	expected_timeout_fds.push_back(5);
 
 	sleep(1);
-	// time(5), GetTimeoutFds: {4, 5}
+	// time(5), GetNewTimeoutFds: {4, 5}
 	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test1
 	expected_timeout_fds.clear();
 
@@ -129,7 +129,7 @@ int RunTestGetTimeoutFds() {
 	manager.AddNewMessage(6);
 
 	sleep(1);
-	// time(7), GetTimeoutFds: {}
+	// time(7), GetNewTimeoutFds: {}
 	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test2
 
 	sleep(3);
@@ -137,24 +137,24 @@ int RunTestGetTimeoutFds() {
 	expected_timeout_fds.push_back(6);
 
 	sleep(1);
-	// time(10), GetTimeoutFds: {6}
+	// time(10), GetNewTimeoutFds: {6}
 	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test3
 
 	return ret_code;
 }
 
 // -----------------------------------------------------------------------------
-// add fd         : 4 5       6
-// timeout(3s)    :       4 5       6
-// current time   : 0 1 2 3 4 5 6 7 8
-// UpdateMessage():               *
+// add fd            : 4 5       6
+// timeout(3s)       :       4 5       6
+// current time      : 0 1 2 3 4 5 6 7 8
+// UpdateMessage()   :               *
 // -----------------------------------------------------------------------------
 //       ↓ 古い5削除&5新規追加
 // -----------------------------------------------------------------------------
-// add fd         : 4         6   5
-// timeout(3s)    :       4         6   5
-// current time   : 0 1 2 3 4 5 6 7 8 9 10 11
-// GetTimeoutFds():                   *    *
+// add fd            : 4         6   5
+// timeout(3s)       :       4         6   5
+// current time      : 0 1 2 3 4 5 6 7 8 9 10 11
+// GetNewTimeoutFds():                   *    *
 // -----------------------------------------------------------------------------
 int RunTestUpdateMessage() {
 	int ret_code = EXIT_SUCCESS;
@@ -191,7 +191,7 @@ int RunTestUpdateMessage() {
 	expected_timeout_fds.push_back(6);
 
 	sleep(1);
-	// time(9), GetTimeoutFds: {4, 6}
+	// time(9), GetNewTimeoutFds: {4, 6}
 	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test4
 	expected_timeout_fds.clear();
 
@@ -200,7 +200,7 @@ int RunTestUpdateMessage() {
 	expected_timeout_fds.push_back(5);
 
 	sleep(1);
-	// time(11), GetTimeoutFds: {5}
+	// time(11), GetNewTimeoutFds: {5}
 	ret_code |= Test(RunIsSameTimeoutFds(manager, expected_timeout_fds)); // test5
 
 	return ret_code;


### PR DESCRIPTION
PR #308 merge 後に main merge

---
client の request に対する timeout ・関連した構成変更の実装工程の 4
1.  `Message class`, `MessageManager class` 作成
2. `MessageManager class` unit test 追加
3. `Message class` に request_buf と response も持たせる
4. Connection: keep-alive かどうかが Http から返ってきたとして、 `send()` 後に `MessageManager` の処理を分ける <- この PR はここだけ


## したこと
- mock_http が簡易的に `is_connection_keep` を設定するようにし、`Server` はその `ConnectionState` を見て `send()` 後の処理を分けるようにしました
- 今までは MessageManager class の機能として時間順に並ぶ list を使っていましたが、map に変更してみています
-> 理由：timeout と分かってから実際に timeout response を送り返すまで response を保持しておく必要があったので、list から pop_front すれば良いというのは使えなくなりました。 send 待ち list を別で作る、という方法もありますが、timeout message を検索するのにかかる処理の時間よりも通常の message の送受信に使う検索の処理が速い方が良いかと思い、map を使ってみました)

迷い中
- timeout 判定された message は分けて保持した方が良いのかも？と悩み中です、変更の可能性あり。本当は MessageManager は timeout してる message を全部返し、Server 側が既に timeout response をセットしたものか新規 timeout message なのかを管理した方が良いのか…？とか思ったり

## 実行
まだ Http class と繋げてないため apache と挙動は違うのですが、この PR で達成したいことは以下の 2 つです
```sh
# webserv
make run

# client
cd test/client

# まだ complete request が来ていない場合
make run PORT=8080 INFILE_PATH=../request_messages/apache_root/get/400_connection-keep_no-CRLF_no-content.txt
# 現 PR の期待 : timeout 秒経過後、仮の 408 timeout response が返ってくる

# complete request が Connection: keep-alive で来た後、次の request が送られてこず timeout 秒経過した場合
make run PORT=8080 INFILE_PATH=../request_messages/apache_root/get/408_connection-keep_CRLF_no-content.txt 
# 現 PR の期待 : 200 OK response の後、timeout 秒経過後、仮の 408 timeout response が返ってくる
```

unit test は挙動変わってないです
```sh
make -C test/unit/message_manager run
```

## 今後
- 既に timeout / error の response が設定されている場合に通常の response を作成しないようにする
- timeout の挙動を決める
- error 時の response 

<br>
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- HTTPリクエストの接続管理を改善し、リクエストバッファの取り扱いを柔軟にしました。
	- 新たに接続状態を管理する機能が追加され、応答処理が強化されました。
	- 新しいHTTPリクエストメッセージのテストケースが追加され、接続の持続性を確認します。

- **バグ修正**
	- 特定のリクエストハンドリングのロジックが改善され、サーバーの応答の正確性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->