### PR TITLE
[update] config_directiveの重複をチェック

### DIFF
--- a/srcs/config_parse/context.hpp
+++ b/srcs/config_parse/context.hpp
@@ -23,7 +23,7 @@ typedef std::list<unsigned int> PortList;
 typedef std::list<LocationCon>  LocationList;
 
 struct ServerCon {
-	std::string                          host; // not implement
+	std::string                          host;
 	PortList                             port;
 	std::list<std::string>               server_names;
 	LocationList                         location_con;

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -3,7 +3,6 @@
 #include "result.hpp"
 #include "utils.hpp"
 #include <algorithm>
-#include <cstdlib> // atoi
 #include <stdexcept>
 
 namespace config {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -125,12 +125,16 @@ void Parser::HandleListen(std::string &host, context::PortList &port, NodeItr &i
 	} else if (FindDuplicated(port, port_number.GetValue())) {
 		throw std::runtime_error("a duplicated parameter in 'listen' directive");
 	}
+    if (host != "") {
+        throw std::runtime_error("'host' directive is duplicated");
+    }
 	host = host_port[0];
 	port.push_back(port_number.GetValue());
 	++it;
 }
 
 void Parser::HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr &it) {
+    static int count = 0; // こうするしかない？
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid number of arguments in 'client_max_body_size' directive");
 	}
@@ -138,8 +142,12 @@ void Parser::HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr 
 	if (!body_max_size.IsOk()) { // check range?
 		throw std::runtime_error("invalid client_max_body_size");
 	}
+    if (count != 0) {
+        throw std::runtime_error("'client_max_body_size' directive is duplicated");
+    }
 	client_max_body_size = body_max_size.GetValue();
 	++it;
+    ++count;
 }
 
 void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, NodeItr &it) {
@@ -154,6 +162,9 @@ void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, N
 		status_code.GetValue() > STATUS_CODE_MAX) {
 		throw std::runtime_error("invalid status code for error_page");
 	}
+    if (error_page.second != "") {
+        throw std::runtime_error("'error_page' directive is duplicated");
+    }
 	error_page = std::make_pair(status_code.GetValue(), (*it).token);
 	++it;
 }
@@ -224,6 +235,9 @@ void Parser::HandleAlias(std::string &alias, NodeItr &it) {
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid number of arguments in 'alias' directive");
 	}
+    if (alias != "") {
+        throw std::runtime_error("'alias' directive is duplicated");
+    }
 	alias = (*it++).token;
 }
 
@@ -231,17 +245,28 @@ void Parser::HandleIndex(std::string &index, NodeItr &it) {
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid number of arguments in 'index' directive");
 	}
