### PR TITLE
[add] Result<void> でも使えるように追加

### DIFF
--- a/srcs/utils/result.hpp
+++ b/srcs/utils/result.hpp
@@ -52,6 +52,35 @@ class Result {
 	T    success_value_;
 };
 
+// Specialization for void type
+template <>
+class Result<void> {
+  public:
+	Result() : is_success_(true) {}
+	~Result() {}
+	explicit Result(bool is_success) : is_success_(is_success) {}
+	Result(const Result &other) {
+		*this = other;
+	}
+	Result &operator=(const Result &other) {
+		if (this != &other) {
+			is_success_ = other.is_success_;
+		}
+		return *this;
+	}
+	// getter
+	bool IsOk() const {
+		return is_success_;
+	}
+	// setter
+	void Set(bool is_success) {
+		is_success_ = is_success;
+	}
+
+  private:
+	bool is_success_;
+};
+
 } // namespace utils
 
 #endif /* RESULT_HPP_ */


### PR DESCRIPTION
Result を void で使いたい場合もあり、別で作れば使えそうだったので追加してみました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `void`型専用の`Result`クラスの新しい特化型を追加し、成功状態を示す機能を強化しました。  
	- 成功状態を管理するためのメンバー関数`IsOk()`と`Set(bool is_success)`を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->