### PR TITLE
[add] ConfigParserのディレクティブ追加

### DIFF
--- a/srcs/config_parse/context.hpp
+++ b/srcs/config_parse/context.hpp
@@ -14,7 +14,7 @@ struct LocationCon {
 	bool                                 autoindex;
 	std::list<std::string>               allowed_methods;
 	std::pair<unsigned int, std::string> redirect;         // cannot use return
-	std::list<std::string>               cgi_extension;    // not implement
+	std::string                          cgi_extension;    // not implement
 	std::string                          upload_directory; // not implement
 	LocationCon() : autoindex(false) {}
 };

--- a/srcs/config_parse/context.hpp
+++ b/srcs/config_parse/context.hpp
@@ -13,9 +13,9 @@ struct LocationCon {
 	std::string                          index;
 	bool                                 autoindex;
 	std::list<std::string>               allowed_methods;
-	std::pair<unsigned int, std::string> redirect;         // cannot use return
-	std::string                          cgi_extension;    // not implement
-	std::string                          upload_directory; // not implement
+	std::pair<unsigned int, std::string> redirect; // cannot use return
+	std::string                          cgi_extension;
+	std::string                          upload_directory;
 	LocationCon() : autoindex(false) {}
 };
 

--- a/srcs/config_parse/directive_names.hpp
+++ b/srcs/config_parse/directive_names.hpp
@@ -43,8 +43,6 @@ extern const std::size_t SIZE_OF_VALID_ALLOWED_METHODS;
 /**
  * @brief Directive in Location Context for CGI
  * @details Dir_name args;
- *
- * @note Not Implemented yet
  */
 
 extern const std::string CGI_EXTENSION;