+    if (index != "") {
+        throw std::runtime_error("'index' directive is duplicated");
+    }
 	index = (*it++).token;
 }
 
 void Parser::HandleAutoIndex(bool &autoindex, NodeItr &it) {
+    static int count = 0; // こうするしかない？
 	if ((*it).token_type != node::WORD || ((*it).token != "on" && (*it).token != "off")) {
 		throw std::runtime_error("invalid arguments in 'autoindex' directive");
 	}
+    if (count != 0) {
+        throw std::runtime_error("'autoindex' directive is duplicated");
+    }
 	autoindex = ((*it++).token == "on");
+    ++count;
 }
 
 void Parser::HandleAllowedMethods(std::list<std::string> &allowed_methods, NodeItr &it) {
+    if (allowed_methods.size() != 0) {
+        throw std::runtime_error("'allowed_methods' directive is duplicated");
+    }
 	while ((*it).token_type != node::DELIM && (*it).token_type == node::WORD) {
 		if (FindDuplicated(allowed_methods, (*it).token)) {
 			throw std::runtime_error("a duplicated parameter in 'allowed_methods' directive");
@@ -262,6 +287,9 @@ void Parser::HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeIt
 	if ((*it).token_type != node::WORD || (*++NodeItr(it)).token_type != node::WORD) {
 		throw std::runtime_error("invalid number of arguments in 'return' directive");
 	}
+    if (redirect.second != "") {
+        throw std::runtime_error("'return' directive is duplicated");
+    }
 	// ex. 302 /index.html, tmp: atoi
 	NodeItr tmp_it = it; // 302
 	it++;                // /index.html
@@ -278,6 +306,9 @@ void Parser::HandleCgiExtension(std::string &cgi_extension, NodeItr &it) {
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid arguments in 'cgi_extension' directive");
 	}
+    if (cgi_extension != "") {
+        throw std::runtime_error("'cgi_extension' directive is duplicated");
+    }
 	cgi_extension = (*it++).token;
 }
 
@@ -285,6 +316,9 @@ void Parser::HandleUploadDirectory(std::string &upload_directory, NodeItr &it) {
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid arguments in 'upload_directory' directive");
 	}
+    if (upload_directory != "") {
+        throw std::runtime_error("'upload_directory' directive is duplicated");
+    }
 	upload_directory = (*it++).token;
 }
 

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -55,6 +55,10 @@ class Parser {
 	static const int STATUS_CODE_MIN = 100;
 	static const int STATUS_CODE_MAX = 599;
 
+	/* For duplicated parameter */
+	bool client_max_body_size_set;
+	bool autoindex_set;
+
   public:
 	explicit Parser(std::list<node::Node> &);
 	~Parser();

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -52,7 +52,7 @@ class Parser {
 
 	static const int PORT_MIN        = 1024;
 	static const int PORT_MAX        = 65535;
-	static const int STATUS_CODE_MIN = 100;
+	static const int STATUS_CODE_MIN = 300;
 	static const int STATUS_CODE_MAX = 599;
 
 	/* For duplicated parameter */

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -5,6 +5,7 @@
 #include "custom_const_iterator.hpp"
 #include "node.hpp"
 #include <list>
+#include <set>
 
 namespace config {
 namespace parser {
@@ -56,8 +57,9 @@ class Parser {
 	static const int STATUS_CODE_MAX = 599;
 
 	/* For duplicated parameter */
-	bool client_max_body_size_set;
-	bool autoindex_set;
+	typedef std::set<std::string> DirectiveSet;
+	DirectiveSet                  server_directive_set_;
+	DirectiveSet                  location_directive_set_;
 
   public:
 	explicit Parser(std::list<node::Node> &);

--- a/test/config/conf_file/success/single_server_ok1.conf
+++ b/test/config/conf_file/success/single_server_ok1.conf
@@ -6,7 +6,6 @@ events {
 http {
     server {
         listen       8080;
-        listen       8080;
         server_name  localhost;
     }
 }

--- a/test/unit/config_parse/test_config.cpp
+++ b/test/unit/config_parse/test_config.cpp
@@ -533,6 +533,36 @@ int main() {
 	ret_code |= RunErrorTest(
 		"test_file_error/error_test19.conf", expected, "test_file_error/error_test19.conf"
 	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test20.conf", expected, "test_file_error/error_test20.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test21.conf", expected, "test_file_error/error_test21.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test22.conf", expected, "test_file_error/error_test22.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test23.conf", expected, "test_file_error/error_test23.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test24.conf", expected, "test_file_error/error_test24.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test25.conf", expected, "test_file_error/error_test25.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test26.conf", expected, "test_file_error/error_test26.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test27.conf", expected, "test_file_error/error_test27.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test28.conf", expected, "test_file_error/error_test28.conf"
+	);
+	ret_code |= RunErrorTest(
+		"test_file_error/error_test29.conf", expected, "test_file_error/error_test29.conf"
+	);
 
 	return ret_code;
 }

--- a/test/unit/config_parse/test_file_error/error_test20.conf
+++ b/test/unit/config_parse/test_file_error/error_test20.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen localhost:4243;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test21.conf
+++ b/test/unit/config_parse/test_file_error/error_test21.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test22.conf
+++ b/test/unit/config_parse/test_file_error/error_test22.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test23.conf
+++ b/test/unit/config_parse/test_file_error/error_test23.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test24.conf
+++ b/test/unit/config_parse/test_file_error/error_test24.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test25.conf
+++ b/test/unit/config_parse/test_file_error/error_test25.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test26.conf
+++ b/test/unit/config_parse/test_file_error/error_test26.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test27.conf
+++ b/test/unit/config_parse/test_file_error/error_test27.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test28.conf
+++ b/test/unit/config_parse/test_file_error/error_test28.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        cgi_extension .php;
+        upload_dir /tmp;
+	}
+}

--- a/test/unit/config_parse/test_file_error/error_test29.conf
+++ b/test/unit/config_parse/test_file_error/error_test29.conf
@@ -1,0 +1,17 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 2024;
+	error_page 404 /404.html;
+	location / {
+		alias /data/;
+		index index.html;
+		autoindex on;
+		allowed_methods GET POST;
+		return 302 /redirect.html;
+        cgi_extension .php;
+        upload_dir /tmp;
+        upload_dir /tmp;
+	}
+}


### PR DESCRIPTION
## Configのディレクティブの重複チェックを入れました

- Directiveにすでに値が埋められている場合にはエラーを投げる
- それでチェックできない場合はフラグを用いて管理
- Nginxに合わせて無効な引数の場合はそのエラー優先
- Nginxに合わせてStatusCodeを300から599に

error_test20 ~ error_test29 が対応するテストです。(ファイル名は追々変更していきます)

## Further
テストケース作りまくってエラー耐性を上げていこうと思います。
テストファイルを上の階層に移動するのもやります。
-> #329 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - `Parser`クラスに重複ディレクティブチェックを追加し、設定の堅牢性を向上させました。
  - 新しいサーバー設定ファイルを複数追加し、リクエスト処理やエラーハンドリングを強化しました。

- **バグ修正**
  - `ServerCon`構造体の`host`メンバーのコメントを削除し、実装状況を明確にしました。

- **テスト**
  - エラーハンドリングのテストケースを10件追加し、テストカバレッジを拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->