### PR TITLE
[http] StatusCodeクラス作成

### DIFF
--- a/sandbox/sawa/http_parse/http_parse.cpp
+++ b/sandbox/sawa/http_parse/http_parse.cpp
@@ -86,7 +86,7 @@ HttpRequestResult HttpParse::Run(const std::string &read_buf) {
 }
 
 RequestLine HttpParse::SetRequestLine(
-	const std::vector<std::string> &request_line_info, StatusCode *status_code
+	const std::vector<std::string> &request_line_info, EStatusCode *status_code
 ) {
 	RequestLine request_line;
 	try {
@@ -100,7 +100,7 @@ RequestLine HttpParse::SetRequestLine(
 }
 
 HeaderFields HttpParse::SetHeaderFields(
-	const std::vector<std::string> &header_fields_info, StatusCode *status_code
+	const std::vector<std::string> &header_fields_info, EStatusCode *status_code
 ) {
 	// todo: 各値が正常な値かどうか確認してから作成する（エラーの場合はenumに設定？）
 	HeaderFields                                     header_fields;
@@ -152,9 +152,9 @@ std::string HttpParse::CheckHeaderFieldValue(const std::string &header_field_val
 	return header_field_value;
 }
 
-HttpParse::HttpException::HttpException(StatusCode status_code) : status_code_(status_code) {}
+HttpParse::HttpException::HttpException(EStatusCode status_code) : status_code_(status_code) {}
 
-StatusCode HttpParse::HttpException::GetStatusCode() const {
+EStatusCode HttpParse::HttpException::GetStatusCode() const {
 	return status_code_;
 }
 

--- a/sandbox/sawa/http_parse/http_parse.hpp
+++ b/sandbox/sawa/http_parse/http_parse.hpp
@@ -27,7 +27,7 @@ struct HttpRequestFormat {
 	std::string  body_message;
 };
 
-enum StatusCode {
+enum EStatusCode {
 	OK,
 	BAD_REQUEST,
 	NOT_FOUND,
@@ -35,7 +35,7 @@ enum StatusCode {
 };
 
 struct HttpRequestResult {
-	StatusCode        status_code;
+	EStatusCode       status_code;
 	HttpRequestFormat request;
 	HttpRequestResult() : status_code(OK) {}
 };
@@ -48,9 +48,9 @@ class HttpParse {
 	HttpParse();
 	~HttpParse();
 	static RequestLine
-	SetRequestLine(const std::vector<std::string> &request_line, StatusCode *status_code);
+	SetRequestLine(const std::vector<std::string> &request_line, EStatusCode *status_code);
 	static HeaderFields
-	SetHeaderFields(const std::vector<std::string> &header_fields_info, StatusCode *status_code);
+	SetHeaderFields(const std::vector<std::string> &header_fields_info, EStatusCode *status_code);
 
 	static std::string CheckMethod(const std::string &method);
 	static std::string CheckRequestTarget(const std::string &request_target);
@@ -59,11 +59,11 @@ class HttpParse {
 	static std::string CheckHeaderFieldValue(const std::string &header_field_value);
 	class HttpException {
 	  public:
-		explicit HttpException(StatusCode status_code);
-		StatusCode GetStatusCode() const;
+		explicit HttpException(EStatusCode status_code);
+		EStatusCode GetStatusCode() const;
 
 	  private:
-		StatusCode status_code_;
+		EStatusCode status_code_;
 	};
 };
 

--- a/srcs/config_parse/custom_const_iterator.hpp
+++ b/srcs/config_parse/custom_const_iterator.hpp
@@ -20,8 +20,8 @@ class CustomConstIterator {
 		typename std::list<T>::const_iterator end,
 		bool                                  throw_on_end = true
 	)
-		: it_(it), end_(end), throw_on_end_(throw_on_end){};
-	~CustomConstIterator(){};
+		: it_(it), end_(end), throw_on_end_(throw_on_end) {};
+	~CustomConstIterator() {};
 
 	CustomConstIterator &operator++() {
 		if (it_ == end_ && throw_on_end_) {

--- a/srcs/http/IHttp.hpp
+++ b/srcs/http/IHttp.hpp
@@ -26,7 +26,7 @@ class IHttp {
 	 */
 	virtual HttpResult
 	Run(const server::DtoClientInfos &client_infos, const server::DtoServerInfos &server_infos) = 0;
-	virtual std::string GetTimeoutResponse(int client_fd)                               = 0;
+	virtual std::string GetTimeoutResponse(int client_fd)                                       = 0;
 };
 
 } // namespace http

--- a/srcs/http/http_exception.cpp
+++ b/srcs/http/http_exception.cpp
@@ -2,10 +2,10 @@
 
 namespace http {
 
-HttpException::HttpException(const std::string &error_message, StatusCode status_code)
+HttpException::HttpException(const std::string &error_message, EStatusCode status_code)
 	: runtime_error(error_message), status_code_(status_code) {}
 
-StatusCode HttpException::GetStatusCode() const {
+EStatusCode HttpException::GetStatusCode() const {
 	return status_code_;
 }
 

--- a/srcs/http/http_exception.cpp
+++ b/srcs/http/http_exception.cpp
@@ -2,10 +2,12 @@
 
 namespace http {
 
-HttpException::HttpException(const std::string &error_message, EStatusCode status_code)
+HttpException::HttpException(const std::string &error_message, const StatusCode &status_code)
 	: runtime_error(error_message), status_code_(status_code) {}
 
-EStatusCode HttpException::GetStatusCode() const {
+HttpException::~HttpException() throw() {}
+
+const StatusCode &HttpException::GetStatusCode() const throw() {
 	return status_code_;
 }
 

--- a/srcs/http/http_exception.hpp
+++ b/srcs/http/http_exception.hpp
@@ -1,5 +1,5 @@
-#ifndef HTTP_RESPONSE_EXCEPTION_HPP_
-#define HTTP_RESPONSE_EXCEPTION_HPP_
+#ifndef HTTP_EXCEPTION_HPP_
+#define HTTP_EXCEPTION_HPP_
 
 #include "status_code.hpp"
 #include <stdexcept>
@@ -9,11 +9,12 @@ namespace http {
 
 class HttpException : public std::runtime_error {
   public:
-	explicit HttpException(const std::string &error_message, EStatusCode status_code);
-	EStatusCode GetStatusCode() const;
+	HttpException(const std::string &error_message, const StatusCode &status_code);
+	~HttpException() throw();
+	const StatusCode &GetStatusCode() const throw();
 
   private:
-	EStatusCode status_code_;
+	StatusCode status_code_;
 };
 
 } // namespace http

--- a/srcs/http/http_exception.hpp
+++ b/srcs/http/http_exception.hpp
@@ -9,11 +9,11 @@ namespace http {
 
 class HttpException : public std::runtime_error {
   public:
-	explicit HttpException(const std::string &error_message, StatusCode status_code);
-	StatusCode GetStatusCode() const;
+	explicit HttpException(const std::string &error_message, EStatusCode status_code);
+	EStatusCode GetStatusCode() const;
 
   private:
-	StatusCode status_code_;
+	EStatusCode status_code_;
 };
 
 } // namespace http

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -101,7 +101,7 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData &data) {
 	const utils::Result<std::size_t> convert_result =
 		utils::ConvertStrToSize(data.request_result.request.header_fields[CONTENT_LENGTH]);
 	if (!convert_result.IsOk()) {
-		throw HttpException("Error: wrong Content-Length number", BAD_REQUEST);
+		throw HttpException("Error: wrong Content-Length number", StatusCode(BAD_REQUEST));
 	}
 	const size_t content_length = convert_result.GetValue();
 	size_t       readable_content_length =
@@ -167,7 +167,8 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		std::vector<std::string> header_field_name_and_value = utils::SplitStr(*it, ":");
 		if (header_field_name_and_value.size() != 2) {
 			throw HttpException(
-				"Error: Missing colon or multiple colons found in header filed", BAD_REQUEST
+				"Error: Missing colon or multiple colons found in header filed",
+				StatusCode(BAD_REQUEST)
 			);
 		}
 		// header_field_valueを初期化してるためheader_field_nameも初期化した
@@ -179,7 +180,9 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		typedef std::pair<HeaderFields::const_iterator, bool> Result;
 		Result result = header_fields.insert(std::make_pair(header_field_name, header_field_value));
 		if (result.second == false) {
-			throw HttpException("Error: The value already exists in header fields", BAD_REQUEST);
+			throw HttpException(
+				"Error: The value already exists in header fields", StatusCode(BAD_REQUEST)
+			);
 		}
 	}
 	return header_fields;
@@ -195,13 +198,16 @@ void HttpParse::CheckValidMethod(const std::string &method) {
 	// US-ASCIIかまたは大文字かどうか -> 400
 	if (IsStringUsAscii(method) == false || IsStringUpper(method) == false) {
 		throw HttpException(
-			"Error: This method contains lowercase or non-USASCII characters.", BAD_REQUEST
+			"Error: This method contains lowercase or non-USASCII characters.",
+			StatusCode(BAD_REQUEST)
 		);
 	}
 	// GET, POST, DELETEかどうか ->　501
 	if (std::find(BASIC_METHODS, BASIC_METHODS + BASIC_METHODS_SIZE, method) ==
 		BASIC_METHODS + BASIC_METHODS_SIZE) {
-		throw HttpException("Error: This method doesn't exist in webserv.", NOT_IMPLEMENTED);
+		throw HttpException(
+			"Error: This method doesn't exist in webserv.", StatusCode(NOT_IMPLEMENTED)
+		);
 	}
 }
 
@@ -209,7 +215,8 @@ void HttpParse::CheckValidRequestTarget(const std::string &request_target) {
 	// /が先頭になかったら場合 -> 400
 	if (request_target.empty() || request_target[0] != '/') {
 		throw HttpException(
-			"Error: the request target is missing the '/' character at the beginning", BAD_REQUEST
+			"Error: the request target is missing the '/' character at the beginning",
+			StatusCode(BAD_REQUEST)
 		);
 	}
 }
@@ -217,7 +224,9 @@ void HttpParse::CheckValidRequestTarget(const std::string &request_target) {
 void HttpParse::CheckValidVersion(const std::string &version) {
 	// HTTP/1.1かどうか -> 400
 	if (version != HTTP_VERSION) {
-		throw HttpException("Error: The version is not supported by webserv", BAD_REQUEST);
+		throw HttpException(
+			"Error: The version is not supported by webserv", StatusCode(BAD_REQUEST)
+		);
 	}
 }
 
@@ -228,7 +237,7 @@ void HttpParse::CheckValidHeaderFieldName(const std::string &header_field_value)
 			header_field_value
 		) == REQUEST_HEADER_FIELDS + REQUEST_HEADER_FIELDS_SIZE) {
 		throw HttpException(
-			"Error: the value does not exist in format of header fields", BAD_REQUEST
+			"Error: the value does not exist in format of header fields", StatusCode(BAD_REQUEST)
 		);
 	}
 }

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -11,7 +11,7 @@
 namespace http {
 
 struct HttpRequestResult {
-	StatusCode        status_code;
+	EStatusCode       status_code;
 	HttpRequestFormat request;
 	HttpRequestResult() : status_code(OK) {}
 };

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -11,7 +11,7 @@
 namespace http {
 
 struct HttpRequestResult {
-	EStatusCode       status_code;
+	StatusCode        status_code;
 	HttpRequestFormat request;
 	HttpRequestResult() : status_code(OK) {}
 };

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -18,7 +18,7 @@ struct HttpRequestResult {
 
 struct IsHttpRequestFormat {
 	IsHttpRequestFormat()
-		: is_request_line(false), is_header_fields(false), is_body_message(false){};
+		: is_request_line(false), is_header_fields(false), is_body_message(false) {};
 	bool is_request_line;
 	bool is_header_fields;
 	bool is_body_message;

--- a/srcs/http/response/http_handle_method.cpp
+++ b/srcs/http/response/http_handle_method.cpp
@@ -40,10 +40,7 @@ void HttpResponse::GetHandler(const std::string &path, std::string &response_bod
 		if (info.IsDirectory()) {
 			// No empty string because the path has '/'
 			if (path[path.size() - 1] != '/') {
-				response_body_message = CreateDefaultBodyMessageFormat(
-					utils::ToString(http::MOVED_PERMANENTLY),
-					reason_phrase.at(http::MOVED_PERMANENTLY)
-				);
+				response_body_message = CreateDefaultBodyMessageFormat(StatusCode(MOVED_PERMANENTLY));
 				return;
 			}
 			// todo: Check for index directive and handle ReadFile function
@@ -51,16 +48,12 @@ void HttpResponse::GetHandler(const std::string &path, std::string &response_bod
 			// todo: Return 403 Forbidden if neither index nor autoindex directives exist
 		} else if (info.IsRegularFile()) {
 			if (!info.IsReadableFile()) {
-				response_body_message = CreateDefaultBodyMessageFormat(
-					utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-				);
+				response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 			} else {
 				response_body_message = ReadFile(path);
 			}
 		} else {
-			response_body_message = CreateDefaultBodyMessageFormat(
-				utils::ToString(http::NOT_FOUND), reason_phrase.at(http::NOT_FOUND)
-			);
+			response_body_message = CreateDefaultBodyMessageFormat(StatusCode(NOT_FOUND));
 		}
 	} catch (const utils::SystemException &e) {
 		SystemExceptionHandler(e, response_body_message);
@@ -75,13 +68,9 @@ void HttpResponse::PostHandler(
 	try {
 		Stat info(path);
 		if (info.IsDirectory()) {
-			response_body_message = CreateDefaultBodyMessageFormat(
-				utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-			);
+			response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 		} else if (info.IsRegularFile()) {
-			response_body_message = CreateDefaultBodyMessageFormat(
-				utils::ToString(http::NO_CONTENT), reason_phrase.at(http::NO_CONTENT)
-			);
+			response_body_message = CreateDefaultBodyMessageFormat(StatusCode(NO_CONTENT));
 		} else {
 			// Location header fields: URI-reference
 			// ex) POST /save/test.txt HTTP/1.1
@@ -102,13 +91,9 @@ void HttpResponse::DeleteHandler(const std::string &path, std::string &response_
 	try {
 		Stat info(path);
 		if (info.IsDirectory()) {
-			response_body_message = CreateDefaultBodyMessageFormat(
-				utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-			);
+			response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 		} else if (std::remove(path.c_str()) == 0) {
-			response_body_message = CreateDefaultBodyMessageFormat(
-				utils::ToString(http::NO_CONTENT), reason_phrase.at(http::NO_CONTENT)
-			);
+			response_body_message = CreateDefaultBodyMessageFormat(StatusCode(NO_CONTENT));
 		} else {
 			throw utils::SystemException(std::strerror(errno), errno);
 		}
@@ -122,18 +107,11 @@ void HttpResponse::SystemExceptionHandler(
 ) {
 	int error_number = e.GetErrorNumber();
 	if (error_number == EACCES || error_number == EPERM) {
-		response_body_message = CreateDefaultBodyMessageFormat(
-			utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-		);
+		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 	} else if (error_number == ENOENT || error_number == ENOTDIR || error_number == ELOOP || error_number == ENAMETOOLONG) {
-		response_body_message = CreateDefaultBodyMessageFormat(
-			utils::ToString(http::NOT_FOUND), reason_phrase.at(http::NOT_FOUND)
-		);
+		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(NOT_FOUND));
 	} else {
-		response_body_message = CreateDefaultBodyMessageFormat(
-			utils::ToString(http::INTERNAL_SERVER_ERROR),
-			reason_phrase.at(http::INTERNAL_SERVER_ERROR)
-		);
+		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(INTERNAL_SERVER_ERROR));
 	}
 }
 
@@ -144,9 +122,7 @@ void HttpResponse::FileCreationHandler(
 ) {
 	std::ofstream file(path.c_str(), std::ios::binary);
 	if (file.fail()) {
-		response_body_message = CreateDefaultBodyMessageFormat(
-			utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-		);
+		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 		return;
 	}
 	file.write(request_body_message.c_str(), request_body_message.length());
@@ -155,14 +131,10 @@ void HttpResponse::FileCreationHandler(
 		if (std::remove(path.c_str()) != 0) {
 			throw utils::SystemException(std::strerror(errno), errno);
 		}
-		response_body_message = CreateDefaultBodyMessageFormat(
-			utils::ToString(http::FORBIDDEN), reason_phrase.at(http::FORBIDDEN)
-		);
+		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
 		return;
 	}
-	response_body_message = CreateDefaultBodyMessageFormat(
-		utils::ToString(http::CREATED), reason_phrase.at(http::CREATED)
-	);
+	response_body_message = CreateDefaultBodyMessageFormat(StatusCode(CREATED));
 }
 
 } // namespace http

--- a/srcs/http/response/http_handle_method.cpp
+++ b/srcs/http/response/http_handle_method.cpp
@@ -40,7 +40,8 @@ void HttpResponse::GetHandler(const std::string &path, std::string &response_bod
 		if (info.IsDirectory()) {
 			// No empty string because the path has '/'
 			if (path[path.size() - 1] != '/') {
-				response_body_message = CreateDefaultBodyMessageFormat(StatusCode(MOVED_PERMANENTLY));
+				response_body_message =
+					CreateDefaultBodyMessageFormat(StatusCode(MOVED_PERMANENTLY));
 				return;
 			}
 			// todo: Check for index directive and handle ReadFile function
@@ -108,7 +109,8 @@ void HttpResponse::SystemExceptionHandler(
 	int error_number = e.GetErrorNumber();
 	if (error_number == EACCES || error_number == EPERM) {
 		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(FORBIDDEN));
-	} else if (error_number == ENOENT || error_number == ENOTDIR || error_number == ELOOP || error_number == ENAMETOOLONG) {
+	} else if (error_number == ENOENT || error_number == ENOTDIR || error_number == ELOOP ||
+			   error_number == ENAMETOOLONG) {
 		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(NOT_FOUND));
 	} else {
 		response_body_message = CreateDefaultBodyMessageFormat(StatusCode(INTERNAL_SERVER_ERROR));

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -87,13 +87,11 @@ HttpResponse::CreateSuccessHttpResponseResult(const HttpRequestResult &request_i
 	return response;
 }
 
-std::string HttpResponse::CreateDefaultBodyMessageFormat(
-	const std::string &status_code, const std::string &reason_phrase
-) {
+std::string HttpResponse::CreateDefaultBodyMessageFormat(const StatusCode &status_code) {
 	std::ostringstream body_message;
-	body_message << "<html>" << CRLF << "<head><title>" << status_code << SP << reason_phrase
-				 << "</title></head>" << CRLF << "<body>" << CRLF << "<center><h1>" << status_code
-				 << SP << reason_phrase << "</h1></center>" << CRLF << "<hr><center>"
+	body_message << "<html>" << CRLF << "<head><title>" << status_code.GetStatusCode() << SP << status_code.GetReasonPhrase()
+				 << "</title></head>" << CRLF << "<body>" << CRLF << "<center><h1>" << status_code.GetStatusCode()
+				 << SP << status_code.GetReasonPhrase() << "</h1></center>" << CRLF << "<hr><center>"
 				 << SERVER_VERSION << "</center>" << CRLF << "</body>" << CRLF << "</html>" << CRLF;
 	return body_message.str();
 }
@@ -107,9 +105,7 @@ HttpResponseFormat HttpResponse::CreateErrorHttpResponseResult(const StatusCode 
 	response.header_fields[CONTENT_TYPE] = "text/html";
 	response.header_fields[SERVER]       = SERVER_VERSION;
 	response.header_fields[CONNECTION]   = "close";
-	response.body_message                = CreateDefaultBodyMessageFormat(
-        response.status_line.status_code, response.status_line.reason_phrase
-    );
+	response.body_message                = CreateDefaultBodyMessageFormat(status_code);
 	response.header_fields[CONTENT_LENGTH] = utils::ToString(response.body_message.length());
 	return response;
 }

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -89,9 +89,10 @@ HttpResponse::CreateSuccessHttpResponseFormat(const HttpRequestResult &request_i
 
 std::string HttpResponse::CreateDefaultBodyMessageFormat(const StatusCode &status_code) {
 	std::ostringstream body_message;
-	body_message << "<html>" << CRLF << "<head><title>" << status_code.GetStatusCode() << SP << status_code.GetReasonPhrase()
-				 << "</title></head>" << CRLF << "<body>" << CRLF << "<center><h1>" << status_code.GetStatusCode()
-				 << SP << status_code.GetReasonPhrase() << "</h1></center>" << CRLF << "<hr><center>"
+	body_message << "<html>" << CRLF << "<head><title>" << status_code.GetStatusCode() << SP
+				 << status_code.GetReasonPhrase() << "</title></head>" << CRLF << "<body>" << CRLF
+				 << "<center><h1>" << status_code.GetStatusCode() << SP
+				 << status_code.GetReasonPhrase() << "</h1></center>" << CRLF << "<hr><center>"
 				 << SERVER_VERSION << "</center>" << CRLF << "</body>" << CRLF << "</html>" << CRLF;
 	return body_message.str();
 }
@@ -99,13 +100,13 @@ std::string HttpResponse::CreateDefaultBodyMessageFormat(const StatusCode &statu
 // mock
 HttpResponseFormat HttpResponse::CreateErrorHttpResponseFormat(const StatusCode &status_code) {
 	HttpResponseFormat response;
-	response.status_line.version         = HTTP_VERSION;
-	response.status_line.status_code     = status_code.GetStatusCode();
-	response.status_line.reason_phrase   = status_code.GetReasonPhrase();
-	response.header_fields[CONTENT_TYPE] = "text/html";
-	response.header_fields[SERVER]       = SERVER_VERSION;
-	response.header_fields[CONNECTION]   = "close";
-	response.body_message                = CreateDefaultBodyMessageFormat(status_code);
+	response.status_line.version           = HTTP_VERSION;
+	response.status_line.status_code       = status_code.GetStatusCode();
+	response.status_line.reason_phrase     = status_code.GetReasonPhrase();
+	response.header_fields[CONTENT_TYPE]   = "text/html";
+	response.header_fields[SERVER]         = SERVER_VERSION;
+	response.header_fields[CONNECTION]     = "close";
+	response.body_message                  = CreateDefaultBodyMessageFormat(status_code);
 	response.header_fields[CONTENT_LENGTH] = utils::ToString(response.body_message.length());
 	return response;
 }

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -65,7 +65,7 @@ HttpResponseFormat HttpResponse::TmpCreateHttpResponseResult(
 // mock
 HttpResponseFormat HttpResponse::CreateHttpResponseResult(const HttpRequestResult &request_info) {
 	HttpResponseFormat response;
-	if (request_info.status_code != http::OK) {
+	if (request_info.status_code.GetEStatusCode() != http::OK) {
 		response = CreateErrorHttpResponseResult(request_info);
 	} else {
 		response = CreateSuccessHttpResponseResult(request_info);
@@ -104,8 +104,8 @@ HttpResponseFormat HttpResponse::CreateErrorHttpResponseResult(const HttpRequest
 ) {
 	HttpResponseFormat response;
 	response.status_line.version       = HTTP_VERSION;
-	response.status_line.status_code   = utils::ToString(request_info.status_code);
-	response.status_line.reason_phrase = reason_phrase.at(request_info.status_code);
+	response.status_line.status_code   = request_info.status_code.GetStatusCode();
+	response.status_line.reason_phrase = request_info.status_code.GetReasonPhrase();
 	// todo: StatusCodeをクラスにして、プライベートで保持する。
 	// response.status_line.status_code   = request_info.status_code.GetStrStatusCode();
 	// response.status_line.reason_phrase   = request_info.status_code.GetReasonPhrase();

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -17,7 +17,7 @@ std::string HttpResponse::Run(const HttpRequestResult &request_info) {
 std::string HttpResponse::TmpRun(
 	const MockDtoClientInfos &client_info,
 	const MockDtoServerInfos &server_info,
-	HttpRequestResult        &request_info
+	const HttpRequestResult  &request_info
 ) {
 	HttpResponseFormat response =
 		TmpCreateHttpResponseResult(client_info, server_info, request_info);
@@ -29,7 +29,7 @@ std::string HttpResponse::TmpRun(
 HttpResponseFormat HttpResponse::TmpCreateHttpResponseResult(
 	const MockDtoClientInfos &client_info,
 	const MockDtoServerInfos &server_info,
-	HttpRequestResult        &request_info
+	const HttpRequestResult  &request_info
 ) {
 	try {
 		HttpResponseFormat    result;
@@ -57,8 +57,7 @@ HttpResponseFormat HttpResponse::TmpCreateHttpResponseResult(
 		return result;
 	} catch (const HttpException &e) {
 		// feature: header_fieldとerror_pageとの関連性がわかり次第変更あり
-		request_info.status_code = e.GetStatusCode();
-		return CreateErrorHttpResponseResult(request_info);
+		return CreateErrorHttpResponseResult(e.GetStatusCode());
 	}
 }
 
@@ -66,7 +65,7 @@ HttpResponseFormat HttpResponse::TmpCreateHttpResponseResult(
 HttpResponseFormat HttpResponse::CreateHttpResponseResult(const HttpRequestResult &request_info) {
 	HttpResponseFormat response;
 	if (request_info.status_code.GetEStatusCode() != http::OK) {
-		response = CreateErrorHttpResponseResult(request_info);
+		response = CreateErrorHttpResponseResult(request_info.status_code);
 	} else {
 		response = CreateSuccessHttpResponseResult(request_info);
 	}
@@ -100,15 +99,11 @@ std::string HttpResponse::CreateDefaultBodyMessageFormat(
 }
 
 // mock
-HttpResponseFormat HttpResponse::CreateErrorHttpResponseResult(const HttpRequestResult &request_info
-) {
+HttpResponseFormat HttpResponse::CreateErrorHttpResponseResult(const StatusCode &status_code) {
 	HttpResponseFormat response;
-	response.status_line.version       = HTTP_VERSION;
-	response.status_line.status_code   = request_info.status_code.GetStatusCode();
-	response.status_line.reason_phrase = request_info.status_code.GetReasonPhrase();
-	// todo: StatusCodeをクラスにして、プライベートで保持する。
-	// response.status_line.status_code   = request_info.status_code.GetStrStatusCode();
-	// response.status_line.reason_phrase   = request_info.status_code.GetReasonPhrase();
+	response.status_line.version         = HTTP_VERSION;
+	response.status_line.status_code     = status_code.GetStatusCode();
+	response.status_line.reason_phrase   = status_code.GetReasonPhrase();
 	response.header_fields[CONTENT_TYPE] = "text/html";
 	response.header_fields[SERVER]       = SERVER_VERSION;
 	response.header_fields[CONNECTION]   = "close";

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -60,9 +60,7 @@ class HttpResponse {
 	static HttpResponseFormat CreateSuccessHttpResponseResult(const HttpRequestResult &request_info
 	);
 	static HttpResponseFormat CreateErrorHttpResponseResult(const StatusCode &status_code);
-	static std::string        CreateDefaultBodyMessageFormat(
-			   const std::string &status_code, const std::string &reason_phrase
-		   );
+	static std::string        CreateDefaultBodyMessageFormat(const StatusCode &status_code);
 	static void
 	SystemExceptionHandler(const utils::SystemException &e, std::string &response_body_message);
 	static void FileCreationHandler(

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -36,7 +36,7 @@ class HttpResponse {
 	static std::string                         TmpRun(
 								const MockDtoClientInfos &client_info,
 								const MockDtoServerInfos &server_info,
-								HttpRequestResult        &request_info
+								const HttpRequestResult  &request_info
 							);
 	static void GetHandler(const std::string &path, std::string &body_message);
 	static void PostHandler(
@@ -55,11 +55,11 @@ class HttpResponse {
 	static HttpResponseFormat TmpCreateHttpResponseResult(
 		const MockDtoClientInfos &client_info,
 		const MockDtoServerInfos &server_info,
-		HttpRequestResult        &request_info
+		const HttpRequestResult  &request_info
 	);
 	static HttpResponseFormat CreateSuccessHttpResponseResult(const HttpRequestResult &request_info
 	);
-	static HttpResponseFormat CreateErrorHttpResponseResult(const HttpRequestResult &request_info);
+	static HttpResponseFormat CreateErrorHttpResponseResult(const StatusCode &status_code);
 	static std::string        CreateDefaultBodyMessageFormat(
 			   const std::string &status_code, const std::string &reason_phrase
 		   );

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -31,13 +31,13 @@ struct MockDtoServerInfos;
 
 class HttpResponse {
   public:
-	typedef std::map<StatusCode, std::string> ReasonPhrase;
-	static std::string                        Run(const HttpRequestResult &request_info);
-	static std::string                        TmpRun(
-							   const MockDtoClientInfos &client_info,
-							   const MockDtoServerInfos &server_info,
-							   HttpRequestResult        &request_info
-						   );
+	typedef std::map<EStatusCode, std::string> ReasonPhrase;
+	static std::string                         Run(const HttpRequestResult &request_info);
+	static std::string                         TmpRun(
+								const MockDtoClientInfos &client_info,
+								const MockDtoServerInfos &server_info,
+								HttpRequestResult        &request_info
+							);
 	static void GetHandler(const std::string &path, std::string &body_message);
 	static void PostHandler(
 		const std::string &path,

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -25,8 +25,8 @@ void HttpServerInfoCheck::CheckDTOServerInfo(
 	const HeaderFields       &header_fields
 ) {
 	if (header_fields.find(CONTENT_LENGTH) != header_fields.end()) {
-		utils::Result<unsigned int> content_length =
-			utils::ConvertStrToUint(header_fields.at(CONTENT_LENGTH));
+		utils::Result<std::size_t> content_length =
+			utils::ConvertStrToSize(header_fields.at(CONTENT_LENGTH));
 		if (content_length.IsOk() && content_length.GetValue() > server_info.client_max_body_size) {
 			throw HttpException("Error: payload too large.", StatusCode(PAYLOAD_TOO_LARGE));
 		}

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -32,7 +32,7 @@ void HttpServerInfoCheck::CheckDTOServerInfo(
 		}
 	}
 	if (!server_info.error_page.second.empty()) {
-		result.error_page = server_info.error_page;
+		result.error_page.Set(true, server_info.error_page);
 	}
 }
 

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -23,7 +23,7 @@ void HttpServerInfoCheck::CheckDTOServerInfo(
 ) {
 	if (static_cast<size_t>(std::atoi(header_fields["Content-Length"].c_str())) >
 		server_info.client_max_body_size) { // Check content_length
-		throw HttpException("Error: payload too large.", PAYLOAD_TOO_LARGE);
+		throw HttpException("Error: payload too large.", StatusCode(PAYLOAD_TOO_LARGE));
 	} else if (!server_info.error_page.second.empty()) { // Check error_page
 		result.error_page = server_info.error_page;
 	}
@@ -65,7 +65,7 @@ const MockLocationCon HttpServerInfoCheck::CheckLocation(
 		}
 	}
 	if (match_loc.request_uri.empty()) {
-		throw HttpException("Error: location not found", NOT_FOUND);
+		throw HttpException("Error: location not found", StatusCode(NOT_FOUND));
 	}
 	return match_loc;
 }

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
@@ -32,7 +32,7 @@ class HttpServerInfoCheck {
 	static void CheckDTOServerInfo(
 		CheckServerInfoResult    &result,
 		const MockDtoServerInfos &server_info,
-		HeaderFields             &header_fields
+		const HeaderFields       &header_fields
 	);
 	static void CheckLocationList(
 		CheckServerInfoResult &result,
@@ -55,7 +55,7 @@ class HttpServerInfoCheck {
 
   public:
 	static CheckServerInfoResult
-	Check(const MockDtoServerInfos &server_info, HttpRequestFormat &request);
+	Check(const MockDtoServerInfos &server_info, const HttpRequestFormat &request);
 };
 
 } // namespace http

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
@@ -20,8 +20,11 @@ struct CheckServerInfoResult {
 	std::string            upload_directory;
 
 	utils::Result< std::pair<unsigned int, std::string> > redirect;
-	std::pair<unsigned int, std::string>                  error_page;
-	CheckServerInfoResult() : autoindex(false){};
+	utils::Result< std::pair<unsigned int, std::string> > error_page;
+	CheckServerInfoResult() : autoindex(false) {
+		redirect.Set(false);
+		error_page.Set(false);
+	};
 };
 
 class HttpServerInfoCheck {

--- a/srcs/http/status_code.cpp
+++ b/srcs/http/status_code.cpp
@@ -20,14 +20,27 @@ ReasonPhrase InitReasonPhrase() {
 
 const ReasonPhrase reason_phrase = InitReasonPhrase();
 
-StatusCode::StatusCode(const EStatusCode &status_code)
+StatusCode::StatusCode(EStatusCode status_code)
 	: status_code_(status_code),
 	  str_status_code_(utils::ToString(status_code)),
 	  reason_phrase_(InitReasonPhrase()) {}
 
 StatusCode::~StatusCode() {}
 
-std::string StatusCode::GetStatusCode() const {
+StatusCode::StatusCode(const StatusCode &other) {
+	*this = other;
+}
+
+StatusCode &StatusCode::operator=(const StatusCode &other) {
+	if (this != &other) {
+		status_code_     = other.status_code_;
+		str_status_code_ = other.str_status_code_;
+		reason_phrase_   = other.reason_phrase_;
+	}
+	return *this;
+}
+
+const std::string &StatusCode::GetStatusCode() const {
 	return str_status_code_;
 }
 
@@ -35,7 +48,7 @@ EStatusCode StatusCode::GetEStatusCode() const {
 	return status_code_;
 }
 
-std::string StatusCode::GetReasonPhrase() const {
+const std::string &StatusCode::GetReasonPhrase() const {
 	return reason_phrase_.at(status_code_);
 }
 

--- a/srcs/http/status_code.cpp
+++ b/srcs/http/status_code.cpp
@@ -1,4 +1,5 @@
 #include "status_code.hpp"
+#include "utils.hpp"
 
 namespace http {
 
@@ -18,5 +19,24 @@ ReasonPhrase InitReasonPhrase() {
 }
 
 const ReasonPhrase reason_phrase = InitReasonPhrase();
+
+StatusCode::StatusCode(const EStatusCode &status_code)
+	: status_code_(status_code),
+	  str_status_code_(utils::ToString(status_code)),
+	  reason_phrase_(InitReasonPhrase()) {}
+
+StatusCode::~StatusCode() {}
+
+std::string StatusCode::GetStatusCode() const {
+	return str_status_code_;
+}
+
+EStatusCode StatusCode::GetEStatusCode() const {
+	return status_code_;
+}
+
+std::string StatusCode::GetReasonPhrase() const {
+	return reason_phrase_.at(status_code_);
+}
 
 } // namespace http

--- a/srcs/http/status_code.cpp
+++ b/srcs/http/status_code.cpp
@@ -3,7 +3,9 @@
 
 namespace http {
 
-ReasonPhrase InitReasonPhrase() {
+typedef std::map<EStatusCode, std::string> ReasonPhrase;
+
+ReasonPhrase StatusCode::InitReasonPhrase() {
 	ReasonPhrase init_reason_phrase;
 	init_reason_phrase[OK]                    = "OK";
 	init_reason_phrase[CREATED]               = "Created";
@@ -17,8 +19,6 @@ ReasonPhrase InitReasonPhrase() {
 	init_reason_phrase[NOT_IMPLEMENTED]       = "Not Implemented";
 	return init_reason_phrase;
 }
-
-const ReasonPhrase reason_phrase = InitReasonPhrase();
 
 StatusCode::StatusCode(EStatusCode status_code)
 	: status_code_(status_code),

--- a/srcs/http/status_code.cpp
+++ b/srcs/http/status_code.cpp
@@ -3,9 +3,7 @@
 
 namespace http {
 
-typedef std::map<EStatusCode, std::string> ReasonPhrase;
-
-ReasonPhrase StatusCode::InitReasonPhrase() {
+StatusCode::ReasonPhrase StatusCode::InitReasonPhrase() {
 	ReasonPhrase init_reason_phrase;
 	init_reason_phrase[OK]                    = "OK";
 	init_reason_phrase[CREATED]               = "Created";

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -24,11 +24,14 @@ extern const ReasonPhrase                  reason_phrase;
 
 class StatusCode {
   public:
-	explicit StatusCode(const EStatusCode &status_code);
+	explicit StatusCode(EStatusCode status_code);
 	~StatusCode();
-	std::string GetStatusCode() const;
-	EStatusCode GetEStatusCode() const;
-	std::string GetReasonPhrase() const;
+	StatusCode(const StatusCode &other);
+	StatusCode &operator=(const StatusCode &other);
+
+	EStatusCode        GetEStatusCode() const;
+	const std::string &GetStatusCode() const;
+	const std::string &GetReasonPhrase() const;
 
   private:
 	EStatusCode                                status_code_;

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -19,9 +19,6 @@ enum EStatusCode {
 	NOT_IMPLEMENTED       = 501
 };
 
-typedef std::map<EStatusCode, std::string> ReasonPhrase;
-extern const ReasonPhrase                  reason_phrase;
-
 class StatusCode {
   public:
 	explicit StatusCode(EStatusCode status_code);
@@ -38,6 +35,7 @@ class StatusCode {
 	std::string                                str_status_code_;
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
 	ReasonPhrase                               reason_phrase_;
+	ReasonPhrase                               InitReasonPhrase();
 };
 
 } // namespace http

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -35,7 +35,7 @@ class StatusCode {
 	std::string                                str_status_code_;
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
 	ReasonPhrase                               reason_phrase_;
-	ReasonPhrase                   InitReasonPhrase();
+	ReasonPhrase                               InitReasonPhrase();
 };
 
 } // namespace http

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -35,7 +35,7 @@ class StatusCode {
 	std::string                                str_status_code_;
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
 	ReasonPhrase                               reason_phrase_;
-	ReasonPhrase                               InitReasonPhrase();
+	StatusCode::ReasonPhrase                   InitReasonPhrase();
 };
 
 } // namespace http

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -6,7 +6,7 @@
 
 namespace http {
 
-enum StatusCode {
+enum EStatusCode {
 	OK                    = 200,
 	CREATED               = 201,
 	NO_CONTENT            = 204,
@@ -18,8 +18,24 @@ enum StatusCode {
 	INTERNAL_SERVER_ERROR = 500,
 	NOT_IMPLEMENTED       = 501
 };
-typedef std::map<StatusCode, std::string> ReasonPhrase;
-extern const ReasonPhrase                 reason_phrase;
+
+typedef std::map<EStatusCode, std::string> ReasonPhrase;
+extern const ReasonPhrase                  reason_phrase;
+
+class StatusCode {
+  public:
+	explicit StatusCode(const EStatusCode &status_code);
+	~StatusCode();
+	std::string GetStatusCode() const;
+	EStatusCode GetEStatusCode() const;
+	std::string GetReasonPhrase() const;
+
+  private:
+	EStatusCode                                status_code_;
+	std::string                                str_status_code_;
+	typedef std::map<EStatusCode, std::string> ReasonPhrase;
+	ReasonPhrase                               reason_phrase_;
+};
 
 } // namespace http
 

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -35,7 +35,7 @@ class StatusCode {
 	std::string                                str_status_code_;
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
 	ReasonPhrase                               reason_phrase_;
-	StatusCode::ReasonPhrase                   InitReasonPhrase();
+	ReasonPhrase                   InitReasonPhrase();
 };
 
 } // namespace http

--- a/srcs/http/tmp_http.cpp
+++ b/srcs/http/tmp_http.cpp
@@ -14,8 +14,6 @@ TmpHttp::~TmpHttp() {}
 
 HttpResult
 TmpHttp::Run(const MockDtoClientInfos &client_info, const MockDtoServerInfos &server_info) {
-	// todo: when HttpResponse::Run arguments require server_info.
-	(void)server_info;
 	HttpResult          result;
 	utils::Result<void> parsed_result =
 		TmpParseHttpRequestFormat(client_info.fd, client_info.request_buf);

--- a/srcs/http/tmp_http.hpp
+++ b/srcs/http/tmp_http.hpp
@@ -35,10 +35,10 @@ class TmpHttp {
 	HttpResult Run(const MockDtoClientInfos &client_info, const MockDtoServerInfos &server_info);
 	void       ParseHttpRequestFormat(int client_fd, const std::string &read_buf);
 	utils::Result<void> TmpParseHttpRequestFormat(int client_fd, const std::string &read_buf);
-	std::string        CreateHttpResponse(int client_fd);
-	std::string        CreateHttpResponse(
-			   const MockDtoClientInfos &client_info, const MockDtoServerInfos &server_info
-		   );
+	std::string         CreateHttpResponse(int client_fd);
+	std::string         CreateHttpResponse(
+				const MockDtoClientInfos &client_info, const MockDtoServerInfos &server_info
+			);
 	// todo: 408のtimeoutのレスポンス
 
 	// For test

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -15,9 +15,9 @@ enum ConnectionState {
 
 // todo: tmp
 struct Response {
-	Response() : connection_state(KEEP){};
+	Response() : connection_state(KEEP) {};
 	Response(ConnectionState connection_state, const std::string &response_str)
-		: connection_state(connection_state), response_str(response_str){};
+		: connection_state(connection_state), response_str(response_str) {};
 
 	ConnectionState connection_state;
 	std::string     response_str;

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -5,6 +5,7 @@ TEST_DIRS	:=	convert_str \
 				http_parse \
 				http_storage \
 				http_method \
+				http_status_code \
 				http_serverinfo_check \
 				sock_context \
 				split_str \

--- a/test/unit/http/Makefile
+++ b/test/unit/http/Makefile
@@ -30,7 +30,7 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_HTTP_RESPONSE_DIR)/http_response.cpp \
 						$(WS_HTTP_SERVER_INFO_CHECK_DIR)/http_serverinfo_check.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp \
-						$(WS_VERTUAL_SERVER_DIR)/virtual_server.cpp \
+						$(WS_VERTUAL_SERVER_DIR)/virtual_server.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http.cpp

--- a/test/unit/http/test_http.cpp
+++ b/test/unit/http/test_http.cpp
@@ -84,10 +84,13 @@ Result IsSameHttpRequestParsedData(
 ) {
 	Result             request_parsed_result;
 	std::ostringstream oss;
-	if (!IsSame(result.request_result.status_code, expected.request_result.status_code)) {
+	if (!IsSame(
+			result.request_result.status_code.GetEStatusCode(),
+			expected.request_result.status_code.GetEStatusCode()
+		)) {
 		oss << "Error: Status Code\n";
-		oss << "- Expected: [" << expected.request_result.status_code << "]\n";
-		oss << "- Result  : [" << result.request_result.status_code << "]\n";
+		oss << "- Expected: [" << expected.request_result.status_code.GetStatusCode() << "]\n";
+		oss << "- Result  : [" << result.request_result.status_code.GetStatusCode() << "]\n";
 		request_parsed_result.is_success = false;
 	}
 	if (!IsSameHttpRequestFormat(result.is_request_format, expected.is_request_format)) {
@@ -139,18 +142,18 @@ int main(void) {
 
 	// 1.リクエストラインの書式が正しい場合
 	http::HttpRequestParsedData test1_request_line;
-	test1_request_line.request_result.status_code        = http::OK;
+	test1_request_line.request_result.status_code        = http::StatusCode(http::OK);
 	test1_request_line.is_request_format.is_request_line = true;
 
 	// 2.リクエストラインの書式が正しいくない場合
 	http::HttpRequestParsedData test2_request_line;
-	test2_request_line.request_result.status_code        = http::BAD_REQUEST;
+	test2_request_line.request_result.status_code        = http::StatusCode(http::BAD_REQUEST);
 	test2_request_line.is_request_format.is_request_line = false;
 
 	// 3.CRLNがない場合
 	http::HttpRequestParsedData test3_request_line;
 	// 本来のステータスコードはRequest Timeout
-	test3_request_line.request_result.status_code        = http::OK;
+	test3_request_line.request_result.status_code        = http::StatusCode(http::OK);
 	test3_request_line.is_request_format.is_request_line = false;
 
 	static const TestCase test_case_http_request_line_format[] = {
@@ -166,14 +169,14 @@ int main(void) {
 
 	// 4.ヘッダフィールドの書式が正しい場合
 	http::HttpRequestParsedData test1_header_fields;
-	test1_header_fields.request_result.status_code         = http::OK;
+	test1_header_fields.request_result.status_code         = http::StatusCode(http::OK);
 	test1_header_fields.is_request_format.is_request_line  = true;
 	test1_header_fields.is_request_format.is_header_fields = true;
 	test1_header_fields.is_request_format.is_body_message  = true;
 
 	// 5.ヘッダフィールドの書式が正しくない場合
 	http::HttpRequestParsedData test2_header_fields;
-	test2_header_fields.request_result.status_code         = http::BAD_REQUEST;
+	test2_header_fields.request_result.status_code         = http::StatusCode(http::BAD_REQUEST);
 	test2_header_fields.is_request_format.is_request_line  = true;
 	test2_header_fields.is_request_format.is_header_fields = false;
 	test2_header_fields.is_request_format.is_body_message  = false;
@@ -181,7 +184,7 @@ int main(void) {
 	// 6.ヘッダフィールドにContent-Lengthがあるがボディメッセージがない場合
 	http::HttpRequestParsedData test3_header_fileds;
 	// 本来のステータスコードはRequest Timeout
-	test3_header_fileds.request_result.status_code         = http::OK;
+	test3_header_fileds.request_result.status_code         = http::StatusCode(http::OK);
 	test3_header_fileds.is_request_format.is_request_line  = true;
 	test3_header_fileds.is_request_format.is_header_fields = true;
 	test3_header_fileds.is_request_format.is_body_message  = false;
@@ -202,14 +205,14 @@ int main(void) {
 
 	// 7.ボディメッセージが正しい場合
 	http::HttpRequestParsedData test1_body_message;
-	test1_body_message.request_result.status_code         = http::OK;
+	test1_body_message.request_result.status_code         = http::StatusCode(http::OK);
 	test1_body_message.is_request_format.is_request_line  = true;
 	test1_body_message.is_request_format.is_header_fields = true;
 	test1_body_message.is_request_format.is_body_message  = true;
 
 	// 8.Content-Lengthの数値以上にボディメッセージがある場合
 	http::HttpRequestParsedData test2_body_message;
-	test2_body_message.request_result.status_code          = http::OK;
+	test2_body_message.request_result.status_code          = http::StatusCode(http::OK);
 	test2_body_message.is_request_format.is_request_line   = true;
 	test2_body_message.is_request_format.is_header_fields  = true;
 	test2_body_message.is_request_format.is_body_message   = true;
@@ -217,7 +220,7 @@ int main(void) {
 
 	// 9.Content-Lengthの値の書式が間違ってる場合
 	http::HttpRequestParsedData test3_body_message;
-	test3_body_message.request_result.status_code          = http::BAD_REQUEST;
+	test3_body_message.request_result.status_code          = http::StatusCode(http::BAD_REQUEST);
 	test3_body_message.is_request_format.is_request_line   = true;
 	test3_body_message.is_request_format.is_header_fields  = true;
 	test3_body_message.is_request_format.is_body_message   = false;
@@ -248,7 +251,7 @@ int main(void) {
 	// 10.ボディメッセージを追加で送信した場合
 	http::TmpHttp               test4_body_message;
 	http::HttpRequestParsedData test4_expected_body_message;
-	test4_expected_body_message.request_result.status_code          = http::OK;
+	test4_expected_body_message.request_result.status_code          = http::StatusCode(http::OK);
 	test4_expected_body_message.is_request_format.is_request_line   = true;
 	test4_expected_body_message.is_request_format.is_header_fields  = true;
 	test4_expected_body_message.is_request_format.is_body_message   = false;

--- a/test/unit/http_method/Makefile
+++ b/test/unit/http_method/Makefile
@@ -21,6 +21,8 @@ WS_VERTUAL_SERVER_DIR	:=	$(WS_SRCS_DIR)/server/context_manager/virtual_server
 
 SRCS			+=	$(WS_UTILS_DIR)/color.cpp \
 					$(WS_UTILS_DIR)/system_exception.cpp \
+					$(WS_UTILS_DIR)/convert_str.cpp \
+					$(WS_UTILS_DIR)/isdigit.cpp \
 					$(WS_HTTP_DIR)/http_message.cpp \
 					$(WS_HTTP_DIR)/status_code.cpp \
 					$(WS_HTTP_DIR)/http_exception.cpp \

--- a/test/unit/http_method/Makefile
+++ b/test/unit/http_method/Makefile
@@ -30,7 +30,7 @@ SRCS			+=	$(WS_UTILS_DIR)/color.cpp \
 					$(WS_HTTP_RESPONSE_DIR)/http_response.cpp \
 					$(WS_HTTP_RESPONSE_DIR)/http_handle_method.cpp \
 					$(WS_HTTP_SERVER_INFO_CHECK_DIR)/http_serverinfo_check.cpp \
-					$(WS_VERTUAL_SERVER_DIR)/virtual_server.cpp \
+					$(WS_VERTUAL_SERVER_DIR)/virtual_server.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http_method.cpp

--- a/test/unit/http_parse/Makefile
+++ b/test/unit/http_parse/Makefile
@@ -20,7 +20,7 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp \
-						$(WS_HTTP_PARSE_DIR)/http_parse.cpp \
+						$(WS_HTTP_PARSE_DIR)/http_parse.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http_parse.cpp

--- a/test/unit/http_parse/Makefile
+++ b/test/unit/http_parse/Makefile
@@ -18,8 +18,9 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/isdigit.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
+						$(WS_HTTP_DIR)/http_exception.cpp \
+						$(WS_HTTP_DIR)/status_code.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp \
-						$(WS_HTTP_DIR)/http_exception.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http_parse.cpp

--- a/test/unit/http_parse/test_http_parse.cpp
+++ b/test/unit/http_parse/test_http_parse.cpp
@@ -87,7 +87,7 @@ IsSameHttpRequest(const http::HttpRequestFormat &res, const http::HttpRequestFor
 	return http_request_result;
 }
 
-Result IsSameStatusCode(http::StatusCode status_code, http::StatusCode expected) {
+Result IsSameStatusCode(http::EStatusCode status_code, http::EStatusCode expected) {
 	Result status_code_result;
 	if (status_code != expected) {
 		std::ostringstream error_log;

--- a/test/unit/http_parse/test_http_parse.cpp
+++ b/test/unit/http_parse/test_http_parse.cpp
@@ -87,13 +87,13 @@ IsSameHttpRequest(const http::HttpRequestFormat &res, const http::HttpRequestFor
 	return http_request_result;
 }
 
-Result IsSameStatusCode(http::EStatusCode status_code, http::EStatusCode expected) {
+Result IsSameStatusCode(const http::StatusCode &status_code, const http::StatusCode &expected) {
 	Result status_code_result;
-	if (status_code != expected) {
+	if (status_code.GetEStatusCode() != expected.GetEStatusCode()) {
 		std::ostringstream error_log;
 		error_log << "Error: Status Code\n";
-		error_log << "- Expected: [" << expected << "]\n";
-		error_log << "- Result  : [" << status_code << "]\n";
+		error_log << "- Expected: [" << expected.GetStatusCode() << "]\n";
+		error_log << "- Result  : [" << status_code.GetStatusCode() << "]\n";
 		status_code_result.is_success = false;
 		status_code_result.error_log  = error_log.str();
 	}
@@ -123,7 +123,7 @@ int HandleResult(const Result &result, const std::string &src) {
 int Run(const std::string &src, const http::HttpRequestResult &expected) {
 	const http::HttpRequestResult result = http::HttpParse::Run(src);
 	Result status_code_result = IsSameStatusCode(result.status_code, expected.status_code);
-	if (status_code_result.is_success && result.status_code == http::OK) {
+	if (status_code_result.is_success && result.status_code.GetEStatusCode() == http::OK) {
 		Result http_request_result = IsSameHttpRequest(result.request, expected.request);
 		return HandleResult(http_request_result, src);
 	} else {
@@ -152,21 +152,21 @@ int main(void) {
 	// NGの場合
 	// static const http::RequestLine             expected_request_line_1("GET", "/d", "HTTP/1.1d");
 	expected_request_line_test_1.request.request_line = expected_request_line_1;
-	expected_request_line_test_1.status_code          = http::OK;
+	expected_request_line_test_1.status_code          = http::StatusCode(http::OK);
 	// NGの場合
-	// expected_request_line_test_1.status_code = http::BAD_REQUEST;
+	// expected_request_line_test_1.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// methodが小文字が含まれてる
 	http::HttpRequestResult expected_request_line_test_2;
-	expected_request_line_test_2.status_code = http::BAD_REQUEST;
+	expected_request_line_test_2.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// methodがUS-ASCII以外の文字が含まれてる
 	http::HttpRequestResult expected_request_line_test_3;
-	expected_request_line_test_3.status_code = http::BAD_REQUEST;
+	expected_request_line_test_3.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// 課題要件以外のmethod(大文字のみ)が含まれてる
 	http::HttpRequestResult expected_request_line_test_4;
-	expected_request_line_test_4.status_code = http::NOT_IMPLEMENTED;
+	expected_request_line_test_4.status_code = http::StatusCode(http::NOT_IMPLEMENTED);
 
 	static const TestCase test_cases_for_request_line[] = {
 		TestCase("GET / HTTP/1.1", expected_request_line_test_1),
@@ -180,39 +180,39 @@ int main(void) {
 	std::cout << "Header Fields Test" << std::endl;
 	http::HttpRequestResult expected_header_fields_test_1;
 	expected_header_fields_test_1.request.request_line                = expected_request_line_1;
-	expected_header_fields_test_1.status_code                         = http::OK;
+	expected_header_fields_test_1.status_code                         = http::StatusCode(http::OK);
 	expected_header_fields_test_1.request.header_fields["Host"]       = "www.example.com";
 	expected_header_fields_test_1.request.header_fields["Connection"] = "keep-alive";
 
 	// セミコロン以降に複数OWS(SpaceとHorizontal Tab)が設定の場合
 	http::HttpRequestResult expected_header_fields_test_2;
 	expected_header_fields_test_2.request.request_line                = expected_request_line_1;
-	expected_header_fields_test_2.status_code                         = http::OK;
+	expected_header_fields_test_2.status_code                         = http::StatusCode(http::OK);
 	expected_header_fields_test_2.request.header_fields["Host"]       = "www.example.com";
 	expected_header_fields_test_2.request.header_fields["Connection"] = "keep-alive";
 
 	// セミコロンの後にnameがある設定の場合
 	http::HttpRequestResult expected_header_fields_test_3;
 	expected_header_fields_test_3.request.request_line                = expected_request_line_1;
-	expected_header_fields_test_3.status_code                         = http::OK;
+	expected_header_fields_test_3.status_code                         = http::StatusCode(http::OK);
 	expected_header_fields_test_3.request.header_fields["Host"]       = "www.example.com";
 	expected_header_fields_test_3.request.header_fields["Connection"] = "keep-alive";
 
 	// 存在しないfield_nameの場合
 	http::HttpRequestResult expected_header_fields_test_4;
-	expected_header_fields_test_4.status_code = http::BAD_REQUEST;
+	expected_header_fields_test_4.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// 複数のヘッダーフィールドの書式が設定の場合
 	http::HttpRequestResult expected_header_fields_test_5;
-	expected_header_fields_test_5.status_code = http::BAD_REQUEST;
+	expected_header_fields_test_5.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// セミコロンがない場合
 	http::HttpRequestResult expected_header_fileds_test_6;
-	expected_header_fileds_test_6.status_code = http::BAD_REQUEST;
+	expected_header_fileds_test_6.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	// セミコロンが複数ある場合
 	http::HttpRequestResult expected_header_fields_test_7;
-	expected_header_fields_test_7.status_code = http::BAD_REQUEST;
+	expected_header_fields_test_7.status_code = http::StatusCode(http::BAD_REQUEST);
 
 	static const TestCase test_cases_for_header_fields[] = {
 		TestCase(

--- a/test/unit/http_serverinfo_check/Makefile
+++ b/test/unit/http_serverinfo_check/Makefile
@@ -18,6 +18,9 @@ WS_HTTP_SERVERINFO_CHECK_DIR	:=	$(WS_HTTP_RESPONSE_DIR)/http_serverinfo_check
 
 SRCS				+=	$(WS_HTTP_SERVERINFO_CHECK_DIR)/http_serverinfo_check.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp \
+						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp
 

--- a/test/unit/http_serverinfo_check/Makefile
+++ b/test/unit/http_serverinfo_check/Makefile
@@ -18,7 +18,8 @@ WS_HTTP_SERVERINFO_CHECK_DIR	:=	$(WS_HTTP_RESPONSE_DIR)/http_serverinfo_check
 
 SRCS				+=	$(WS_HTTP_SERVERINFO_CHECK_DIR)/http_serverinfo_check.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
-						$(WS_HTTP_DIR)/http_exception.cpp
+						$(WS_HTTP_DIR)/http_exception.cpp \
+						$(WS_HTTP_DIR)/status_code.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http_serverinfo_check.cpp

--- a/test/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -128,7 +128,7 @@ int Test1() {
 		COMPARE(result.cgi_extension, location.cgi_extension);
 		COMPARE(result.upload_directory, location.upload_directory);
 		COMPARE(result.redirect.GetValue(), location.redirect);
-		COMPARE(result.error_page, server_info.error_page);
+		COMPARE(result.error_page.GetValue(), server_info.error_page);
 	} catch (const std::exception &e) {
 		PrintNg();
 		std::cerr << e.what() << '\n';
@@ -157,7 +157,7 @@ int Test2() {
 		COMPARE(result.cgi_extension, location.cgi_extension);
 		COMPARE(result.upload_directory, location.upload_directory);
 		COMPARE(result.redirect.GetValue(), location.redirect);
-		COMPARE(result.error_page, server_info.error_page);
+		COMPARE(result.error_page.GetValue(), server_info.error_page);
 	} catch (const std::exception &e) {
 		PrintNg();
 		std::cerr << e.what() << '\n';
@@ -187,7 +187,7 @@ int Test3() {
 		COMPARE(result.cgi_extension, location.cgi_extension);
 		COMPARE(result.upload_directory, location.upload_directory);
 		COMPARE(result.redirect.GetValue(), location.redirect);
-		COMPARE(result.error_page, server_info.error_page);
+		COMPARE(result.error_page.GetValue(), server_info.error_page);
 	} catch (const std::exception &e) {
 		PrintNg();
 		std::cerr << e.what() << '\n';
@@ -218,7 +218,7 @@ int Test4() {
 		COMPARE(result.cgi_extension, location.cgi_extension);
 		COMPARE(result.upload_directory, location.upload_directory);
 		COMPARE(result.redirect.GetValue(), location.redirect);
-		COMPARE(result.error_page, server_info.error_page);
+		COMPARE(result.error_page.GetValue(), server_info.error_page);
 	} catch (const std::exception &e) {
 		PrintNg();
 		std::cerr << e.what() << '\n';

--- a/test/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -1,3 +1,4 @@
+#include "http_message.hpp"
 #include "http_serverinfo_check.hpp"
 #include "utils.hpp"
 #include <cstdlib>
@@ -111,9 +112,9 @@ int Test1() {
 	// request
 	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
 	HttpRequestFormat request;
-	request.request_line                = request_line;
-	request.header_fields["Host"]       = "localhost";
-	request.header_fields["Connection"] = "keep-alive";
+	request.request_line              = request_line;
+	request.header_fields[HOST]       = "localhost";
+	request.header_fields[CONNECTION] = "keep-alive";
 
 	MockDtoServerInfos    server_info = BuildMockDtoServerInfos();
 	CheckServerInfoResult result      = HttpServerInfoCheck::Check(server_info, request);
@@ -141,9 +142,9 @@ int Test2() {
 	// request
 	const RequestLine request_line = {"GET", "/www/test.html", "HTTP/1.1"}; // location2(redirect)
 	HttpRequestFormat request;
-	request.request_line                = request_line;
-	request.header_fields["Host"]       = "localhost";
-	request.header_fields["Connection"] = "keep-alive";
+	request.request_line              = request_line;
+	request.header_fields[HOST]       = "localhost";
+	request.header_fields[CONNECTION] = "keep-alive";
 
 	MockDtoServerInfos    server_info = BuildMockDtoServerInfos();
 	CheckServerInfoResult result      = HttpServerInfoCheck::Check(server_info, request);
@@ -170,9 +171,9 @@ int Test3() {
 	// request
 	const RequestLine request_line = {"GET", "/www/data/test.html", "HTTP/1.1"};
 	HttpRequestFormat request;
-	request.request_line                = request_line;
-	request.header_fields["Host"]       = "localhost";
-	request.header_fields["Connection"] = "keep-alive";
+	request.request_line              = request_line;
+	request.header_fields[HOST]       = "localhost";
+	request.header_fields[CONNECTION] = "keep-alive";
 
 	MockDtoServerInfos    server_info = BuildMockDtoServerInfos();
 	CheckServerInfoResult result      = HttpServerInfoCheck::Check(server_info, request);
@@ -200,9 +201,9 @@ int Test4() {
 	// request
 	const RequestLine request_line = {"GET", "/web/", "HTTP/1.1"};
 	HttpRequestFormat request;
-	request.request_line                = request_line;
-	request.header_fields["Host"]       = "localhost";
-	request.header_fields["Connection"] = "keep-alive";
+	request.request_line              = request_line;
+	request.header_fields[HOST]       = "localhost";
+	request.header_fields[CONNECTION] = "keep-alive";
 
 	MockDtoServerInfos    server_info = BuildMockDtoServerInfos();
 	CheckServerInfoResult result      = HttpServerInfoCheck::Check(server_info, request);

--- a/test/unit/http_status_code/Makefile
+++ b/test/unit/http_status_code/Makefile
@@ -1,0 +1,76 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	http_status_code
+TEST_CASE_DIR		:=	test
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR		:=	../../../srcs
+WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
+WS_HTTP_DIR				:=	$(WS_SRCS_DIR)/http
+
+SRCS			+=	$(WS_UTILS_DIR)/color.cpp \
+					$(WS_HTTP_DIR)/status_code.cpp \
+# 3. Add unit test files
+SRCS	+=	test_http_status_code.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_UTILS_DIR) \
+				$(WS_HTTP_DIR) \
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all:  $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean: 
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/unit/http_status_code/Makefile
+++ b/test/unit/http_status_code/Makefile
@@ -14,13 +14,14 @@ WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
 WS_HTTP_DIR				:=	$(WS_SRCS_DIR)/http
 
 SRCS			+=	$(WS_UTILS_DIR)/color.cpp \
-					$(WS_HTTP_DIR)/status_code.cpp \
+					$(WS_HTTP_DIR)/status_code.cpp
+
 # 3. Add unit test files
 SRCS	+=	test_http_status_code.cpp
 
 # 4. Add directory for INCLUDE
 SRCS_DIR	:=	$(WS_UTILS_DIR) \
-				$(WS_HTTP_DIR) \
+				$(WS_HTTP_DIR)
 
 #--------------------------------------------
 OBJ_DIR		:=	objs

--- a/test/unit/http_status_code/test_http_status_code.cpp
+++ b/test/unit/http_status_code/test_http_status_code.cpp
@@ -28,12 +28,17 @@ int HandleResult(const T &result, const T &expected) {
 int main(void) {
 	int ret_code = EXIT_SUCCESS;
 
+	// OKのステータスコードの場合
 	http::StatusCode   ok(http::OK);
 	const std::string &expected_200 = "200";
 	const std::string &expected_ok  = "OK";
 	ret_code |= HandleResult(ok.GetEStatusCode(), http::OK);
 	ret_code |= HandleResult(ok.GetStatusCode(), expected_200);
 	ret_code |= HandleResult(ok.GetReasonPhrase(), expected_ok);
+
+	// 存在しないステータスコードの場合 コンパイルエラー
+	// http::StatusCode   no_status_code(0);
+	// ret_code |= HandleResult(no_status_code.GetEStatusCode(), 0);
 
 	return ret_code;
 }

--- a/test/unit/http_status_code/test_http_status_code.cpp
+++ b/test/unit/http_status_code/test_http_status_code.cpp
@@ -1,0 +1,39 @@
+#include "status_code.hpp"
+#include "utils.hpp"
+#include <cstdlib>
+
+namespace {
+
+int GetTestCaseNum() {
+	static unsigned int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+template <typename T>
+int HandleResult(const T &result, const T &expected) {
+	if (result == expected) {
+		std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+				  << std::endl;
+		return EXIT_SUCCESS;
+	} else {
+		std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+				  << std::endl;
+		return EXIT_FAILURE;
+	}
+}
+
+} // namespace
+
+int main(void) {
+	int ret_code = EXIT_SUCCESS;
+
+	http::StatusCode   ok(http::OK);
+	const std::string &expected_200 = "200";
+	const std::string &expected_ok  = "OK";
+	ret_code |= HandleResult(ok.GetEStatusCode(), http::OK);
+	ret_code |= HandleResult(ok.GetStatusCode(), expected_200);
+	ret_code |= HandleResult(ok.GetReasonPhrase(), expected_ok);
+
+	return ret_code;
+}

--- a/test/unit/http_storage/Makefile
+++ b/test/unit/http_storage/Makefile
@@ -20,6 +20,7 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
+						$(WS_HTTP_DIR)/status_code.cpp \
 						$(WS_HTTP_REQUEST_DIR)/http_storage.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp
 

--- a/test/unit/http_storage/test_http_storage.cpp
+++ b/test/unit/http_storage/test_http_storage.cpp
@@ -36,18 +36,20 @@ int main(void) {
 
 	// クライアントのHttpRequestParsedDataを新規作成 -> OK
 	http::HttpRequestParsedData new_data = storage.GetClientSaveData(1);
-	ret_code |= HandleResult(new_data.request_result.status_code, http::OK);
+	ret_code |= HandleResult(new_data.request_result.status_code.GetEStatusCode(), http::OK);
 
 	// 登録したクライアントのHttpRequestParsedData取得 -> OK
 	http::HttpRequestParsedData save_data = storage.GetClientSaveData(1);
-	ret_code |= HandleResult(save_data.request_result.status_code, http::OK);
+	ret_code |= HandleResult(save_data.request_result.status_code.GetEStatusCode(), http::OK);
 
 	// ClientSaveDataを更新 -> OK
 	try {
-		save_data.request_result.status_code = http::BAD_REQUEST;
+		save_data.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
 		storage.UpdateClientSaveData(1, save_data);
 		http::HttpRequestParsedData update_data = storage.GetClientSaveData(1);
-		ret_code |= HandleResult(update_data.request_result.status_code, http::BAD_REQUEST);
+		ret_code |= HandleResult(
+			update_data.request_result.status_code.GetEStatusCode(), http::BAD_REQUEST
+		);
 	} catch (const std::logic_error &e) {
 		ret_code |= ResultNg();
 		std::cerr << e.what() << std::endl;
@@ -67,7 +69,7 @@ int main(void) {
 		storage.DeleteClientSaveData(1);
 		new_data = storage.GetClientSaveData(1);
 		// 更新したSaveData情報を削除されているかどうかを確認するため、BAD_REQUESTではなくOK
-		ret_code |= HandleResult(new_data.request_result.status_code, http::OK);
+		ret_code |= HandleResult(new_data.request_result.status_code.GetEStatusCode(), http::OK);
 	} catch (const std::logic_error &e) {
 		ret_code |= ResultNg();
 		std::cerr << e.what() << std::endl;


### PR DESCRIPTION
### したこと
- StatusCodeクラス作成
  - enumからclassへのリファクタリング
- HttpResponse::TmpRunの引数をconst参照に変更
- HttpServerInfoCheck::Check
  - 引数をconst参照に変更
  - error_pageとheader_filedsのcontent_lengthをResult型に変更
  - CheckServerInfoResult にあるerror_pageとredirectの初期化をfalseに変更

### 今後
- CheckServerInfoResult に対応したMethodHandler作成
- cgi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTP ステータスコードの取り扱いを強化するため、`StatusCode` クラスが導入されました。
  - エラーハンドリングの改善により、HTTP ステータスコードをより明確に管理できるようになりました。

- **バグ修正**
  - HTTP リクエストの解析におけるエラー処理が改善され、ステータスコードの管理が一貫性を持つようになりました。

- **ドキュメント**
  - テストカバレッジが拡張され、HTTP ステータスコードに関連する機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->