### PR TITLE
[server] 複数 virtual server が同じ host:port を共有している場合の対応 

### DIFF
--- a/srcs/server/connection.cpp
+++ b/srcs/server/connection.cpp
@@ -32,7 +32,7 @@ Connection::AddrInfo *Connection::GetAddrInfoList(const ServerInfo &server_info)
 	InitHints(&hints);
 
 	AddrInfo *result;
-	const int status = getaddrinfo(NULL, port.c_str(), &hints, &result);
+	const int status = getaddrinfo(server_info.GetHost().c_str(), port.c_str(), &hints, &result);
 	// EAI_MEMORY is also included in status != 0
 	if (status != 0) {
 		throw std::runtime_error("getaddrinfo failed: " + std::string(gai_strerror(status)));

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -30,6 +30,9 @@ void ContextManager::AddServerInfo(
 ) {
 	const int server_fd = server_info.GetFd();
 	virtual_servers_.AddMapping(server_fd, virtual_server);
+	if (sock_context_.IsServerInfoExist(server_fd)) {
+		return;
+	}
 	sock_context_.AddServerInfo(server_fd, server_info);
 }
 

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -42,7 +42,7 @@ void ContextManager::DeleteClientInfo(int client_fd) {
 	sock_context_.DeleteClientInfo(client_fd);
 }
 
-const VirtualServerStorage::VirtualServerList &ContextManager::GetVirtualServerList() const {
+const VirtualServerStorage::VirtualServerList &ContextManager::GetAllVirtualServer() const {
 	return virtual_servers_.GetAllVirtualServerList();
 }
 

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -29,6 +29,7 @@ void ContextManager::AddServerInfo(
 	const ServerInfo &server_info, const VirtualServer *virtual_server
 ) {
 	const int server_fd = server_info.GetFd();
+	virtual_servers_.RemoveAddMapping(server_fd, virtual_server); // todo: remove
 	virtual_servers_.AddMapping(server_fd, virtual_server);
 	if (sock_context_.IsServerInfoExist(server_fd)) {
 		return;

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -56,15 +56,17 @@ ServerContext ContextManager::GetServerContext(int client_fd) const {
 	const int         server_fd   = server_info.GetFd();
 
 	// from virtual_servers
+	// todo: remove
 	const VirtualServer &virtual_server = virtual_servers_.GetVirtualServer(server_fd);
 
 	// create ServerContext
 	ServerContext server_infos;
 	server_infos.fd          = server_fd;
-	server_infos.server_name = virtual_server.GetServerName();
+	server_infos.server_name = virtual_server.GetServerName(); // todo: remove
 	// todo: uintのままで良いかも？
-	server_infos.port      = utils::ConvertUintToStr(server_info.GetPort());
-	server_infos.locations = virtual_server.GetLocations();
+	server_infos.port      = utils::ConvertUintToStr(server_info.GetPort()); // todo: remove
+	server_infos.locations = virtual_server.GetLocations();                  // todo: remove
+	server_infos.virtual_server_addr_list = virtual_servers_.GetVirtualServerAddrList(server_fd);
 	return server_infos;
 }
 

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -1,7 +1,6 @@
 #include "context_manager.hpp"
 #include "client_info.hpp"
 #include "server_info.hpp"
-#include "utils.hpp"
 
 namespace server {
 
@@ -58,6 +57,11 @@ ServerContext ContextManager::GetServerContext(int client_fd) const {
 	server_infos.fd                       = server_fd;
 	server_infos.virtual_server_addr_list = virtual_servers_.GetVirtualServerAddrList(server_fd);
 	return server_infos;
+}
+
+ContextManager::GetServerInfoResult
+ContextManager::GetServerInfo(const std::string &host, unsigned int port) const {
+	return sock_context_.GetServerInfo(host, port);
 }
 
 // todo: IP以外も必要ならClientContext作って詰めて返す

--- a/srcs/server/context_manager/context_manager.cpp
+++ b/srcs/server/context_manager/context_manager.cpp
@@ -29,7 +29,6 @@ void ContextManager::AddServerInfo(
 	const ServerInfo &server_info, const VirtualServer *virtual_server
 ) {
 	const int server_fd = server_info.GetFd();
-	virtual_servers_.RemoveAddMapping(server_fd, virtual_server); // todo: remove
 	virtual_servers_.AddMapping(server_fd, virtual_server);
 	if (sock_context_.IsServerInfoExist(server_fd)) {
 		return;
@@ -51,21 +50,12 @@ const VirtualServerStorage::VirtualServerList &ContextManager::GetAllVirtualServ
 }
 
 ServerContext ContextManager::GetServerContext(int client_fd) const {
-	// from sock_context
 	const ServerInfo &server_info = sock_context_.GetConnectedServerInfo(client_fd);
 	const int         server_fd   = server_info.GetFd();
 
-	// from virtual_servers
-	// todo: remove
-	const VirtualServer &virtual_server = virtual_servers_.GetVirtualServer(server_fd);
-
 	// create ServerContext
 	ServerContext server_infos;
-	server_infos.fd          = server_fd;
-	server_infos.server_name = virtual_server.GetServerName(); // todo: remove
-	// todo: uintのままで良いかも？
-	server_infos.port      = utils::ConvertUintToStr(server_info.GetPort()); // todo: remove
-	server_infos.locations = virtual_server.GetLocations();                  // todo: remove
+	server_infos.fd                       = server_fd;
 	server_infos.virtual_server_addr_list = virtual_servers_.GetVirtualServerAddrList(server_fd);
 	return server_infos;
 }

--- a/srcs/server/context_manager/context_manager.hpp
+++ b/srcs/server/context_manager/context_manager.hpp
@@ -9,11 +9,7 @@
 namespace server {
 
 struct ServerContext {
-	int                         fd;
-	std::string                 server_name; // todo: remove
-	std::string                 port;        // todo: remove
-	VirtualServer::LocationList locations;   // todo: remove
-
+	int                                         fd;
 	VirtualServerStorage::VirtualServerAddrList virtual_server_addr_list;
 };
 

--- a/srcs/server/context_manager/context_manager.hpp
+++ b/srcs/server/context_manager/context_manager.hpp
@@ -28,7 +28,7 @@ class ContextManager {
 	void AddClientInfo(const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int client_fd);
 	// getter
-	const VirtualServerStorage::VirtualServerList &GetVirtualServerList() const;
+	const VirtualServerStorage::VirtualServerList &GetAllVirtualServer() const;
 	ServerContext                                  GetServerContext(int client_fd) const;
 	const std::string                             &GetClientIp(int client_fd) const;
 

--- a/srcs/server/context_manager/context_manager.hpp
+++ b/srcs/server/context_manager/context_manager.hpp
@@ -2,6 +2,7 @@
 #define SERVER_CONTEXTMANAGER_CONTEXTMANAGER_HPP_
 
 #include "sock_context.hpp"
+#include "utils.hpp"
 #include "virtual_server.hpp"
 #include "virtual_server_storage.hpp"
 #include <string>
@@ -16,6 +17,8 @@ struct ServerContext {
 // holds and manages virtual server info and socket context(server socket info, client socket info).
 class ContextManager {
   public:
+	typedef utils::Result<ServerInfo> GetServerInfoResult;
+
 	ContextManager();
 	~ContextManager();
 	ContextManager(const ContextManager &other);
@@ -28,7 +31,8 @@ class ContextManager {
 	// getter
 	const VirtualServerStorage::VirtualServerList &GetAllVirtualServer() const;
 	ServerContext                                  GetServerContext(int client_fd) const;
-	const std::string                             &GetClientIp(int client_fd) const;
+	GetServerInfoResult GetServerInfo(const std::string &host, unsigned int port) const;
+	const std::string  &GetClientIp(int client_fd) const;
 
   private:
 	VirtualServerStorage virtual_servers_;

--- a/srcs/server/context_manager/context_manager.hpp
+++ b/srcs/server/context_manager/context_manager.hpp
@@ -10,9 +10,11 @@ namespace server {
 
 struct ServerContext {
 	int                         fd;
-	std::string                 server_name;
-	std::string                 port;
-	VirtualServer::LocationList locations;
+	std::string                 server_name; // todo: remove
+	std::string                 port;        // todo: remove
+	VirtualServer::LocationList locations;   // todo: remove
+
+	VirtualServerStorage::VirtualServerAddrList virtual_server_addr_list;
 };
 
 // holds and manages virtual server info and socket context(server socket info, client socket info).

--- a/srcs/server/context_manager/sock_context/server_info.cpp
+++ b/srcs/server/context_manager/sock_context/server_info.cpp
@@ -2,9 +2,10 @@
 
 namespace server {
 
-ServerInfo::ServerInfo() : fd_(0), port_(0) {}
+ServerInfo::ServerInfo() : fd_(0), host_("0.0.0.0"), port_(0) {}
 
-ServerInfo::ServerInfo(unsigned int port) : fd_(0), port_(port) {}
+ServerInfo::ServerInfo(const std::string &host, unsigned int port)
+	: fd_(0), host_(host), port_(port) {}
 
 ServerInfo::~ServerInfo() {}
 
@@ -15,6 +16,7 @@ ServerInfo::ServerInfo(const ServerInfo &other) {
 ServerInfo &ServerInfo::operator=(const ServerInfo &other) {
 	if (this != &other) {
 		fd_   = other.fd_;
+		host_ = other.host_;
 		port_ = other.port_;
 	}
 	return *this;
@@ -22,6 +24,10 @@ ServerInfo &ServerInfo::operator=(const ServerInfo &other) {
 
 int ServerInfo::GetFd() const {
 	return fd_;
+}
+
+const std::string &ServerInfo::GetHost() const {
+	return host_;
 }
 
 unsigned int ServerInfo::GetPort() const {

--- a/srcs/server/context_manager/sock_context/server_info.cpp
+++ b/srcs/server/context_manager/sock_context/server_info.cpp
@@ -26,6 +26,7 @@ int ServerInfo::GetFd() const {
 	return fd_;
 }
 
+// todo: not used yet
 const std::string &ServerInfo::GetHost() const {
 	return host_;
 }

--- a/srcs/server/context_manager/sock_context/server_info.cpp
+++ b/srcs/server/context_manager/sock_context/server_info.cpp
@@ -26,7 +26,6 @@ int ServerInfo::GetFd() const {
 	return fd_;
 }
 
-// todo: not used yet
 const std::string &ServerInfo::GetHost() const {
 	return host_;
 }

--- a/srcs/server/context_manager/sock_context/server_info.hpp
+++ b/srcs/server/context_manager/sock_context/server_info.hpp
@@ -9,18 +9,20 @@ class ServerInfo {
   public:
 	// default constructor: necessary for map's insert/[]
 	ServerInfo();
-	explicit ServerInfo(unsigned int port);
+	ServerInfo(const std::string &host, unsigned int port);
 	~ServerInfo();
 	ServerInfo(const ServerInfo &other);
 	ServerInfo &operator=(const ServerInfo &other);
 	// getter
-	int          GetFd() const;
-	unsigned int GetPort() const;
+	int                GetFd() const;
+	const std::string &GetHost() const;
+	unsigned int       GetPort() const;
 	// setter
 	void SetSockFd(int fd);
 
   private:
 	int          fd_;
+	std::string  host_;
 	unsigned int port_;
 };
 

--- a/srcs/server/context_manager/sock_context/sock_context.cpp
+++ b/srcs/server/context_manager/sock_context/sock_context.cpp
@@ -66,6 +66,22 @@ void SockContext::DeleteClientInfo(int client_fd) {
 	host_servers_.erase(client_fd);
 }
 
+SockContext::GetServerInfoResult
+SockContext::GetServerInfo(const std::string &host, unsigned int port) const {
+	GetServerInfoResult result;
+	result.Set(false);
+
+	typedef ServerInfoMap::const_iterator Itr;
+	for (Itr it = server_context_.begin(); it != server_context_.end(); ++it) {
+		const ServerInfo &server_info = it->second;
+		if (server_info.GetHost() == host && server_info.GetPort() == port) {
+			result.Set(true, server_info);
+			break;
+		}
+	}
+	return result;
+}
+
 const ClientInfo &SockContext::GetClientInfo(int client_fd) const {
 	try {
 		return client_context_.at(client_fd);

--- a/srcs/server/context_manager/sock_context/sock_context.cpp
+++ b/srcs/server/context_manager/sock_context/sock_context.cpp
@@ -39,6 +39,10 @@ void SockContext::AddServerInfo(int server_fd, const ServerInfo &server_info) {
 	}
 }
 
+bool SockContext::IsServerInfoExist(int server_fd) const {
+	return server_context_.count(server_fd) != 0;
+}
+
 void SockContext::AddClientInfo(int client_fd, const ClientInfo &client_info, int server_fd) {
 	// add client_info to client_context
 	typedef std::pair<ClientInfoMap::const_iterator, bool> ResultInsertToClientContext;

--- a/srcs/server/context_manager/sock_context/sock_context.hpp
+++ b/srcs/server/context_manager/sock_context/sock_context.hpp
@@ -20,6 +20,7 @@ class SockContext {
 	SockContext &operator=(const SockContext &other);
 	// functions
 	void AddServerInfo(int server_fd, const ServerInfo &server_info);
+	bool IsServerInfoExist(int server_fd) const;
 	void AddClientInfo(int client_fd, const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int client_fd);
 	// getter

--- a/srcs/server/context_manager/sock_context/sock_context.hpp
+++ b/srcs/server/context_manager/sock_context/sock_context.hpp
@@ -1,7 +1,9 @@
 #ifndef SERVER_CONTEXTMANAGER_SOCKCONTEXT_SOCKCONTEXT_HPP_
 #define SERVER_CONTEXTMANAGER_SOCKCONTEXT_SOCKCONTEXT_HPP_
 
+#include "utils.hpp"
 #include <map>
+#include <string>
 
 namespace server {
 
@@ -14,6 +16,9 @@ class SockContext {
 	typedef std::map<int, ServerInfo>         ServerInfoMap;
 	typedef std::map<int, ClientInfo>         ClientInfoMap;
 	typedef std::map<int, const ServerInfo *> HostServerInfoMap;
+
+	typedef utils::Result<ServerInfo> GetServerInfoResult;
+
 	SockContext();
 	~SockContext();
 	SockContext(const SockContext &other);
@@ -24,8 +29,9 @@ class SockContext {
 	void AddClientInfo(int client_fd, const ClientInfo &client_info, int server_fd);
 	void DeleteClientInfo(int client_fd);
 	// getter
-	const ClientInfo &GetClientInfo(int client_fd) const;
-	const ServerInfo &GetConnectedServerInfo(int client_fd) const;
+	GetServerInfoResult GetServerInfo(const std::string &host, unsigned int port) const;
+	const ClientInfo   &GetClientInfo(int client_fd) const;
+	const ServerInfo   &GetConnectedServerInfo(int client_fd) const;
 
   private:
 	// function

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -7,13 +7,9 @@ VirtualServer::VirtualServer() {}
 VirtualServer::VirtualServer(
 	const std::string  &server_name,
 	const LocationList &locations,
-	const PortList     &ports,
 	const HostPortList &host_port_list
 )
-	: server_name_(server_name),
-	  locations_(locations),
-	  ports_(ports),
-	  host_port_list_(host_port_list) {}
+	: server_name_(server_name), locations_(locations), host_port_list_(host_port_list) {}
 
 VirtualServer::~VirtualServer() {}
 
@@ -25,7 +21,6 @@ VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
 		server_name_    = other.server_name_;
 		locations_      = other.locations_;
-		ports_          = other.ports_;
 		host_port_list_ = other.host_port_list_;
 	}
 	return *this;
@@ -37,10 +32,6 @@ const std::string &VirtualServer::GetServerName() const {
 
 const VirtualServer::LocationList &VirtualServer::GetLocations() const {
 	return locations_;
-}
-
-const VirtualServer::PortList &VirtualServer::GetPorts() const {
-	return ports_;
 }
 
 const VirtualServer::HostPortList &VirtualServer::GetHostPortList() const {

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -5,9 +5,15 @@ namespace server {
 VirtualServer::VirtualServer() {}
 
 VirtualServer::VirtualServer(
-	const std::string &server_name, const LocationList &locations, const PortList &ports
+	const std::string  &server_name,
+	const LocationList &locations,
+	const PortList     &ports,
+	const HostPortList &host_port_list
 )
-	: server_name_(server_name), locations_(locations), ports_(ports) {}
+	: server_name_(server_name),
+	  locations_(locations),
+	  ports_(ports),
+	  host_port_list_(host_port_list) {}
 
 VirtualServer::~VirtualServer() {}
 

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -30,6 +30,7 @@ const std::string &VirtualServer::GetServerName() const {
 	return server_name_;
 }
 
+// todo: not used yet
 const VirtualServer::LocationList &VirtualServer::GetLocations() const {
 	return locations_;
 }

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -43,4 +43,8 @@ const VirtualServer::PortList &VirtualServer::GetPorts() const {
 	return ports_;
 }
 
+const VirtualServer::HostPortList &VirtualServer::GetHostPortList() const {
+	return host_port_list_;
+}
+
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -17,9 +17,10 @@ VirtualServer::VirtualServer(const VirtualServer &other) {
 
 VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
-		server_name_ = other.server_name_;
-		locations_   = other.locations_;
-		ports_       = other.ports_;
+		server_name_    = other.server_name_;
+		locations_      = other.locations_;
+		ports_          = other.ports_;
+		host_port_list_ = other.host_port_list_;
 	}
 	return *this;
 }

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -26,7 +26,10 @@ class VirtualServer {
 	VirtualServer();
 	// todo: configもらう？
 	VirtualServer(
-		const std::string &server_name, const LocationList &locations, const PortList &ports
+		const std::string  &server_name,
+		const LocationList &locations,
+		const PortList     &ports,
+		const HostPortList &host_port_list
 	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -17,8 +17,11 @@ struct Location {
 // virtual serverとして必要な情報を保持・取得する
 class VirtualServer {
   public:
-	typedef std::list<Location>     LocationList;
-	typedef std::list<unsigned int> PortList;
+	typedef std::list<Location>                  LocationList;
+	typedef std::list<unsigned int>              PortList; // todo: remove
+	typedef std::pair<std::string, unsigned int> HostPortPair;
+	typedef std::list<HostPortPair>              HostPortList;
+
 	// default constructor: necessary for map's insert/[]
 	VirtualServer();
 	// todo: configもらう？
@@ -31,13 +34,14 @@ class VirtualServer {
 	// getter
 	const std::string  &GetServerName() const;
 	const LocationList &GetLocations() const;
-	const PortList     &GetPorts() const;
+	const PortList     &GetPorts() const; // todo: remove
 
   private:
 	// todo: add member(& operator=)
 	std::string  server_name_;
 	LocationList locations_; // todo
-	PortList     ports_;
+	PortList     ports_;     // todo: remove
+	HostPortList host_port_list_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -38,6 +38,7 @@ class VirtualServer {
 	const std::string  &GetServerName() const;
 	const LocationList &GetLocations() const;
 	const PortList     &GetPorts() const; // todo: remove
+	const HostPortList &GetHostPortList() const;
 
   private:
 	// todo: add member(& operator=)

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -18,7 +18,6 @@ struct Location {
 class VirtualServer {
   public:
 	typedef std::list<Location>                  LocationList;
-	typedef std::list<unsigned int>              PortList; // todo: remove
 	typedef std::pair<std::string, unsigned int> HostPortPair;
 	typedef std::list<HostPortPair>              HostPortList;
 
@@ -28,7 +27,6 @@ class VirtualServer {
 	VirtualServer(
 		const std::string  &server_name,
 		const LocationList &locations,
-		const PortList     &ports,
 		const HostPortList &host_port_list
 	);
 	~VirtualServer();
@@ -37,14 +35,12 @@ class VirtualServer {
 	// getter
 	const std::string  &GetServerName() const;
 	const LocationList &GetLocations() const;
-	const PortList     &GetPorts() const; // todo: remove
 	const HostPortList &GetHostPortList() const;
 
   private:
 	// todo: add member(& operator=)
 	std::string  server_name_;
 	LocationList locations_; // todo
-	PortList     ports_;     // todo: remove
 	HostPortList host_port_list_;
 };
 

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
@@ -30,13 +30,25 @@ void VirtualServerStorage::AddVirtualServer(const VirtualServer &virtual_server)
 // virtual_server_storage.AddMapping(4, virtual_server1*);
 // virtual_server_storage.AddMapping(5, virtual_server1*);
 // -> mapping_fd_to_virtual_servers_ = {{4, virtual_server1*}, {5, virtual_servers1*}}
-void VirtualServerStorage::AddMapping(int server_fd, const VirtualServer *virtual_server) {
+void VirtualServerStorage::RemoveAddMapping(int server_fd, const VirtualServer *virtual_server) {
+	if (mapping_fd_to_virtual_servers_.count(server_fd) != 0) {
+		return;
+	}
 	typedef std::pair<VirtualServerMapping::const_iterator, bool> InsertResult;
 	InsertResult                                                  result =
 		mapping_fd_to_virtual_servers_.insert(std::make_pair(server_fd, virtual_server));
 	if (result.second == false) {
 		throw std::logic_error("server_fd is already mapped");
 	}
+}
+
+// server_fdが新規なら作成して良いのでmap[]を使用
+// e.g., VirtualServerAddrListMap -> {{fd 4 : List{virtual_server1*, virtual_server2*}},
+//                                    {fd 5 : List{virtual_server3*}},
+//                                    {fd 6 : List{virtual_server2*, virtual_server3*}}}
+void VirtualServerStorage::AddMapping(int server_fd, const VirtualServer *virtual_server) {
+	VirtualServerAddrList &virtual_server_addr_list = virtual_server_addr_list_map_[server_fd];
+	virtual_server_addr_list.push_back(virtual_server);
 }
 
 const VirtualServer &VirtualServerStorage::GetVirtualServer(int server_fd) const {

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
@@ -47,6 +47,15 @@ const VirtualServer &VirtualServerStorage::GetVirtualServer(int server_fd) const
 	}
 }
 
+const VirtualServerStorage::VirtualServerAddrList &
+VirtualServerStorage::GetVirtualServerAddrList(int server_fd) const {
+	try {
+		return virtual_server_addr_list_map_.at(server_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("VirtualServerAddrList doesn't exists");
+	}
+}
+
 // todo: tmp. need?
 const VirtualServerStorage::VirtualServerList &
 VirtualServerStorage::GetAllVirtualServerList() const {

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
@@ -14,32 +14,14 @@ VirtualServerStorage::VirtualServerStorage(const VirtualServerStorage &other) {
 
 VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage &other) {
 	if (this != &other) {
-		virtual_servers_               = other.virtual_servers_;
-		mapping_fd_to_virtual_servers_ = other.mapping_fd_to_virtual_servers_; // todo: remove
-		virtual_server_addr_list_map_  = other.virtual_server_addr_list_map_;
+		virtual_servers_              = other.virtual_servers_;
+		virtual_server_addr_list_map_ = other.virtual_server_addr_list_map_;
 	}
 	return *this;
 }
 
 void VirtualServerStorage::AddVirtualServer(const VirtualServer &virtual_server) {
 	virtual_servers_.push_back(virtual_server);
-}
-
-// ex)
-// - virtual_server1が通信でfd 4,5を使用している場合
-// virtual_server_storage.AddMapping(4, virtual_server1*);
-// virtual_server_storage.AddMapping(5, virtual_server1*);
-// -> mapping_fd_to_virtual_servers_ = {{4, virtual_server1*}, {5, virtual_servers1*}}
-void VirtualServerStorage::RemoveAddMapping(int server_fd, const VirtualServer *virtual_server) {
-	if (mapping_fd_to_virtual_servers_.count(server_fd) != 0) {
-		return;
-	}
-	typedef std::pair<VirtualServerMapping::const_iterator, bool> InsertResult;
-	InsertResult                                                  result =
-		mapping_fd_to_virtual_servers_.insert(std::make_pair(server_fd, virtual_server));
-	if (result.second == false) {
-		throw std::logic_error("server_fd is already mapped");
-	}
 }
 
 // server_fdが新規なら作成して良いのでmap[]を使用
@@ -49,14 +31,6 @@ void VirtualServerStorage::RemoveAddMapping(int server_fd, const VirtualServer *
 void VirtualServerStorage::AddMapping(int server_fd, const VirtualServer *virtual_server) {
 	VirtualServerAddrList &virtual_server_addr_list = virtual_server_addr_list_map_[server_fd];
 	virtual_server_addr_list.push_back(virtual_server);
-}
-
-const VirtualServer &VirtualServerStorage::GetVirtualServer(int server_fd) const {
-	try {
-		return *mapping_fd_to_virtual_servers_.at(server_fd);
-	} catch (const std::exception &e) {
-		throw std::logic_error("VirtualServer doesn't exists");
-	}
 }
 
 const VirtualServerStorage::VirtualServerAddrList &

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.cpp
@@ -15,7 +15,8 @@ VirtualServerStorage::VirtualServerStorage(const VirtualServerStorage &other) {
 VirtualServerStorage &VirtualServerStorage::operator=(const VirtualServerStorage &other) {
 	if (this != &other) {
 		virtual_servers_               = other.virtual_servers_;
-		mapping_fd_to_virtual_servers_ = other.mapping_fd_to_virtual_servers_;
+		mapping_fd_to_virtual_servers_ = other.mapping_fd_to_virtual_servers_; // todo: remove
+		virtual_server_addr_list_map_  = other.virtual_server_addr_list_map_;
 	}
 	return *this;
 }

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
@@ -12,7 +12,11 @@ class VirtualServer;
 class VirtualServerStorage {
   public:
 	typedef std::list<VirtualServer>             VirtualServerList;
-	typedef std::map<int, const VirtualServer *> VirtualServerMapping;
+	typedef std::map<int, const VirtualServer *> VirtualServerMapping; // todo: remove
+
+	typedef std::list<const VirtualServer *>     VirtualServerAddrList;
+	typedef std::map<int, VirtualServerAddrList> VirtualServerAddrListMap;
+
 	VirtualServerStorage();
 	~VirtualServerStorage();
 	VirtualServerStorage(const VirtualServerStorage &other);
@@ -28,7 +32,9 @@ class VirtualServerStorage {
 	// 全VirtualServerを保持
 	VirtualServerList virtual_servers_;
 	// VirtualServerと、VirtualServerが通信に使用している複数fdを紐づける
-	VirtualServerMapping mapping_fd_to_virtual_servers_;
+	VirtualServerMapping mapping_fd_to_virtual_servers_; // todo: remove
+	// server_fd(host:port)が属するVirtualServerAddrのlistを保持
+	VirtualServerAddrListMap virtual_server_addr_list_map_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
@@ -23,6 +23,7 @@ class VirtualServerStorage {
 	VirtualServerStorage &operator=(const VirtualServerStorage &other);
 	// functions
 	void AddVirtualServer(const VirtualServer &virtual_server);
+	void RemoveAddMapping(int server_fd, const VirtualServer *virtual_server); // todo: remove
 	void AddMapping(int server_fd, const VirtualServer *virtual_server);
 	// getter
 	const VirtualServer         &GetVirtualServer(int server_fd) const; // todo: remove

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
@@ -11,8 +11,7 @@ class VirtualServer;
 // fdとVirtualServerを紐づけて全VirtualServerを保持・取得する
 class VirtualServerStorage {
   public:
-	typedef std::list<VirtualServer>             VirtualServerList;
-	typedef std::map<int, const VirtualServer *> VirtualServerMapping; // todo: remove
+	typedef std::list<VirtualServer> VirtualServerList;
 
 	typedef std::list<const VirtualServer *>     VirtualServerAddrList;
 	typedef std::map<int, VirtualServerAddrList> VirtualServerAddrListMap;
@@ -23,18 +22,14 @@ class VirtualServerStorage {
 	VirtualServerStorage &operator=(const VirtualServerStorage &other);
 	// functions
 	void AddVirtualServer(const VirtualServer &virtual_server);
-	void RemoveAddMapping(int server_fd, const VirtualServer *virtual_server); // todo: remove
 	void AddMapping(int server_fd, const VirtualServer *virtual_server);
 	// getter
-	const VirtualServer         &GetVirtualServer(int server_fd) const; // todo: remove
 	const VirtualServerAddrList &GetVirtualServerAddrList(int server_fd) const;
 	const VirtualServerList     &GetAllVirtualServerList() const;
 
   private:
 	// 全VirtualServerを保持
 	VirtualServerList virtual_servers_;
-	// VirtualServerと、VirtualServerが通信に使用している複数fdを紐づける
-	VirtualServerMapping mapping_fd_to_virtual_servers_; // todo: remove
 	// server_fd(host:port)が属するVirtualServerAddrのlistを保持
 	VirtualServerAddrListMap virtual_server_addr_list_map_;
 };

--- a/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server_storage.hpp
@@ -25,8 +25,9 @@ class VirtualServerStorage {
 	void AddVirtualServer(const VirtualServer &virtual_server);
 	void AddMapping(int server_fd, const VirtualServer *virtual_server);
 	// getter
-	const VirtualServer     &GetVirtualServer(int server_fd) const;
-	const VirtualServerList &GetAllVirtualServerList() const;
+	const VirtualServer         &GetVirtualServer(int server_fd) const; // todo: remove
+	const VirtualServerAddrList &GetVirtualServerAddrList(int server_fd) const;
+	const VirtualServerList     &GetAllVirtualServerList() const;
 
   private:
 	// 全VirtualServerを保持

--- a/srcs/server/dto/dto_server_to_http.hpp
+++ b/srcs/server/dto/dto_server_to_http.hpp
@@ -1,7 +1,6 @@
 #ifndef SERVER_DTO_HPP_
 #define SERVER_DTO_HPP_
 
-#include "virtual_server.hpp" // todo: remove
 #include "virtual_server_storage.hpp"
 #include <string>
 
@@ -14,11 +13,7 @@ struct DtoClientInfos {
 };
 
 struct DtoServerInfos {
-	int                         fd;
-	std::string                 server_name; // todo: remove
-	std::string                 port;        // todo: remove
-	VirtualServer::LocationList locations;   // todo: remove
-
+	int                                         fd;
 	VirtualServerStorage::VirtualServerAddrList virtual_server_addr_list;
 };
 

--- a/srcs/server/dto/dto_server_to_http.hpp
+++ b/srcs/server/dto/dto_server_to_http.hpp
@@ -1,7 +1,8 @@
 #ifndef SERVER_DTO_HPP_
 #define SERVER_DTO_HPP_
 
-#include "virtual_server.hpp"
+#include "virtual_server.hpp" // todo: remove
+#include "virtual_server_storage.hpp"
 #include <string>
 
 namespace server {
@@ -14,9 +15,11 @@ struct DtoClientInfos {
 
 struct DtoServerInfos {
 	int                         fd;
-	std::string                 server_name;
-	std::string                 port;
-	VirtualServer::LocationList locations;
+	std::string                 server_name; // todo: remove
+	std::string                 port;        // todo: remove
+	VirtualServer::LocationList locations;   // todo: remove
+
+	VirtualServerStorage::VirtualServerAddrList virtual_server_addr_list;
 };
 
 } // namespace server

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -34,23 +34,9 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 	return location_list;
 }
 
-// todo: remove
-// todo: configからstd::list<unsigned int>で渡されるようになったら変更する
-VirtualServer::PortList ConvertPorts(const config::context::PortList &ports_str) {
-	VirtualServer::PortList port_list;
-
-	typedef config::context::PortList::const_iterator Itr;
-	for (Itr it = ports_str.begin(); it != ports_str.end(); ++it) {
-		const unsigned int port = static_cast<unsigned int>(*it);
-		port_list.push_back(port);
-	}
-	return port_list;
-}
-
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
 	const std::string          &server_name = *(config_server.server_names.begin()); // tmp
 	VirtualServer::LocationList locations   = ConvertLocations(config_server.location_con);
-	VirtualServer::PortList     ports       = ConvertPorts(config_server.port); // todo: remove
 
 	// todo: tmp
 	static int                  n = 0;
@@ -66,7 +52,7 @@ VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_se
 	}
 	++n;
 
-	return VirtualServer(server_name, locations, ports, host_port_list);
+	return VirtualServer(server_name, locations, host_port_list);
 }
 // todo: tmp for debug
 void DebugVirtualServerNames(
@@ -166,9 +152,6 @@ DtoServerInfos Server::GetServerInfos(int client_fd) const {
 
 	DtoServerInfos server_infos;
 	server_infos.fd                       = server_context.fd;
-	server_infos.server_name              = server_context.server_name; // todo: remove
-	server_infos.port                     = server_context.port;        // todo: remove
-	server_infos.locations                = server_context.locations;   // todo: remove
 	server_infos.virtual_server_addr_list = server_context.virtual_server_addr_list;
 	return server_infos;
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -318,7 +318,11 @@ void Server::Init() {
 				server_info.SetSockFd(server_fd);
 
 				event_monitor_.Add(server_fd, event::EVENT_READ);
-				utils::Debug("server", "listen", server_fd);
+				utils::Debug(
+					"server",
+					"listen " + it_host_port->first + ":" + utils::ToString(it_host_port->second),
+					server_fd
+				);
 			}
 			// add to context
 			context_.AddServerInfo(server_info, &virtual_server);

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -34,6 +34,7 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 	return location_list;
 }
 
+// todo: remove
 // todo: configからstd::list<unsigned int>で渡されるようになったら変更する
 VirtualServer::PortList ConvertPorts(const config::context::PortList &ports_str) {
 	VirtualServer::PortList port_list;
@@ -49,14 +50,14 @@ VirtualServer::PortList ConvertPorts(const config::context::PortList &ports_str)
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
 	const std::string          &server_name = *(config_server.server_names.begin()); // tmp
 	VirtualServer::LocationList locations   = ConvertLocations(config_server.location_con);
-	VirtualServer::PortList     ports       = ConvertPorts(config_server.port);
+	VirtualServer::PortList     ports       = ConvertPorts(config_server.port); // todo: remove
 
 	// todo: tmp
 	static int                  n = 0;
 	VirtualServer::HostPortList host_port_list;
 	if (n == 0) {
 		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
-		host_port_list.push_back(std::make_pair("::1", 8080));
+		// host_port_list.push_back(std::make_pair("::1", 8080));
 	} else {
 		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
 		host_port_list.push_back(std::make_pair("0.0.0.0", 9999));
@@ -67,25 +68,24 @@ VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_se
 
 	return VirtualServer(server_name, locations, ports, host_port_list);
 }
-
 // todo: tmp for debug
-void PrintLocations(const VirtualServer::LocationList &locations) {
-	typedef VirtualServer::LocationList::const_iterator Itr;
-	for (Itr it = locations.begin(); it != locations.end(); ++it) {
-		const server::Location &location = *it;
-		std::cerr << "- location: " << location.location << ", root: " << location.root
-				  << ", index: " << location.index << std::endl;
+void DebugVirtualServerNames(
+	const VirtualServerStorage::VirtualServerAddrList &virtual_server_addr_list
+) {
+	typedef VirtualServerStorage::VirtualServerAddrList::const_iterator ItVs;
+	std::cerr << "server_name: ";
+	for (ItVs it = virtual_server_addr_list.begin(); it != virtual_server_addr_list.end(); ++it) {
+		const VirtualServer *virtual_server = *it;
+		std::cerr << "[" << virtual_server->GetServerName() << "]";
 	}
+	std::cerr << std::endl;
 }
 
 // todo: tmp for debug
 void DebugDto(const DtoClientInfos &client_infos, const DtoServerInfos &server_infos) {
 	utils::Debug("server", "ClientInfo - IP: " + client_infos.ip + ", fd", client_infos.fd);
 	utils::Debug("server", "received ServerInfo, fd", server_infos.fd);
-	std::cerr << "server_name: " << server_infos.server_name << ", port: " << server_infos.port
-			  << std::endl;
-	std::cerr << "locations: " << std::endl;
-	PrintLocations(server_infos.locations);
+	DebugVirtualServerNames(server_infos.virtual_server_addr_list);
 }
 
 } // namespace
@@ -165,10 +165,11 @@ DtoServerInfos Server::GetServerInfos(int client_fd) const {
 	const ServerContext &server_context = context_.GetServerContext(client_fd);
 
 	DtoServerInfos server_infos;
-	server_infos.fd          = server_context.fd;
-	server_infos.server_name = server_context.server_name;
-	server_infos.port        = server_context.port;
-	server_infos.locations   = server_context.locations;
+	server_infos.fd                       = server_context.fd;
+	server_infos.server_name              = server_context.server_name; // todo: remove
+	server_infos.port                     = server_context.port;        // todo: remove
+	server_infos.locations                = server_context.locations;   // todo: remove
+	server_infos.virtual_server_addr_list = server_context.virtual_server_addr_list;
 	return server_infos;
 }
 
@@ -312,23 +313,36 @@ void Server::Init() {
 	const VirtualServerStorage::VirtualServerList &all_virtual_server =
 		context_.GetAllVirtualServer();
 
+	// todo: refactor
+	std::map<VirtualServer::HostPortPair, ServerInfo> host_port_fd_map;
+
 	typedef VirtualServerStorage::VirtualServerList::const_iterator ItVirtualServer;
 	for (ItVirtualServer it = all_virtual_server.begin(); it != all_virtual_server.end(); ++it) {
-		const VirtualServer           &virtual_server = *it;
-		const VirtualServer::PortList &ports          = virtual_server.GetPorts();
+		const VirtualServer               &virtual_server = *it;
+		const VirtualServer::HostPortList &host_port_list = virtual_server.GetHostPortList();
 
-		// 各virtual serverの全portをsocket通信
-		typedef VirtualServer::PortList::const_iterator ItPort;
-		for (ItPort it_port = ports.begin(); it_port != ports.end(); ++it_port) {
-			// create ServerInfo & listen
-			ServerInfo server_info("0.0.0.0", *it_port);
-			const int  server_fd = connection_.Connect(server_info);
-			server_info.SetSockFd(server_fd);
+		// 各virtual serverの全host:portをsocket通信
+		typedef VirtualServer::HostPortList::const_iterator ItHostPort;
+		for (ItHostPort it_host_port = host_port_list.begin(); it_host_port != host_port_list.end();
+			 ++it_host_port) {
+			ServerInfo server_info;
+			// first host:port
+			if (host_port_fd_map.count(*it_host_port) == 0) {
+				// create ServerInfo & listen
+				server_info         = ServerInfo(it_host_port->first, it_host_port->second);
+				const int server_fd = connection_.Connect(server_info);
+				server_info.SetSockFd(server_fd);
 
+				event_monitor_.Add(server_fd, event::EVENT_READ);
+				utils::Debug("server", "listen", server_fd);
+
+				// listen済みhost:portであることとそのserver_infoを記録
+				host_port_fd_map[*it_host_port] = server_info;
+			} else {
+				server_info = host_port_fd_map.at(*it_host_port);
+			}
 			// add to context
 			context_.AddServerInfo(server_info, &virtual_server);
-			event_monitor_.Add(server_fd, event::EVENT_READ);
-			utils::Debug("server", "listen", server_fd);
 		}
 	}
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -322,7 +322,7 @@ void Server::Init() {
 		typedef VirtualServer::PortList::const_iterator ItPort;
 		for (ItPort it_port = ports.begin(); it_port != ports.end(); ++it_port) {
 			// create ServerInfo & listen
-			ServerInfo server_info(*it_port);
+			ServerInfo server_info("0.0.0.0", *it_port);
 			const int  server_fd = connection_.Connect(server_info);
 			server_info.SetSockFd(server_fd);
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -309,12 +309,11 @@ void Server::UpdateConnectionAfterSendResponse(
 }
 
 void Server::Init() {
-	const VirtualServerStorage::VirtualServerList &all_virtual_server_list =
-		context_.GetVirtualServerList();
+	const VirtualServerStorage::VirtualServerList &all_virtual_server =
+		context_.GetAllVirtualServer();
 
 	typedef VirtualServerStorage::VirtualServerList::const_iterator ItVirtualServer;
-	for (ItVirtualServer it = all_virtual_server_list.begin(); it != all_virtual_server_list.end();
-		 ++it) {
+	for (ItVirtualServer it = all_virtual_server.begin(); it != all_virtual_server.end(); ++it) {
 		const VirtualServer           &virtual_server = *it;
 		const VirtualServer::PortList &ports          = virtual_server.GetPorts();
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -50,7 +50,22 @@ VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_se
 	const std::string          &server_name = *(config_server.server_names.begin()); // tmp
 	VirtualServer::LocationList locations   = ConvertLocations(config_server.location_con);
 	VirtualServer::PortList     ports       = ConvertPorts(config_server.port);
-	return VirtualServer(server_name, locations, ports);
+
+	// todo: tmp
+	static int                  n = 0;
+	VirtualServer::HostPortList host_port_list;
+	if (n == 0) {
+		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
+		host_port_list.push_back(std::make_pair("::1", 8080));
+	} else {
+		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
+		host_port_list.push_back(std::make_pair("0.0.0.0", 9999));
+		host_port_list.push_back(std::make_pair("0.0.0.0", 12345));
+		// host_port_list.push_back(std::make_pair("::1", 8080));
+	}
+	++n;
+
+	return VirtualServer(server_name, locations, ports, host_port_list);
 }
 
 // todo: tmp for debug

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -30,19 +30,20 @@ class Server {
 	Server(const Server &other);
 	Server &operator=(const Server &other);
 	// functions
-	void AddVirtualServers(const ConfigServers &config_servers);
-	void HandleEvent(const event::Event &event);
-	void HandleNewConnection(int server_fd);
-	void HandleExistingConnection(const event::Event &event);
-	void ReadRequest(int client_fd);
-	void RunHttp(const event::Event &event);
-	void SendResponse(int client_fd);
-	void HandleTimeoutMessages();
-	void KeepConnection(int client_fd);
-	void Disconnect(int client_fd);
-	void UpdateEventInResponseComplete(
-		const message::ConnectionState connection_state, const event::Event &event
-	);
+	void       AddVirtualServers(const ConfigServers &config_servers);
+	ServerInfo Listen(const std::string &host, unsigned int port);
+	void       HandleEvent(const event::Event &event);
+	void       HandleNewConnection(int server_fd);
+	void       HandleExistingConnection(const event::Event &event);
+	void       ReadRequest(int client_fd);
+	void       RunHttp(const event::Event &event);
+	void       SendResponse(int client_fd);
+	void       HandleTimeoutMessages();
+	void       KeepConnection(int client_fd);
+	void       Disconnect(int client_fd);
+	void       UpdateEventInResponseComplete(
+			  const message::ConnectionState connection_state, const event::Event &event
+		  );
 	void UpdateConnectionAfterSendResponse(
 		int client_fd, const message::ConnectionState connection_state
 	);

--- a/test/unit/sock_context/test_sock_context.cpp
+++ b/test/unit/sock_context/test_sock_context.cpp
@@ -76,7 +76,7 @@ Result RunGetClientInfo(
 }
 
 bool IsSameServerInfo(const server::ServerInfo &a, const server::ServerInfo &b) {
-	return a.GetFd() == b.GetFd() && a.GetPort() == b.GetPort();
+	return a.GetFd() == b.GetFd() && a.GetHost() == b.GetHost() && a.GetPort() == b.GetPort();
 }
 
 // ServerInfo同士のメンバが全て等しいことを期待するテスト
@@ -95,6 +95,8 @@ Result RunGetConnectedServerInfo(
 		std::ostringstream oss;
 		oss << "server_fd  : result   [" << a.GetFd() << "]" << std::endl;
 		oss << "             expected [" << b.GetFd() << "]" << std::endl;
+		oss << "host       : result   [" << a.GetHost() << "]" << std::endl;
+		oss << "             expected [" << b.GetHost() << "]" << std::endl;
 		oss << "port       : result   [" << a.GetPort() << "]" << std::endl;
 		oss << "             expected [" << b.GetPort() << "]" << std::endl;
 		result.error_log = oss.str();
@@ -198,9 +200,9 @@ int RunTestSockContext() {
 
 	/* ----------- 準備 ----------- */
 	// SockContextに渡す用のServerInfoを2個作成
-	server::ServerInfo server_info1(8080);
+	server::ServerInfo server_info1("localhost", 8080);
 	server_info1.SetSockFd(4);
-	server::ServerInfo server_info2(12345);
+	server::ServerInfo server_info2("0.0.0.0", 12345);
 	server_info2.SetSockFd(5);
 
 	// SockContextに渡す用のClientInfoを2個作成


### PR DESCRIPTION
`srcs/ +177, -127`
`test/unit/ +138, -112`

連動した変更箇所が多く、見るの疲れそうな PR になってしまいました…🙏
なるべく細かく commit 分けてます

---

## したこと
今まで port のみの `PortList` を使って listen() してところを、host も使うようにしました

(実装の方針としては、`PortList` を残しつつ、新規で `HostPortList` を使った実装を追加していき、最後に `PortList` から `HostPortList` に全部置き換えてます)

具体的には以下のように同じ`host:port` が複数 VirtualServer に属する場合も ok とし、1 回だけ listen() するようにしました
```
# default.conf

# vs1
server {
  listen 0.0.0.0:8080; <-
}

# vs2
server {
  listen 0.0.0.0:8080; <-
  listen 0.0.0.0:9999;
  listen 0.0.0.0:12345;
}
```
1 つの `host:port` が 1 つの `server_fd` に対応します
上の例だと Server class としての扱いはこういうイメージです
- server_fd 3 : `0.0.0.0:8080`, 属する `VirtualServerAddrList : {vs1 *, vs2 *}`
- server_fd 4 : `0.0.0.0:9999`, 属する `VirtualServerAddrList : {vs2 *}`
- server_fd 5 : `0.0.0.0:12345`, 属する `VirtualServerAddrist : {vs2 *}`


## 実行
挙動に特に変更はないです
```sh
make run
make test
```
リクエストを送ると、対応する VirtualServer の候補の server_name を全部 debug 出力するようにしています
```sh
make run
curl localhost:8080
# server_name: [localhost][test_serv]

curl localhost:9999
# server_name: [test_serv]

curl localhost:12345
# server_name: [test_serv]
```


## 今後
- Server class から Http class に、既存の `ClientInfos` と今回作成した `VirtualServerAddrList` を渡すようにしようと思います
- 以下のように後に `0.0.0.0` がある場合は今 bind error になるので対応します -> Issue #370 
```
# vs1
server {
  listen 172.17.0.1:8080; <-
}

# vs2
server {
  listen 0.0.0.0:8080; <-
  listen 0.0.0.0:9999;
  listen 0.0.0.0:12345;
}
```

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


## Summary by CodeRabbit

- **新機能**
  - サーバー情報の重複を防ぐチェックを追加しました。
  - サーバー情報をホストとポートに基づいて取得する新しいメソッドを追加しました。
  - 複数の仮想サーバーをファイルディスクリプタに関連付ける新しい構造を導入しました。
  - サーバーが指定したホストとポートで接続をリッスンする機能を追加しました。

- **バグ修正**
  - サーバー情報の比較ロジックを強化し、ホスト属性を含めました。

- **ドキュメント**
  - サーバー情報の構造を更新し、より複雑なデータ構造を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->