### PR TITLE
[server] fcntl() を使って各 fd に nonblocking mode をセットする

### DIFF
--- a/srcs/server/send.cpp
+++ b/srcs/server/send.cpp
@@ -1,4 +1,5 @@
 #include "send.hpp"
+#include "utils.hpp"
 #include <cstdio>       // perror
 #include <sys/socket.h> // send
 
@@ -12,6 +13,7 @@ Send::SendResult Send::SendResponse(int client_fd, const Response &response) {
 	SendResult send_result;
 
 	ssize_t send_size = send(client_fd, response.c_str(), response.size(), 0);
+	utils::Debug("Send", "send_size: ", send_size);
 	if (send_size == SYSTEM_ERROR) {
 		perror("send failed");
 		send_result.Set(false);

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -8,6 +8,7 @@
 #include "utils.hpp"
 #include "virtual_server.hpp"
 #include <errno.h>
+#include <fcntl.h>      // fcntl
 #include <sys/socket.h> // socket
 #include <unistd.h>     // close
 
@@ -119,6 +120,7 @@ void Server::HandleNewConnection(int server_fd) {
 	// A new socket that has established a connection with the peer socket.
 	const ClientInfo new_client_info = Connection::Accept(server_fd);
 	const int        client_fd       = new_client_info.GetFd();
+	SetNonBlockingMode(client_fd);
 
 	// add client_info, event, message
 	context_.AddClientInfo(new_client_info, server_fd);
@@ -310,12 +312,24 @@ void Server::Init() {
 			ServerInfo server_info(*it_port);
 			const int  server_fd = connection_.Connect(server_info);
 			server_info.SetSockFd(server_fd);
+			SetNonBlockingMode(server_fd);
 
 			// add to context
 			context_.AddServerInfo(server_info, &virtual_server);
 			event_monitor_.Add(server_fd, event::EVENT_READ);
 			utils::Debug("server", "listen", server_fd);
 		}
+	}
+}
+
+void Server::SetNonBlockingMode(int sock_fd) {
+	int flags = fcntl(sock_fd, F_GETFL);
+	if (flags == SYSTEM_ERROR) {
+		throw std::runtime_error("fcntl F_GETFL failed");
+	}
+	flags |= O_NONBLOCK;
+	if (fcntl(sock_fd, F_SETFL, flags) == SYSTEM_ERROR) {
+		throw std::runtime_error("fcntl F_SETFL failed");
 	}
 }
 

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -46,6 +46,7 @@ class Server {
 	void UpdateConnectionAfterSendResponse(
 		int client_fd, const message::ConnectionState connection_state
 	);
+	void SetNonBlockingMode(int sock_fd);
 	// for Server to Http
 	DtoClientInfos GetClientInfos(int client_fd) const;
 	DtoServerInfos GetServerInfos(int client_fd) const;


### PR DESCRIPTION
#350 merge 後、main merge

---

- `fcntl()` : 機能の 1 つに、オープン済みソケットのオープンファイルステータスフラグの参照・設定がある
`F_GETFL` で参照し、`F_SETFL` で変更する

## したこと
webserv が non-blocking で通信できるよう、server_fd, client_fd に non-blocking mode を設定しました

これにより、1 例として Server の send() がブロッキングされなくなりました (他の例はあまり検証できてないです…)
- before 
client が send() 後に recv() しない場合、server から send() してる文字列が長いと送信バッファがいっぱいになり、空きが出るまで send() がブロッキングしていた
- after (この PR)
server は送信バッファの空き分だけ send() し、残ったら次の send() 用に保存。送信バッファに空きが出たら再度残りを送る、という挙動に変わりました

## 実行
```sh
# index.html に追加して長くする (長さはマシンで違いがあるかもです)
python3 -c "print('a' * 2700000)" >> html/index.html
```

- before : 試しに `SetNonBlockingMode()` をコメントアウトすると、send() は 1 度のみだと思います
```sh
# webserv
make run

curl localhost:8080
# [Send] send_size: (2701316)
```

- after :  `SetNonBlockingMode()` を設定すると、server の debug print から send() が 2 回に分かれていることが確認できるかと思います
```sh
# webserv
make run

curl localhost:8080
# -> こんな感じの出力
# [Send] send_size: (2686976)
# [Send] send_size: (14340)
```

<br>

ちなみに before のブロッキングしてるのをより分かりやすく見るには、`SetNonBlockingMode()` をコメントアウトし、`test/client/client.cpp` を以下のように編集して send() 後に recv() しないで無限待機にし、
```cpp
void Client::SendRequestAndReceiveResponse(const std::string &message) {
	ssize_t send_size = send(sock_fd_, message.c_str(), message.size(), 0);
	DebugPrint("Message sent. (" + utils::ToString(send_size) + " bytes)");

	DebugPrint("Response from server:");
	while (true) {
		sleep(1);
	}
}
```
以下を実行すると server が止まって次に進まないのが見れるかと思います
(こういう挙動をする client のテストも追加したい…)
```sh
# webserv
make run

# client
make -C test/client run PORT=8080 INFILE_PATH=../request_messages/apache_root/get/200/connection-keep.txt
```

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サーバーが複数の接続を効率的に処理できるように、ソケットをノンブロッキングモードに設定する新しい機能を追加しました。
  
- **バグ修正**
  - データ送信時のサイズをログに記録するデバッグステートメントを追加し、送信プロセスのトラッキングとデバッグを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->