### PR TITLE
[update] readfile integrationtest

### DIFF
--- a/test/client/Makefile
+++ b/test/client/Makefile
@@ -42,8 +42,8 @@ re: fclean all
 DEFAULT_PORT	:=	8080
 PORT			:=	$(DEFAULT_PORT)
 
-# ex) make run INFILE_PATH=request_messages/200_get_sub.txt
-# ex) make run PORT=4242 INFILE_PATH=request_messages/200_get_sub.txt
+# ex) make run INFILE_PATH=../request_messages/webserver/get/200_get_sub.txt
+# ex) make run PORT=4242 INFILE_PATH=../request_messages/apache_root/get/200/connection-close.txt
 .PHONY	: run
 run: all
 	@./$(NAME) $(PORT) $(INFILE_PATH)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -45,12 +45,10 @@ response_header_get_sub_200 = (
 
 
 def test_get_root_close_200():
-    expected_response = response_header_get_root_200 + read_file(
-        "../../html/index.html"
-    )
+    expected_response = response_header_get_root_200 + read_file("html/index.html")
     client_instance = client.Client(8080)
     request = read_file_binary(
-        "../request_messages/webserv/get/200_root_connection-close.txt"
+        "test/request_messages/webserv/get/200_root_connection-close.txt"
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
@@ -59,13 +57,11 @@ def test_get_root_close_200():
 
 
 def test_get_root_keep_200():
-    expected_response = response_header_get_root_200 + read_file(
-        "../../html/index.html"
-    )
+    expected_response = response_header_get_root_200 + read_file("html/index.html")
     # responseヘッダーもkeepaliveになる？
     client_instance = client.Client(8080)
     request = read_file_binary(
-        "../request_messages/webserv/get/200_root_connection-keep.txt"
+        "test/request_messages/webserv/get/200_root_connection-keep.txt"
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
@@ -74,12 +70,10 @@ def test_get_root_keep_200():
 
 
 def test_get_sub_close_200():
-    expected_response = response_header_get_sub_200 + read_file(
-        "../../html/sub/index.html"
-    )
+    expected_response = response_header_get_sub_200 + read_file("html/sub/index.html")
     client_instance = client.Client(8080)
     request = read_file_binary(
-        "../request_messages/webserv/get/200_sub_connection-close.txt"
+        "test/request_messages/webserv/get/200_sub_connection-close.txt"
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -24,15 +24,87 @@ except ImportError as e:
     print(f"Import failed: {e}")
 
 
-# def test_webserv():
-#     try:
-#         test1()
-#         test2()
-#         test3()
-#         test4()
-#         test5()
-#     except Exception as e:
-#         print(f"Test failed: {e}")
+def read_file(file):
+    with open(file, "r") as f:
+        return f.read()
+
+
+# \r\nをそのまま読み込む用(ヘッダー部分)
+def read_file_binary(file):
+    with open(file, "rb") as f:
+        return f.read()
+
+
+response_header_get_root_200 = (
+    "HTTP/1.1 200 OK\r\nConnection: close \r\nContent-Length: 1250 \r\n\r\n"
+)
+
+response_header_get_sub_200 = (
+    "HTTP/1.1 200 OK\r\nConnection: close \r\nContent-Length: 398 \r\n\r\n"
+)
+
+
+def test_get_root_close_200():
+    expected_response = response_header_get_root_200 + read_file(
+        "../../html/index.html"
+    )
+    client_instance = client.Client(8080)
+    request = read_file_binary(
+        "../request_messages/webserv/get/200_root_connection-close.txt"
+    )
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_root_keep_200():
+    expected_response = response_header_get_root_200 + read_file(
+        "../../html/index.html"
+    )
+    # responseヘッダーもkeepaliveになる？
+    client_instance = client.Client(8080)
+    request = read_file_binary(
+        "../request_messages/webserv/get/200_root_connection-keep.txt"
+    )
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_sub_close_200():
+    expected_response = response_header_get_sub_200 + read_file(
+        "../../html/sub/index.html"
+    )
+    client_instance = client.Client(8080)
+    request = read_file_binary(
+        "../request_messages/webserv/get/200_sub_connection-close.txt"
+    )
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+# def test_get_404():
+#     expected_response = response_header_get_404 + read_file("../../html/sub/index.html")
+#     client_instance = client.Client(8080)
+#     request = read_file_binary("../request_messages/webserv/get/404_not-exist-path_connection-close.txt")
+#     response = client_instance.SendRequestAndReceiveResponse(request)
+#     assert (
+#         response == expected_response
+#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_webserv():
+    try:
+        test_get_root_close_200()
+        test_get_root_keep_200()
+        test_get_sub_close_200()
+        # test_get_404()
+    except Exception as e:
+        print(f"Test failed: {e}")
 
 
 # def test1():
@@ -75,5 +147,5 @@ except ImportError as e:
 #     # assert
 
 
-# if __name__ == "__main__":
-#     test_webserv()
+if __name__ == "__main__":
+    test_webserv()


### PR DESCRIPTION
## ファイルからレスポンスを読み込めるようなIngetrationTestを追加しました

- 200_getの場合のみに対応
- ファイルからリクエストを読み込む
- レスポンスは自分で用意したヘッダーとgetしたファイル(index.html)を結合
- Actionsとパスの関係でルートディレクトリからしか動かせません
```
pytest -v ./test/integration
```

レスポンスの書式が決まり次第順次テストケースを追加していこうと思います

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
  - 更新されたパスを反映したテスト用の `Makefile` コメントを修正し、リソースの場所を明確化。

- **新機能**
  - ウェブサーバーのクライアントテスト機能を強化するために、複数の新しいテスト関数を追加。
  - テストデータの準備を簡素化するためのユーティリティ関数を導入。

- **ドキュメント**
  - テスト用の `Makefile` のコメントを更新し、使用方法を明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->