--- a/srcs/config_parse/lexer.cpp
+++ b/srcs/config_parse/lexer.cpp
@@ -34,13 +34,13 @@ void Lexer::InitDefinition() {
 	directive_.push_back(ERROR_PAGE);
 	directive_.push_back(CLIENT_MAX_BODY_SIZE);
 
+	directive_.push_back(ALIAS);
+	directive_.push_back(INDEX);
+	directive_.push_back(AUTO_INDEX);
 	directive_.push_back(ALLOWED_METHODS);
 	directive_.push_back(RETURN);
-	directive_.push_back(ALIAS);
-	directive_.push_back(AUTO_INDEX);
-	directive_.push_back(INDEX);
-
-	// CGI未実装
+	directive_.push_back(CGI_EXTENSION);
+	directive_.push_back(UPLOAD_DIR);
 }
 
 void Lexer::LexBuffer() {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -105,7 +105,8 @@ void Parser::HandleListen(context::PortList &port, NodeItr &it) {
 		throw std::runtime_error("invalid number of arguments in 'listen' directive");
 	}
 	utils::Result<unsigned int> port_number = utils::ConvertStrToUint((*it).token);
-	if (!port_number.IsOk() || port_number.GetValue() < 1024 || port_number.GetValue() > 65535) {
+	if (!port_number.IsOk() || port_number.GetValue() < PORT_MIN ||
+		port_number.GetValue() > PORT_MAX) {
 		throw std::runtime_error("invalid port number for ports");
 	} else if (FindDuplicated(port, port_number.GetValue())) {
 		throw std::runtime_error("a duplicated parameter in 'listen' directive");
@@ -134,7 +135,8 @@ void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, N
 	NodeItr tmp_it = it; // 404
 	it++;                // /404.html
 	utils::Result<unsigned int> status_code = utils::ConvertStrToUint((*tmp_it).token);
-	if (!status_code.IsOk() || status_code.GetValue() < 100 || status_code.GetValue() > 599) {
+	if (!status_code.IsOk() || status_code.GetValue() < STATUS_CODE_MIN ||
+		status_code.GetValue() > STATUS_CODE_MAX) {
 		throw std::runtime_error("invalid status code for error_page");
 	}
 	error_page = std::make_pair(status_code.GetValue(), (*it).token);
@@ -249,7 +251,8 @@ void Parser::HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeIt
 	NodeItr tmp_it = it; // 302
 	it++;                // /index.html
 	utils::Result<unsigned int> status_code = utils::ConvertStrToUint((*tmp_it).token);
-	if (!status_code.IsOk() || status_code.GetValue() < 100 || status_code.GetValue() > 599) {
+	if (!status_code.IsOk() || status_code.GetValue() < STATUS_CODE_MIN ||
+		status_code.GetValue() > STATUS_CODE_MAX) {
 		throw std::runtime_error("invalid status code for return");
 	}
 	redirect = std::make_pair(status_code.GetValue(), (*it).token);

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -118,9 +118,7 @@ void Parser::HandleListen(std::string &host, context::PortList &port, NodeItr &i
 	}
 	// for listen localhost:8080
 	std::vector<std::string> host_port = utils::SplitStr((*it).token, ":");
-	if (host_port.size() != 2) {
-		throw std::runtime_error("invalid number of arguments in 'listen' directive");
-	}
+	// 2個ないときは他の部分で例外が投げられる
 	utils::Result<unsigned int> port_number = utils::ConvertStrToUint(host_port[1]);
 	if (host_port[0] == "" || !port_number.IsOk() || port_number.GetValue() < PORT_MIN ||
 		port_number.GetValue() > PORT_MAX) {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -192,7 +192,12 @@ void Parser::HandleLocationContextDirective(context::LocationCon &location, Node
 		HandleAllowedMethods(location.allowed_methods, ++it);
 	} else if ((*it).token == RETURN) {
 		HandleReturn(location.redirect, ++it);
+	} else if ((*it).token == CGI_EXTENSION) {
+		HandleCgiExtension(location.cgi_extension, ++it);
+	} else if ((*it).token == UPLOAD_DIR) {
+		HandleUploadDirectory(location.upload_directory, ++it);
 	}
+
 	if ((*it).token_type != node::DELIM) {
 		throw std::runtime_error("expect ';' after arguments");
 	}
@@ -249,6 +254,20 @@ void Parser::HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeIt
 	}
 	redirect = std::make_pair(status_code.GetValue(), (*it).token);
 	++it;
+}
+
+void Parser::HandleCgiExtension(std::string &cgi_extension, NodeItr &it) {
+	if ((*it).token_type != node::WORD) {
+		throw std::runtime_error("invalid arguments in 'cgi_extension' directive");
+	}
+	cgi_extension = (*it++).token;
+}
+
+void Parser::HandleUploadDirectory(std::string &upload_directory, NodeItr &it) {
+	if ((*it).token_type != node::WORD) {
+		throw std::runtime_error("invalid arguments in 'upload_directory' directive");
+	}
+	upload_directory = (*it++).token;
 }
 
 std::list<context::ServerCon> Parser::GetServers() const {

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -47,6 +47,8 @@ class Parser {
 	void HandleAutoIndex(bool &autoindex, NodeItr &it);
 	void HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeItr &it);
 	void HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeItr &it);
+	void HandleCgiExtension(std::string &cgi_extension, NodeItr &it);
+	void HandleUploadDirectory(std::string &upload_directory, NodeItr &it);
 
   public:
 	explicit Parser(std::list<node::Node> &);

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -34,7 +34,7 @@ class Parser {
 	 */
 
 	void HandleServerName(std::list<std::string> &server_names, NodeItr &it);
-	void HandleListen(context::PortList &ports, NodeItr &it);
+	void HandleListen(std::string &host, context::PortList &port, NodeItr &it);
 	void HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it);
 	void HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it);
 

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -50,6 +50,11 @@ class Parser {
 	void HandleCgiExtension(std::string &cgi_extension, NodeItr &it);
 	void HandleUploadDirectory(std::string &upload_directory, NodeItr &it);
 
+	static const int PORT_MIN        = 1024;
+	static const int PORT_MAX        = 65535;
+	static const int STATUS_CODE_MIN = 100;
+	static const int STATUS_CODE_MAX = 599;
+
   public:
 	explicit Parser(std::list<node::Node> &);
 	~Parser();

--- a/test/unit/config_parse/Makefile
+++ b/test/unit/config_parse/Makefile
@@ -17,7 +17,8 @@ SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
 					$(WS_UTILS_DIR)/color.cpp \
 					$(WS_UTILS_DIR)/convert_str.cpp \
-					$(WS_UTILS_DIR)/isdigit.cpp
+					$(WS_UTILS_DIR)/isdigit.cpp \
+					$(WS_UTILS_DIR)/split_str.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_config.cpp

--- a/test/unit/config_parse/parser/Makefile
+++ b/test/unit/config_parse/parser/Makefile
@@ -16,7 +16,8 @@ SRCS			+=	$(WS_CONFIG_PARSE_DIR)/parser.cpp \
 					$(WS_CONFIG_PARSE_DIR)/directive_names.cpp \
 					$(WS_UTILS_DIR)/color.cpp \
 					$(WS_UTILS_DIR)/convert_str.cpp \
-					$(WS_UTILS_DIR)/isdigit.cpp
+					$(WS_UTILS_DIR)/isdigit.cpp \
+					$(WS_UTILS_DIR)/split_str.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_config_parser.cpp

--- a/test/unit/config_parse/test_config.cpp
+++ b/test/unit/config_parse/test_config.cpp
@@ -429,6 +429,34 @@ ServerList MakeExpectedTest8() {
 	return expected_result;
 }
 
+/* Test9 Additional Directives (host, cgi_extension, upload_dir) */
+ServerList MakeExpectedTest9() {
+	ServerList              expected_result;
+	std::list<unsigned int> expected_ports_1;
+	expected_ports_1.push_back(4242);
+	expected_ports_1.push_back(8080);
+	std::list<std::string> server_names_1;
+	server_names_1.push_back("localhost");
+	LocationList           expected_locationlist_1;
+	std::list<std::string> allowed_methods_1;
+	allowed_methods_1.push_back("GET");
+	allowed_methods_1.push_back("POST");
+	std::pair<unsigned int, std::string> redirect_1(302, "/redirect.html");
+	context::LocationCon                 expected_location_1_1 =
+		BuildLocationCon("/", "/data/", "index.html", true, allowed_methods_1, redirect_1);
+	expected_location_1_1.cgi_extension    = ".php"; // tmp(Builderに追加したい)
+	expected_location_1_1.upload_directory = "/tmp"; // tmp(Builderに追加したい)
+	expected_locationlist_1.push_back(expected_location_1_1);
+	std::pair<unsigned int, std::string> error_page_1(404, "/404.html");
+	context::ServerCon                   expected_server_1 = BuildServerCon(
+        expected_ports_1, server_names_1, expected_locationlist_1, 2024, error_page_1
+    );
+	expected_server_1.host = "localhost"; // tmp(Builderに追加したい)
+	expected_result.push_back(expected_server_1);
+
+	return expected_result;
+}
+
 } // namespace
 
 int main() {
@@ -443,6 +471,7 @@ int main() {
 	ret_code |= Test(Run("test_file/test6.conf", MakeExpectedTest6()), "test_file/test6.conf");
 	ret_code |= Test(Run("test_file/test7.conf", MakeExpectedTest7()), "test_file/test7.conf");
 	ret_code |= Test(Run("test_file/test8.conf", MakeExpectedTest8()), "test_file/test8.conf");
+	ret_code |= Test(Run("test_file/test9.conf", MakeExpectedTest9()), "test_file/test9.conf");
 
 	std::cout << std::endl;
 	std::cout << "Error Tests" << std::endl;

--- a/test/unit/config_parse/test_file/test9.conf
+++ b/test/unit/config_parse/test_file/test9.conf
@@ -1,0 +1,16 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}


### PR DESCRIPTION
## ConfigParserの機能を追加しました

テストケースはTest9だけで順次追加していきます。

- [x] host:port 
- [x] cgi_extension, upload_dir
- [x] port, status_codeの範囲を定数に

upload_dirは課題の

> Make the route able to accept uploaded files and configure where they should be saved.

に対応した部分です。

課題

> Choose the port and host of each ’server’.

と

> Your server must be able to listen to multiple ports (see Configuration file).

両方に対応するために

```
server {
	listen localhost:4242;
	listen 8080;
}
```
みたいに書かれる想定です。

## Further
- [ ] ディレクティブ自体の個数のチェックも追加(値がセットされてたら弾く？)
- [ ] サーバーとの統合
- [ ] HttpServerInfoCheckとの統合

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - カスタムイテレータとコンテナを追加し、イテレーションの動作を柔軟に制御可能に。
  - 許可されるHTTPメソッドを定義し、リクエストの検証を強化。
  - CGI拡張子とアップロードディレクトリの設定をサポート。

- **バグ修正**
  - ポート番号のデータ型を変更し、負の値を防止。

- **ドキュメント**
  - テストのための新しい設定ファイルを追加し、エラーハンドリングを強化。

- **テスト**
  - カスタムイテレータの単体テストを追加し、正常時とエラー時の動作を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->