### PR TITLE
[setting] devcontainer 内の clang-format の version 上げ

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,16 @@ RUN pip install --upgrade pip && \
     pip-compile /workspaces/webserv/requirements.in --strip-extras && \
     pip-sync
 
+# この書き方だとここ(pip系の後)でないとできない
+RUN apt-get update && \
+    apt-get install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh 14 && \
+    apt update && \
+    apt install clang-format-14 && \
+    ln -sf /usr/bin/clang-format-14 /usr/local/bin/clang-format
+
 RUN rm -rf /var/lib/apt/lists/*
 
 VOLUME [ "/workspaces" ]


### PR DESCRIPTION
エラーの出てる `BlockIndentd` は clang-format-14 からの機能で、devcontainer は 10 なので一部インデントの format がかけられてなかったみたいです

 `BlockIndentd` の設定を変えて全ファイル format かけ直すよりは、devcontainer 内の clang-format version を上げる方が楽かと思ったので、devcontainer の clang-format version を 10 ->14 に上げました

ubuntu の version 的に直接 14 は install できなくて、後から強引に 14 を install してみました
既存の `clang-format=1:10.0-50~exp1` install 部分を消すとエラーになったり、pip 系の後に install しないとエラーになったりするので、依存関係かなり適当な気がします。他に良い方法があれば…

一応 devcontainer を再 build して make format できるか確認してみてほしいです

---

それか、ローカルの clang-format の version を `BlockIndentd` 対応してるところまで上げてもらう、でも良いと思います

