### PR TITLE
[epoll] response によって epoll 監視イベント変更 

### DIFF
--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -95,6 +95,18 @@ void Epoll::Replace(int socket_fd, const event::Type new_type) {
 	}
 }
 
+// append old_type to new_type
+void Epoll::Append(const event::Event &event, const event::Type new_type) {
+	int socket_fd = event.fd;
+
+	struct epoll_event ev = {};
+	ev.events             = ConvertToEpollEventType(event.type) | ConvertToEpollEventType(new_type);
+	ev.data.fd            = socket_fd;
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
+		throw std::runtime_error("epoll_ctl failed");
+	}
+}
+
 event::Event Epoll::GetEvent(std::size_t index) const {
 	if (index >= MAX_EVENTS) {
 		throw std::out_of_range("evlist index out of range");

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -33,13 +33,13 @@ uint32_t ConvertToEpollEventType(uint32_t type) {
 	return ret_type;
 }
 
-uint32_t ConvertToEventType(uint32_t event) {
+uint32_t ConvertToEventType(uint32_t type) {
 	uint32_t ret_type = event::EVENT_NONE;
 
-	if (event & EPOLLIN) {
+	if (type & EPOLLIN) {
 		ret_type |= event::EVENT_READ;
 	}
-	if (event & EPOLLOUT) {
+	if (type & EPOLLOUT) {
 		ret_type |= event::EVENT_WRITE;
 	}
 	// todo: tmp
@@ -55,7 +55,7 @@ event::Event ConvertToEventDto(const struct epoll_event &event) {
 
 } // namespace
 
-// add socket_fd to epoll's interest list
+// add new socket_fd to epoll's interest list
 void Epoll::Add(int socket_fd, event::Type type) {
 	struct epoll_event ev = {};
 	ev.events             = ConvertToEpollEventType(type);

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -21,7 +21,7 @@ Epoll::~Epoll() {
 
 namespace {
 
-uint32_t ConvertToEpollEventType(event::Type type) {
+uint32_t ConvertToEpollEventType(uint32_t type) {
 	uint32_t ret_type = 0;
 
 	if (type & event::EVENT_READ) {

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -85,8 +85,8 @@ int Epoll::CreateReadyList() {
 	return ready;
 }
 
-// update epoll's interest list with new_type
-void Epoll::Update(int socket_fd, const event::Type new_type) {
+// replace old_type with new_type
+void Epoll::Replace(int socket_fd, const event::Type new_type) {
 	struct epoll_event ev = {};
 	ev.events             = ConvertToEpollEventType(new_type);
 	ev.data.fd            = socket_fd;

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -95,7 +95,7 @@ void Epoll::Replace(int socket_fd, const event::Type new_type) {
 	}
 }
 
-// append old_type to new_type
+// append new_type to old_type
 void Epoll::Append(const event::Event &event, const event::Type new_type) {
 	int socket_fd = event.fd;
 

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -14,6 +14,7 @@ class Epoll {
 	void Add(int socket_fd, event::Type type);
 	void Delete(int socket_fd);
 	void Replace(int socket_fd, event::Type new_type);
+	void Append(const event::Event &event, event::Type new_type);
 	int  CreateReadyList();
 	// getter
 	event::Event GetEvent(std::size_t index) const;

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -13,7 +13,7 @@ class Epoll {
 	~Epoll();
 	void Add(int socket_fd, event::Type type);
 	void Delete(int socket_fd);
-	void Update(int socket_fd, event::Type new_type);
+	void Replace(int socket_fd, event::Type new_type);
 	int  CreateReadyList();
 	// getter
 	event::Event GetEvent(std::size_t index) const;

--- a/srcs/event/event.hpp
+++ b/srcs/event/event.hpp
@@ -14,8 +14,8 @@ enum Type {
 };
 
 struct Event {
-	int     fd;
-	int32_t type;
+	int      fd;
+	uint32_t type;
 };
 
 } // namespace event

--- a/srcs/server/message_manager/message.cpp
+++ b/srcs/server/message_manager/message.cpp
@@ -72,6 +72,10 @@ Response Message::PopFrontResponse() {
 	return response;
 }
 
+bool Message::IsResponseExist() const {
+	return !responses_.empty();
+}
+
 int Message::GetFd() const {
 	return client_fd_;
 }

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -44,6 +44,7 @@ class Message {
 	void     AddBackResponse(ConnectionState connection_state, const std::string &response_str);
 	void     AddFrontResponse(ConnectionState connection_state, const std::string &response_str);
 	Response PopFrontResponse();
+	bool     IsResponseExist() const;
 
 	// getter
 	int                GetFd() const;

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -85,6 +85,11 @@ message::Response MessageManager::PopHeadResponse(int client_fd) {
 	return message.PopFrontResponse();
 }
 
+bool MessageManager::IsResponseExist(int client_fd) const {
+	const message::Message &message = messages_.at(client_fd);
+	return message.IsResponseExist();
+}
+
 const std::string &MessageManager::GetRequestBuf(int client_fd) const {
 	const message::Message &message = messages_.at(client_fd);
 	return message.GetRequestBuf();

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -34,6 +34,7 @@ class MessageManager {
 		int client_fd, message::ConnectionState connection_state, const std::string &response
 	);
 	message::Response PopHeadResponse(int client_fd);
+	bool              IsResponseExist(int client_fd) const;
 
 	// getter
 	const std::string &GetRequestBuf(int client_fd) const;

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -192,7 +192,7 @@ void Server::RunHttp(const event::Event &event) {
 	const message::ConnectionState connection_state =
 		http_result.is_connection_keep ? message::KEEP : message::CLOSE;
 	message_manager_.AddNormalResponse(client_fd, connection_state, http_result.response);
-	event_monitor_.Update(event.fd, event::EVENT_WRITE);
+	event_monitor_.Replace(event.fd, event::EVENT_WRITE);
 }
 
 void Server::SendResponse(int client_fd) {
@@ -212,7 +212,7 @@ void Server::SendResponse(int client_fd) {
 	switch (connection_state) {
 	case message::KEEP:
 		message_manager_.UpdateTime(client_fd);
-		event_monitor_.Update(client_fd, event::EVENT_READ);
+		event_monitor_.Replace(client_fd, event::EVENT_READ);
 		utils::Debug("server", "Connection: keep-alive client", client_fd);
 		break;
 	case message::CLOSE:
@@ -236,7 +236,7 @@ void Server::HandleTimeoutMessages() {
 		const int          client_fd        = *it;
 		const std::string &timeout_response = mock_http_.GetTimeoutResponse(client_fd);
 		message_manager_.AddPrimaryResponse(client_fd, message::CLOSE, timeout_response);
-		event_monitor_.Update(client_fd, event::EVENT_WRITE);
+		event_monitor_.Replace(client_fd, event::EVENT_WRITE);
 		utils::Debug("server", "timeout client", client_fd);
 	}
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -196,6 +196,9 @@ void Server::RunHttp(const event::Event &event) {
 }
 
 void Server::SendResponse(int client_fd) {
+	if (!message_manager_.IsResponseExist(client_fd)) {
+		return;
+	}
 	message::Response              response         = message_manager_.PopHeadResponse(client_fd);
 	const message::ConnectionState connection_state = response.connection_state;
 	const std::string             &response_str     = response.response_str;
@@ -212,7 +215,6 @@ void Server::SendResponse(int client_fd) {
 	switch (connection_state) {
 	case message::KEEP:
 		message_manager_.UpdateTime(client_fd);
-		event_monitor_.Replace(client_fd, event::EVENT_READ);
 		utils::Debug("server", "Connection: keep-alive client", client_fd);
 		break;
 	case message::CLOSE:

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -39,6 +39,9 @@ class Server {
 	void SendResponse(int client_fd);
 	void HandleTimeoutMessages();
 	void Disconnect(int client_fd);
+	void UpdateEventInResponseComplete(
+		const message::ConnectionState connection_state, const event::Event &event
+	);
 	// for Server to Http
 	DtoClientInfos GetClientInfos(int client_fd) const;
 	DtoServerInfos GetServerInfos(int client_fd) const;


### PR DESCRIPTION
## したこと
- response が作成された後、connection keep-alive か close かによって epoll の監視対象event を変更
- 他にも細かい epoll 関係の修正

一度 send() が始まってからは、connection-close (や timeout/error) が来ない限り EVENT_READ と EVENT_WRITE を同時監視するようにしました
connection-close (や timeout/error) の場合は EVENT_WRITE のみにしています

これにより PDF の以下の部分が達成できているのではないか？と思います
> poll() (or equivalent) must check read and write at the same time.

## 実行
挙動は変えてないです
```sh
# webserv
make run

make test
make -C test/unit/message_manager run

# client
cd test/client

# まだ complete request が来ていない場合
make run PORT=8080 INFILE_PATH=../request_messages/apache_root/get/400_connection-keep_no-CRLF_no-content.txt
# 現 PR の期待 : timeout 秒経過後、仮の 408 timeout response が返ってくる

# complete request が Connection: keep-alive で来た後、次の request が送られてこず timeout 秒経過した場合
make run PORT=8080 INFILE_PATH=../request_messages/apache_root/get/408_connection-keep_CRLF_no-content.txt 
# 現 PR の期待 : 200 OK response の後、timeout 秒経過後、仮の 408 timeout response が返ってくる
```

## 今後
- send() を返り値を見て response_str を編集
- internal server erorr

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



## Summary by CodeRabbit

- **新機能**
  - `Epoll` クラスに新しい `Append` メソッドを追加し、複数のイベントタイプを単一のソケットに関連付ける機能を強化。
  - `Message` クラスに `IsResponseExist` メソッドを追加し、レスポンスの存在を確認する機能を提供。
  - `MessageManager` クラスに `IsResponseExist` メソッドを追加し、特定のクライアントに関連するレスポンスの存在を確認する機能を提供。
  - `Server` クラスに `UpdateEventInResponseComplete` メソッドを追加し、接続状態に基づくイベント更新の処理を強化。

- **バグ修正**
  - HTTPレスポンスの処理において、レスポンスが存在するかのチェックを追加し、効率を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->