### PR TITLE
[update] Config で追加されたディレクティブに Server が対応する

### DIFF
--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -35,12 +35,12 @@ VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	return *this;
 }
 
-const VirtualServer::ServerNameList &VirtualServer::GetServerNames() const {
+const VirtualServer::ServerNameList &VirtualServer::GetServerNameList() const {
 	return server_names_;
 }
 
 // todo: not used yet
-const VirtualServer::LocationList &VirtualServer::GetLocations() const {
+const VirtualServer::LocationList &VirtualServer::GetLocationList() const {
 	return locations_;
 }
 

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -2,12 +2,18 @@
 
 namespace server {
 
-VirtualServer::VirtualServer() {}
+VirtualServer::VirtualServer() : client_max_body_size_(DEFAULT_CLIENT_MAX_BODY_SIZE) {}
 
 VirtualServer::VirtualServer(
-	const std::string &server_name, const LocationList &locations, const HostPortList &host_ports
+	const std::string  &server_name,
+	const LocationList &locations,
+	const HostPortList &host_ports,
+	std::size_t         client_max_body_size
 )
-	: server_name_(server_name), locations_(locations), host_ports_(host_ports) {}
+	: server_name_(server_name),
+	  locations_(locations),
+	  host_ports_(host_ports),
+	  client_max_body_size_(client_max_body_size) {}
 
 VirtualServer::~VirtualServer() {}
 
@@ -17,9 +23,10 @@ VirtualServer::VirtualServer(const VirtualServer &other) {
 
 VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
-		server_name_ = other.server_name_;
-		locations_   = other.locations_;
-		host_ports_  = other.host_ports_;
+		server_name_          = other.server_name_;
+		locations_            = other.locations_;
+		host_ports_           = other.host_ports_;
+		client_max_body_size_ = other.client_max_body_size_;
 	}
 	return *this;
 }
@@ -36,5 +43,10 @@ const VirtualServer::LocationList &VirtualServer::GetLocations() const {
 const VirtualServer::HostPortList &VirtualServer::GetHostPortList() const {
 	return host_ports_;
 }
+
+std::size_t VirtualServer::GetClientMaxBodySize() const {
+	return client_max_body_size_;
+}
+
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -5,11 +5,9 @@ namespace server {
 VirtualServer::VirtualServer() {}
 
 VirtualServer::VirtualServer(
-	const std::string  &server_name,
-	const LocationList &locations,
-	const HostPortList &host_port_list
+	const std::string &server_name, const LocationList &locations, const HostPortList &host_ports
 )
-	: server_name_(server_name), locations_(locations), host_port_list_(host_port_list) {}
+	: server_name_(server_name), locations_(locations), host_ports_(host_ports) {}
 
 VirtualServer::~VirtualServer() {}
 
@@ -19,9 +17,9 @@ VirtualServer::VirtualServer(const VirtualServer &other) {
 
 VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
-		server_name_    = other.server_name_;
-		locations_      = other.locations_;
-		host_port_list_ = other.host_port_list_;
+		server_name_ = other.server_name_;
+		locations_   = other.locations_;
+		host_ports_  = other.host_ports_;
 	}
 	return *this;
 }
@@ -36,7 +34,7 @@ const VirtualServer::LocationList &VirtualServer::GetLocations() const {
 }
 
 const VirtualServer::HostPortList &VirtualServer::GetHostPortList() const {
-	return host_port_list_;
+	return host_ports_;
 }
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -6,13 +6,13 @@ VirtualServer::VirtualServer()
 	: client_max_body_size_(DEFAULT_CLIENT_MAX_BODY_SIZE), error_page_(std::make_pair(0, "")) {}
 
 VirtualServer::VirtualServer(
-	const std::string  &server_name,
-	const LocationList &locations,
-	const HostPortList &host_ports,
-	std::size_t         client_max_body_size,
-	const ErrorPage    &error_page
+	const ServerNameList &server_names,
+	const LocationList   &locations,
+	const HostPortList   &host_ports,
+	std::size_t           client_max_body_size,
+	const ErrorPage      &error_page
 )
-	: server_name_(server_name),
+	: server_names_(server_names),
 	  locations_(locations),
 	  host_ports_(host_ports),
 	  client_max_body_size_(client_max_body_size),
@@ -26,7 +26,7 @@ VirtualServer::VirtualServer(const VirtualServer &other) {
 
 VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	if (this != &other) {
-		server_name_          = other.server_name_;
+		server_names_         = other.server_names_;
 		locations_            = other.locations_;
 		host_ports_           = other.host_ports_;
 		client_max_body_size_ = other.client_max_body_size_;
@@ -35,8 +35,8 @@ VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 	return *this;
 }
 
-const std::string &VirtualServer::GetServerName() const {
-	return server_name_;
+const VirtualServer::ServerNameList &VirtualServer::GetServerNames() const {
+	return server_names_;
 }
 
 // todo: not used yet

--- a/srcs/server/context_manager/virtual_server/virtual_server.cpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.cpp
@@ -2,18 +2,21 @@
 
 namespace server {
 
-VirtualServer::VirtualServer() : client_max_body_size_(DEFAULT_CLIENT_MAX_BODY_SIZE) {}
+VirtualServer::VirtualServer()
+	: client_max_body_size_(DEFAULT_CLIENT_MAX_BODY_SIZE), error_page_(std::make_pair(0, "")) {}
 
 VirtualServer::VirtualServer(
 	const std::string  &server_name,
 	const LocationList &locations,
 	const HostPortList &host_ports,
-	std::size_t         client_max_body_size
+	std::size_t         client_max_body_size,
+	const ErrorPage    &error_page
 )
 	: server_name_(server_name),
 	  locations_(locations),
 	  host_ports_(host_ports),
-	  client_max_body_size_(client_max_body_size) {}
+	  client_max_body_size_(client_max_body_size),
+	  error_page_(error_page) {}
 
 VirtualServer::~VirtualServer() {}
 
@@ -27,6 +30,7 @@ VirtualServer &VirtualServer::operator=(const VirtualServer &other) {
 		locations_            = other.locations_;
 		host_ports_           = other.host_ports_;
 		client_max_body_size_ = other.client_max_body_size_;
+		error_page_           = other.error_page_;
 	}
 	return *this;
 }
@@ -48,5 +52,8 @@ std::size_t VirtualServer::GetClientMaxBodySize() const {
 	return client_max_body_size_;
 }
 
+const VirtualServer::ErrorPage &VirtualServer::GetErrorPage() const {
+	return error_page_;
+}
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -23,11 +23,10 @@ class VirtualServer {
 
 	// default constructor: necessary for map's insert/[]
 	VirtualServer();
-	// todo: configもらう？
 	VirtualServer(
 		const std::string  &server_name,
 		const LocationList &locations,
-		const HostPortList &host_port_list
+		const HostPortList &host_ports
 	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);
@@ -41,7 +40,7 @@ class VirtualServer {
 	// todo: add member(& operator=)
 	std::string  server_name_;
 	LocationList locations_; // todo
-	HostPortList host_port_list_;
+	HostPortList host_ports_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -27,6 +27,7 @@ struct Location {
 // virtual serverとして必要な情報を保持・取得する
 class VirtualServer {
   public:
+	typedef std::list<std::string>               ServerNameList;
 	typedef std::list<Location>                  LocationList;
 	typedef std::pair<std::string, unsigned int> HostPortPair;
 	typedef std::list<HostPortPair>              HostPortList;
@@ -35,30 +36,30 @@ class VirtualServer {
 	// default constructor: necessary for map's insert/[]
 	VirtualServer();
 	VirtualServer(
-		const std::string  &server_name,
-		const LocationList &locations,
-		const HostPortList &host_ports,
-		std::size_t         client_max_body_size,
-		const ErrorPage    &error_page
+		const ServerNameList &server_names,
+		const LocationList   &locations,
+		const HostPortList   &host_ports,
+		std::size_t           client_max_body_size,
+		const ErrorPage      &error_page
 	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);
 	VirtualServer &operator=(const VirtualServer &other);
 	// getter
-	const std::string  &GetServerName() const;
-	const LocationList &GetLocations() const;
-	const HostPortList &GetHostPortList() const;
-	std::size_t         GetClientMaxBodySize() const;
-	const ErrorPage    &GetErrorPage() const;
+	const ServerNameList &GetServerNames() const;
+	const LocationList   &GetLocations() const;
+	const HostPortList   &GetHostPortList() const;
+	std::size_t           GetClientMaxBodySize() const;
+	const ErrorPage      &GetErrorPage() const;
 
   private:
 	static const std::size_t DEFAULT_CLIENT_MAX_BODY_SIZE = 1024;
 	// variables
-	std::string  server_name_;
-	LocationList locations_;
-	HostPortList host_ports_;
-	std::size_t  client_max_body_size_;
-	ErrorPage    error_page_;
+	ServerNameList server_names_;
+	LocationList   locations_;
+	HostPortList   host_ports_;
+	std::size_t    client_max_body_size_;
+	ErrorPage      error_page_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -8,10 +8,19 @@ namespace server {
 
 // todo: in VirtualServer class?
 struct Location {
-	std::string location;
-	std::string root;
-	std::string index;
-	std::string allowed_method;
+	typedef std::list<std::string>               AllowedMethodList;
+	typedef std::pair<unsigned int, std::string> Redirect;
+
+	Location() : autoindex(false), redirect(std::make_pair(0, "")) {}
+
+	std::string       request_uri;
+	std::string       alias;
+	std::string       index;
+	bool              autoindex;
+	AllowedMethodList allowed_methods;
+	Redirect          redirect;
+	std::string       cgi_extension;
+	std::string       upload_directory;
 };
 
 // virtual serverとして必要な情報を保持・取得する
@@ -39,7 +48,7 @@ class VirtualServer {
   private:
 	// todo: add member(& operator=)
 	std::string  server_name_;
-	LocationList locations_; // todo
+	LocationList locations_;
 	HostPortList host_ports_;
 };
 

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -30,6 +30,7 @@ class VirtualServer {
 	typedef std::list<Location>                  LocationList;
 	typedef std::pair<std::string, unsigned int> HostPortPair;
 	typedef std::list<HostPortPair>              HostPortList;
+	typedef std::pair<unsigned int, std::string> ErrorPage;
 
 	// default constructor: necessary for map's insert/[]
 	VirtualServer();
@@ -37,7 +38,8 @@ class VirtualServer {
 		const std::string  &server_name,
 		const LocationList &locations,
 		const HostPortList &host_ports,
-		std::size_t         client_max_body_size
+		std::size_t         client_max_body_size,
+		const ErrorPage    &error_page
 	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);
@@ -47,6 +49,7 @@ class VirtualServer {
 	const LocationList &GetLocations() const;
 	const HostPortList &GetHostPortList() const;
 	std::size_t         GetClientMaxBodySize() const;
+	const ErrorPage    &GetErrorPage() const;
 
   private:
 	static const std::size_t DEFAULT_CLIENT_MAX_BODY_SIZE = 1024;
@@ -55,6 +58,7 @@ class VirtualServer {
 	LocationList locations_;
 	HostPortList host_ports_;
 	std::size_t  client_max_body_size_;
+	ErrorPage    error_page_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_CONTEXTMANAGER_VIRTUALSERVER_VIRTUALSERVER_HPP_
 #define SERVER_CONTEXTMANAGER_VIRTUALSERVER_VIRTUALSERVER_HPP_
 
+#include <cstddef> // size_t
 #include <list>
 #include <string>
 
@@ -35,7 +36,8 @@ class VirtualServer {
 	VirtualServer(
 		const std::string  &server_name,
 		const LocationList &locations,
-		const HostPortList &host_ports
+		const HostPortList &host_ports,
+		std::size_t         client_max_body_size
 	);
 	~VirtualServer();
 	VirtualServer(const VirtualServer &other);
@@ -44,12 +46,15 @@ class VirtualServer {
 	const std::string  &GetServerName() const;
 	const LocationList &GetLocations() const;
 	const HostPortList &GetHostPortList() const;
+	std::size_t         GetClientMaxBodySize() const;
 
   private:
-	// todo: add member(& operator=)
+	static const std::size_t DEFAULT_CLIENT_MAX_BODY_SIZE = 1024;
+	// variables
 	std::string  server_name_;
 	LocationList locations_;
 	HostPortList host_ports_;
+	std::size_t  client_max_body_size_;
 };
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server/virtual_server.hpp
+++ b/srcs/server/context_manager/virtual_server/virtual_server.hpp
@@ -46,8 +46,8 @@ class VirtualServer {
 	VirtualServer(const VirtualServer &other);
 	VirtualServer &operator=(const VirtualServer &other);
 	// getter
-	const ServerNameList &GetServerNames() const;
-	const LocationList   &GetLocations() const;
+	const ServerNameList &GetServerNameList() const;
+	const LocationList   &GetLocationList() const;
 	const HostPortList   &GetHostPortList() const;
 	std::size_t           GetClientMaxBodySize() const;
 	const ErrorPage      &GetErrorPage() const;

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -57,7 +57,7 @@ void DebugVirtualServerNames(
 	std::cerr << "server_name: ";
 	for (ItVs it = virtual_server_addr_list.begin(); it != virtual_server_addr_list.end(); ++it) {
 		const VirtualServer *virtual_server = *it;
-		std::cerr << "[" << *virtual_server->GetServerNames().begin() << "]"; // todo: tmp
+		std::cerr << "[" << *virtual_server->GetServerNameList().begin() << "]"; // todo: tmp
 	}
 	std::cerr << std::endl;
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -26,18 +26,23 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 	typedef config::context::LocationList::const_iterator Itr;
 	for (Itr it = config_locations.begin(); it != config_locations.end(); ++it) {
 		Location location;
-		location.location       = it->request_uri;
-		location.root           = it->alias;
-		location.index          = it->index;
-		location.allowed_method = "GET"; // todo: tmp
+		location.request_uri      = it->request_uri;
+		location.alias            = it->alias;
+		location.index            = it->index;
+		location.autoindex        = it->autoindex;
+		location.allowed_methods  = it->allowed_methods;
+		location.redirect         = it->redirect;
+		location.cgi_extension    = it->cgi_extension;
+		location.upload_directory = it->upload_directory;
+
 		location_list.push_back(location);
 	}
 	return location_list;
 }
 
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
-	const std::string          &server_name = *(config_server.server_names.begin()); // tmp
-	VirtualServer::LocationList locations   = ConvertLocations(config_server.location_con);
+	const std::string                 &server_name = *(config_server.server_names.begin()); // tmp
+	const VirtualServer::LocationList &locations   = ConvertLocations(config_server.location_con);
 	return VirtualServer(server_name, locations, config_server.host_ports);
 }
 // todo: tmp for debug

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -41,10 +41,9 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 }
 
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
-	const VirtualServer::LocationList &locations = ConvertLocations(config_server.location_con);
 	return VirtualServer(
 		config_server.server_names,
-		locations,
+		ConvertLocations(config_server.location_con),
 		config_server.host_ports,
 		config_server.client_max_body_size,
 		config_server.error_page

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -41,10 +41,9 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 }
 
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
-	const std::string                 &server_name = *(config_server.server_names.begin()); // tmp
-	const VirtualServer::LocationList &locations   = ConvertLocations(config_server.location_con);
+	const VirtualServer::LocationList &locations = ConvertLocations(config_server.location_con);
 	return VirtualServer(
-		server_name,
+		config_server.server_names,
 		locations,
 		config_server.host_ports,
 		config_server.client_max_body_size,
@@ -59,7 +58,7 @@ void DebugVirtualServerNames(
 	std::cerr << "server_name: ";
 	for (ItVs it = virtual_server_addr_list.begin(); it != virtual_server_addr_list.end(); ++it) {
 		const VirtualServer *virtual_server = *it;
-		std::cerr << "[" << virtual_server->GetServerName() << "]";
+		std::cerr << "[" << *virtual_server->GetServerNames().begin() << "]"; // todo: tmp
 	}
 	std::cerr << std::endl;
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -43,7 +43,9 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
 	const std::string                 &server_name = *(config_server.server_names.begin()); // tmp
 	const VirtualServer::LocationList &locations   = ConvertLocations(config_server.location_con);
-	return VirtualServer(server_name, locations, config_server.host_ports);
+	return VirtualServer(
+		server_name, locations, config_server.host_ports, config_server.client_max_body_size
+	);
 }
 // todo: tmp for debug
 void DebugVirtualServerNames(

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -44,7 +44,11 @@ VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_se
 	const std::string                 &server_name = *(config_server.server_names.begin()); // tmp
 	const VirtualServer::LocationList &locations   = ConvertLocations(config_server.location_con);
 	return VirtualServer(
-		server_name, locations, config_server.host_ports, config_server.client_max_body_size
+		server_name,
+		locations,
+		config_server.host_ports,
+		config_server.client_max_body_size,
+		config_server.error_page
 	);
 }
 // todo: tmp for debug

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -38,22 +38,7 @@ VirtualServer::LocationList ConvertLocations(const config::context::LocationList
 VirtualServer ConvertToVirtualServer(const config::context::ServerCon &config_server) {
 	const std::string          &server_name = *(config_server.server_names.begin()); // tmp
 	VirtualServer::LocationList locations   = ConvertLocations(config_server.location_con);
-
-	// todo: tmp
-	static int                  n = 0;
-	VirtualServer::HostPortList host_port_list;
-	if (n == 0) {
-		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
-		// host_port_list.push_back(std::make_pair("::1", 8080));
-	} else {
-		host_port_list.push_back(std::make_pair("0.0.0.0", 8080));
-		host_port_list.push_back(std::make_pair("0.0.0.0", 9999));
-		host_port_list.push_back(std::make_pair("0.0.0.0", 12345));
-		// host_port_list.push_back(std::make_pair("::1", 8080));
-	}
-	++n;
-
-	return VirtualServer(server_name, locations, host_port_list);
+	return VirtualServer(server_name, locations, config_server.host_ports);
 }
 // todo: tmp for debug
 void DebugVirtualServerNames(

--- a/test/unit/virtual_server/test_virtual_server.cpp
+++ b/test/unit/virtual_server/test_virtual_server.cpp
@@ -300,11 +300,11 @@ int main() {
 	// server_name : 0個
 	// location    : 0個
 	// host:port   : 0個
-	ServerNameList    expected_server_names1;
-	LocationList      expected_locations1;
-	HostPortList      expected_host_ports1;
-	const std::size_t expected_client_max_body_size1 = 1024;
-	ErrorPage         error_page1                    = std::make_pair(0, "");
+	const ServerNameList expected_server_names1;
+	const LocationList   expected_locations1;
+	const HostPortList   expected_host_ports1;
+	const std::size_t    expected_client_max_body_size1 = 1024;
+	const ErrorPage      error_page1                    = std::make_pair(0, "");
 
 	// server_name : 1個
 	// location    : 1個
@@ -327,7 +327,7 @@ int main() {
 	HostPortList expected_host_ports2;
 	expected_host_ports2.push_back(std::make_pair("host1", 9999));
 	const std::size_t expected_client_max_body_size2 = 2048;
-	ErrorPage         error_page2                    = std::make_pair(404, "/error_page.html");
+	const ErrorPage   error_page2                    = std::make_pair(404, "/error_page.html");
 
 	// server_name : 複数
 	// location    : 複数
@@ -364,7 +364,7 @@ int main() {
 	expected_host_ports3.push_back(std::make_pair("host1", 8080));
 	expected_host_ports3.push_back(std::make_pair("host2", 12345));
 	const std::size_t expected_client_max_body_size3 = 4096;
-	ErrorPage         error_page3                    = std::make_pair(404, "/error.html");
+	const ErrorPage   error_page3                    = std::make_pair(404, "/error.html");
 
 	/* ------------------ test ------------------ */
 	ret_code |= Test(RunDefaultConstructor(

--- a/test/unit/virtual_server/test_virtual_server.cpp
+++ b/test/unit/virtual_server/test_virtual_server.cpp
@@ -6,13 +6,29 @@
 
 namespace server {
 
+// テストfail時のServerNameList,AllowedMethodListのdebug出力用
+std::ostream &operator<<(std::ostream &os, const std::list<std::string> &list) {
+	typedef std::list<std::string>::const_iterator It;
+	for (It it = list.begin(); it != list.end(); ++it) {
+		os << "[" << *it << "]";
+	}
+	os << std::endl;
+	return os;
+}
+
 // テストfail時のLocationListのdebug出力用
 std::ostream &operator<<(std::ostream &os, const VirtualServer::LocationList &locations) {
 	typedef VirtualServer::LocationList::const_iterator It;
 	for (It it = locations.begin(); it != locations.end(); ++it) {
 		const Location &location = *it;
-		os << "location: [" << location.location << "], root: [" << location.root << "], index: ["
-		   << location.index << "]";
+		os << "  request_uri: [" << location.request_uri << "]" << std::endl;
+		os << "  alias: [" << location.alias << "]" << std::endl;
+		os << "  index: [" << location.index << "]" << std::endl;
+		os << "  autoindex: [" << (location.autoindex ? "on" : "off") << "]" << std::endl;
+		os << "  allowed_methods: " << location.allowed_methods << std::endl; // todo
+		os << "  redirect: [" << location.request_uri << "]" << std::endl;
+		os << "  cgi_extension: [" << location.cgi_extension << "]" << std::endl;
+		os << "  upload_directory: [" << location.upload_directory << "]" << std::endl;
 		if (++It(it) != locations.end()) {
 			os << std::endl;
 		}
@@ -22,20 +38,28 @@ std::ostream &operator<<(std::ostream &os, const VirtualServer::LocationList &lo
 
 // std::list<Location>のoperator==が呼ばれる時用にstruct Locationのoperator==の実装
 bool operator==(const Location &lhs, const Location &rhs) {
-	return lhs.location == rhs.location && lhs.root == rhs.root && lhs.index == rhs.index &&
-		   lhs.allowed_method == rhs.allowed_method;
+	return lhs.request_uri == rhs.request_uri && lhs.alias == rhs.alias && lhs.index == rhs.index &&
+		   lhs.autoindex == rhs.autoindex && lhs.allowed_methods == rhs.allowed_methods &&
+		   lhs.redirect == rhs.redirect && lhs.cgi_extension == rhs.cgi_extension &&
+		   lhs.upload_directory == rhs.upload_directory;
 }
 
 // テストfail時のHostPortListのdebug出力用
-std::ostream &operator<<(std::ostream &os, const VirtualServer::HostPortList &host_port_list) {
+std::ostream &operator<<(std::ostream &os, const VirtualServer::HostPortList &host_ports) {
 	typedef VirtualServer::HostPortList::const_iterator It;
-	for (It it = host_port_list.begin(); it != host_port_list.end(); ++it) {
+	for (It it = host_ports.begin(); it != host_ports.end(); ++it) {
 		const VirtualServer::HostPortPair &host_port_pair = *it;
 		os << "host: [" << host_port_pair.first << "], port: [" << host_port_pair.second << "]";
-		if (++It(it) != host_port_list.end()) {
+		if (++It(it) != host_ports.end()) {
 			os << std::endl;
 		}
 	}
+	return os;
+}
+
+// テストfail時のErrorPageのdebug出力用
+std::ostream &operator<<(std::ostream &os, const VirtualServer::ErrorPage &error_page) {
+	os << "[" << error_page.first << "][" << error_page.second << "]";
 	return os;
 }
 
@@ -44,9 +68,14 @@ std::ostream &operator<<(std::ostream &os, const VirtualServer::HostPortList &ho
 namespace {
 
 typedef server::Location                    Location;
-typedef server::VirtualServer::LocationList LocationList;
-typedef server::VirtualServer::HostPortPair HostPortPair;
-typedef server::VirtualServer::HostPortList HostPortList;
+typedef server::Location::AllowedMethodList AllowedMethodList;
+typedef server::Location::Redirect          Redirect;
+
+typedef server::VirtualServer::ServerNameList ServerNameList;
+typedef server::VirtualServer::LocationList   LocationList;
+typedef server::VirtualServer::HostPortPair   HostPortPair;
+typedef server::VirtualServer::HostPortList   HostPortList;
+typedef server::VirtualServer::ErrorPage      ErrorPage;
 
 struct Result {
 	bool        is_ok;
@@ -91,9 +120,12 @@ int Test(Result result) {
 // -----------------------------------------------------------------------------
 Result TestIsSameMembers(
 	const server::VirtualServer &under_test_vs,
-	const std::string           &expected_server_name,
+	const ServerNameList        &expected_server_names,
 	const LocationList          &expected_locations,
-	const HostPortList          &expected_host_port_list
+	const HostPortList          &expected_host_ports,
+	std::size_t                  expected_client_max_body_size,
+	const ErrorPage             &expected_error_page
+
 ) {
 	using namespace server;
 
@@ -101,17 +133,19 @@ Result TestIsSameMembers(
 	result.is_ok = true;
 	std::ostringstream oss;
 
-	// VirtualServer.GetServerName()
-	const std::string &server_name = under_test_vs.GetServerName();
-	if (!IsSame(server_name, expected_server_name)) {
+	// VirtualServer.GetServerNameList()
+	const ServerNameList &server_names = under_test_vs.GetServerNameList();
+	if (!IsSame(server_names, expected_server_names)) {
 		result.is_ok = false;
-		oss << "server_name" << std::endl;
-		oss << "- result   [" << server_name << "]" << std::endl;
-		oss << "- expected [" << expected_server_name << "]" << std::endl;
+		oss << "server_names" << std::endl;
+		oss << "- result  " << std::endl;
+		oss << server_names << std::endl;
+		oss << "- expected" << std::endl;
+		oss << expected_server_names << std::endl;
 	}
 
-	// VirtualServer.GetLocations()
-	const LocationList &locations = under_test_vs.GetLocations();
+	// VirtualServer.GetLocationList()
+	const LocationList &locations = under_test_vs.GetLocationList();
 	if (!IsSame(locations, expected_locations)) {
 		result.is_ok = false;
 		oss << "locations" << std::endl;
@@ -122,14 +156,32 @@ Result TestIsSameMembers(
 	}
 
 	// VirtualServer.GetHostPortList()
-	const HostPortList &host_port_list = under_test_vs.GetHostPortList();
-	if (!IsSame(host_port_list, expected_host_port_list)) {
+	const HostPortList &host_ports = under_test_vs.GetHostPortList();
+	if (!IsSame(host_ports, expected_host_ports)) {
 		result.is_ok = false;
-		oss << "host_port_list" << std::endl;
+		oss << "host_ports" << std::endl;
 		oss << "- result  " << std::endl;
-		oss << host_port_list << std::endl;
+		oss << host_ports << std::endl;
 		oss << "- expected" << std::endl;
-		oss << expected_host_port_list << std::endl;
+		oss << expected_host_ports << std::endl;
+	}
+
+	// VirtualServer.GetClientMaxBodySize()
+	const std::size_t &client_max_body_size = under_test_vs.GetClientMaxBodySize();
+	if (!IsSame(client_max_body_size, expected_client_max_body_size)) {
+		result.is_ok = false;
+		oss << "client_max_body_size" << std::endl;
+		oss << "- result   [" << client_max_body_size << "]" << std::endl;
+		oss << "- expected [" << expected_client_max_body_size << "]" << std::endl;
+	}
+
+	// VirtualServer.GetErrorPage()
+	const ErrorPage &error_page = under_test_vs.GetErrorPage();
+	if (!IsSame(error_page, expected_error_page)) {
+		result.is_ok = false;
+		oss << "error_page" << std::endl;
+		oss << "- result  : " << error_page << std::endl;
+		oss << "- expected: " << expected_error_page << std::endl;
 	}
 
 	result.error_log = oss.str();
@@ -138,66 +190,104 @@ Result TestIsSameMembers(
 
 // test default constructor
 Result RunDefaultConstructor(
-	const std::string  &expected_server_name,
-	const LocationList &expected_locations,
-	const HostPortList &expected_host_port_list
+	const ServerNameList &expected_server_names,
+	const LocationList   &expected_locations,
+	const HostPortList   &expected_host_ports,
+	std::size_t           expected_client_max_body_size,
+	const ErrorPage      &expected_error_page
 ) {
 	// default constructor
 	server::VirtualServer virtual_server;
 
 	return TestIsSameMembers(
-		virtual_server, expected_server_name, expected_locations, expected_host_port_list
+		virtual_server,
+		expected_server_names,
+		expected_locations,
+		expected_host_ports,
+		expected_client_max_body_size,
+		expected_error_page
 	);
 }
 
 // test copy constructor
 Result RunCopyConstructor(
-	const std::string  &expected_server_name,
-	const LocationList &expected_locations,
-	const HostPortList &expected_host_port_list
+	const ServerNameList &expected_server_names,
+	const LocationList   &expected_locations,
+	const HostPortList   &expected_host_ports,
+	std::size_t           expected_client_max_body_size,
+	const ErrorPage      &expected_error_page
 ) {
 	// construct
 	server::VirtualServer virtual_server(
-		expected_server_name, expected_locations, expected_host_port_list
+		expected_server_names,
+		expected_locations,
+		expected_host_ports,
+		expected_client_max_body_size,
+		expected_error_page
 	);
 
 	// copy
 	server::VirtualServer copy_virtual_server(virtual_server);
 
 	return TestIsSameMembers(
-		copy_virtual_server, expected_server_name, expected_locations, expected_host_port_list
+		copy_virtual_server,
+		expected_server_names,
+		expected_locations,
+		expected_host_ports,
+		expected_client_max_body_size,
+		expected_error_page
 	);
 }
 
 // test copy assignment operator=
 Result RunCopyAssignmentOperator(
-	const std::string  &expected_server_name,
-	const LocationList &expected_locations,
-	const HostPortList &expected_host_port_list
+	const ServerNameList &expected_server_names,
+	const LocationList   &expected_locations,
+	const HostPortList   &expected_host_ports,
+	std::size_t           expected_client_max_body_size,
+	const ErrorPage      &expected_error_page
 ) {
 	// construct
 	server::VirtualServer virtual_server(
-		expected_server_name, expected_locations, expected_host_port_list
+		expected_server_names,
+		expected_locations,
+		expected_host_ports,
+		expected_client_max_body_size,
+		expected_error_page
 	);
 
 	// copy assignment operator=
 	server::VirtualServer copy_virtual_server = virtual_server;
 	return TestIsSameMembers(
-		copy_virtual_server, expected_server_name, expected_locations, expected_host_port_list
+		copy_virtual_server,
+		expected_server_names,
+		expected_locations,
+		expected_host_ports,
+		expected_client_max_body_size,
+		expected_error_page
 	);
 }
 
 Location CreateLocation(
-	const std::string &location,
-	const std::string &root,
-	const std::string &index,
-	const std::string &allowed_method
+	const std::string       &request_uri,
+	const std::string       &alias,
+	const std::string       &index,
+	bool                     autoindex,
+	const AllowedMethodList &allowed_methods,
+	const Redirect          &redirect,
+	const std::string       &cgi_extension,
+	const std::string       &upload_directory
+
 ) {
 	server::Location location_directive;
-	location_directive.location       = location;
-	location_directive.root           = root;
-	location_directive.index          = index;
-	location_directive.allowed_method = allowed_method;
+	location_directive.request_uri      = request_uri;
+	location_directive.alias            = alias;
+	location_directive.index            = index;
+	location_directive.autoindex        = autoindex;
+	location_directive.allowed_methods  = allowed_methods;
+	location_directive.redirect         = redirect;
+	location_directive.cgi_extension    = cgi_extension;
+	location_directive.upload_directory = upload_directory;
 	return location_directive;
 }
 
@@ -207,36 +297,97 @@ int main() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- expected用意 -------------- */
-	// location : 0個
-	// host:port: 0個
-	LocationList expected_locations1;
-	HostPortList expected_host_port_list1;
+	// server_name : 0個
+	// location    : 0個
+	// host:port   : 0個
+	ServerNameList    expected_server_names1;
+	LocationList      expected_locations1;
+	HostPortList      expected_host_ports1;
+	const std::size_t expected_client_max_body_size1 = 1024;
+	ErrorPage         error_page1                    = std::make_pair(0, "");
 
-	// location : 1個
-	// host:port: 1個
+	// server_name : 1個
+	// location    : 1個
+	// host:port   : 1個
+	ServerNameList expected_server_names2;
+	expected_server_names2.push_back("server_name1");
+	AllowedMethodList allowed_methods2;
+	allowed_methods2.push_back("GET");
 	LocationList expected_locations2;
-	expected_locations2.push_back(CreateLocation("/www/", "/data/", "index.html", "GET"));
-	HostPortList expected_host_port_list2;
-	expected_host_port_list2.push_back(std::make_pair("host1", 9999));
+	expected_locations2.push_back(CreateLocation(
+		"/www/",
+		"/data/",
+		"index.html",
+		true,
+		allowed_methods2,
+		std::make_pair(400, "/redirect"),
+		".py",
+		"/upload"
+	));
+	HostPortList expected_host_ports2;
+	expected_host_ports2.push_back(std::make_pair("host1", 9999));
+	const std::size_t expected_client_max_body_size2 = 2048;
+	ErrorPage         error_page2                    = std::make_pair(404, "/error_page.html");
 
-	// location : 複数
-	// host:port: 複数
+	// server_name : 複数
+	// location    : 複数
+	// host:port   : 複数
+	ServerNameList expected_server_names3;
+	expected_server_names3.push_back("server_name1");
+	expected_server_names3.push_back("server_name2");
+	AllowedMethodList allowed_methods3;
+	allowed_methods3.push_back("GET");
+	allowed_methods3.push_back("POST");
 	LocationList expected_locations3;
-	expected_locations3.push_back(CreateLocation("/", "/data/www/test", "index.html", "GET POST"));
-	expected_locations3.push_back(
-		CreateLocation("/static/", "/data/www", "index.html", "GET POST DELETE")
-	);
-	HostPortList expected_host_port_list3;
-	expected_host_port_list3.push_back(std::make_pair("host1", 8080));
-	expected_host_port_list3.push_back(std::make_pair("host2", 12345));
+	expected_locations3.push_back(CreateLocation(
+		"/",
+		"/data/www/test",
+		"index.html",
+		false,
+		allowed_methods2,
+		std::make_pair(302, "/redirect.html"),
+		".php",
+		"/upload"
+	));
+	allowed_methods3.push_back("DELETE");
+	expected_locations3.push_back(CreateLocation(
+		"/static/",
+		"/data/www",
+		"index.html",
+		true,
+		allowed_methods3,
+		std::make_pair(404, "/redirect.html"),
+		".perl",
+		"/upload"
+	));
+	HostPortList expected_host_ports3;
+	expected_host_ports3.push_back(std::make_pair("host1", 8080));
+	expected_host_ports3.push_back(std::make_pair("host2", 12345));
+	const std::size_t expected_client_max_body_size3 = 4096;
+	ErrorPage         error_page3                    = std::make_pair(404, "/error.html");
 
 	/* ------------------ test ------------------ */
-	ret_code |= Test(RunDefaultConstructor("", expected_locations1, expected_host_port_list1));
-	ret_code |=
-		Test(RunCopyConstructor("localhost", expected_locations2, expected_host_port_list2));
-	ret_code |=
-		Test(RunCopyAssignmentOperator("localhost2", expected_locations3, expected_host_port_list3)
-		);
+	ret_code |= Test(RunDefaultConstructor(
+		expected_server_names1,
+		expected_locations1,
+		expected_host_ports1,
+		expected_client_max_body_size1,
+		error_page1
+	));
+	ret_code |= Test(RunCopyConstructor(
+		expected_server_names2,
+		expected_locations2,
+		expected_host_ports2,
+		expected_client_max_body_size2,
+		error_page2
+	));
+	ret_code |= Test(RunCopyAssignmentOperator(
+		expected_server_names3,
+		expected_locations3,
+		expected_host_ports3,
+		expected_client_max_body_size3,
+		error_page3
+	));
 
 	return ret_code;
 }

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -120,9 +120,10 @@ Result RunGetVirtualServer(
 
 server::VirtualServer
 CreateVirtualServer(const ServerNameList &server_names, const HostPortList &host_ports) {
-	LocationList      locations;
-	const std::size_t client_max_body_size = 1024;
-	ErrorPage         error_page           = std::make_pair(404, "/error_page.html");
+	const LocationList locations;
+	const std::size_t  client_max_body_size = 1024;
+	const ErrorPage    error_page           = std::make_pair(404, "/error_page.html");
+
 	return server::VirtualServer(
 		server_names, locations, host_ports, client_max_body_size, error_page
 	);
@@ -143,7 +144,7 @@ int RunTestVirtualServerStorage() {
 	HostPortList host_ports;
 	host_ports.push_back(std::make_pair("host1", 8080));
 	host_ports.push_back(std::make_pair("host2", 12345));
-	server::VirtualServer vs1 = CreateVirtualServer(server_name1, host_ports);
+	const server::VirtualServer vs1 = CreateVirtualServer(server_name1, host_ports);
 
 	ServerNameList server_name2;
 	server_name2.push_back("localhost2");
@@ -151,7 +152,7 @@ int RunTestVirtualServerStorage() {
 	HostPortList host_ports2;
 	host_ports2.push_back(std::make_pair("host1", 8080));
 	host_ports2.push_back(std::make_pair("host3", 9999));
-	server::VirtualServer vs2 = CreateVirtualServer(server_name2, host_ports2);
+	const server::VirtualServer vs2 = CreateVirtualServer(server_name2, host_ports2);
 
 	/* -------------- VirtualServerAddrList用意 -------------- */
 	VirtualServerAddrList expected_vs_addr_list1;

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -118,6 +118,16 @@ Result RunGetVirtualServer(
 	return TestIsSameVirtualServer(vs_addr_list, expected_vs_addr_list);
 }
 
+server::VirtualServer
+CreateVirtualServer(const ServerNameList &server_names, const HostPortList &host_ports) {
+	LocationList      locations;
+	const std::size_t client_max_body_size = 1024;
+	ErrorPage         error_page           = std::make_pair(404, "/error_page.html");
+	return server::VirtualServer(
+		server_names, locations, host_ports, client_max_body_size, error_page
+	);
+}
+
 // -----------------------------------------------------------------------------
 // - virtual_serverは以下の想定
 // virtual_server | server_name          | host:port
@@ -128,40 +138,20 @@ int RunTestVirtualServerStorage() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- VirtualServer2個用意 -------------- */
-	ServerNameList expected_server_name1;
-	expected_server_name1.push_back("localhost");
-	AllowedMethodList allowed_methods1;
-	LocationList      expected_locations1;
-	HostPortList      expected_host_port_list1;
-	expected_host_port_list1.push_back(std::make_pair("host1", 8080));
-	expected_host_port_list1.push_back(std::make_pair("host2", 12345));
-	const std::size_t     expected_client_max_body_size1 = 1024;
-	ErrorPage             error_page1                    = std::make_pair(0, "");
-	server::VirtualServer vs1(
-		expected_server_name1,
-		expected_locations1,
-		expected_host_port_list1,
-		expected_client_max_body_size1,
-		error_page1
-	);
+	ServerNameList server_name1;
+	server_name1.push_back("localhost");
+	HostPortList host_ports;
+	host_ports.push_back(std::make_pair("host1", 8080));
+	host_ports.push_back(std::make_pair("host2", 12345));
+	server::VirtualServer vs1 = CreateVirtualServer(server_name1, host_ports);
 
-	ServerNameList expected_server_name2;
-	expected_server_name2.push_back("localhost2");
-	expected_server_name2.push_back("test_serv");
-	AllowedMethodList allowed_methods2;
-	LocationList      expected_locations2;
-	HostPortList      expected_host_port_list2;
-	expected_host_port_list1.push_back(std::make_pair("host1", 8080));
-	expected_host_port_list2.push_back(std::make_pair("host3", 9999));
-	const std::size_t     expected_client_max_body_size2 = 2048;
-	ErrorPage             error_page2                    = std::make_pair(404, "/error_page.html");
-	server::VirtualServer vs2(
-		expected_server_name2,
-		expected_locations2,
-		expected_host_port_list2,
-		expected_client_max_body_size2,
-		error_page2
-	);
+	ServerNameList server_name2;
+	server_name2.push_back("localhost2");
+	server_name2.push_back("test_serv");
+	HostPortList host_ports2;
+	host_ports2.push_back(std::make_pair("host1", 8080));
+	host_ports2.push_back(std::make_pair("host3", 9999));
+	server::VirtualServer vs2 = CreateVirtualServer(server_name2, host_ports2);
 
 	/* -------------- VirtualServerAddrList用意 -------------- */
 	VirtualServerAddrList expected_vs_addr_list1;

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -5,39 +5,15 @@
 #include <iostream>
 #include <sstream> // ostringstream
 
-// (todo : test_virtual_server.cppと全く同じoverloadを書いてるのでどうにかしても良いかも)
 namespace server {
 
-// テストfail時のLocationListのdebug出力用
-std::ostream &operator<<(std::ostream &os, const VirtualServer::LocationList &locations) {
-	typedef VirtualServer::LocationList::const_iterator It;
-	for (It it = locations.begin(); it != locations.end(); ++it) {
-		const Location &location = *it;
-		os << "location: [" << location.location << "], root: [" << location.root << "], index: ["
-		   << location.index << "]";
-		if (++It(it) != locations.end()) {
-			os << std::endl;
-		}
+// テストfail時のServerNameListのdebug出力用
+std::ostream &operator<<(std::ostream &os, const VirtualServer::ServerNameList &list) {
+	typedef VirtualServer::ServerNameList::const_iterator It;
+	for (It it = list.begin(); it != list.end(); ++it) {
+		os << "[" << *it << "]";
 	}
-	return os;
-}
-
-// std::list<Location>のoperator==が呼ばれる時用にstruct Locationのoperator==の実装
-bool operator==(const Location &lhs, const Location &rhs) {
-	return lhs.location == rhs.location && lhs.root == rhs.root && lhs.index == rhs.index &&
-		   lhs.allowed_method == rhs.allowed_method;
-}
-
-// テストfail時のHostPortListのdebug出力用
-std::ostream &operator<<(std::ostream &os, const VirtualServer::HostPortList &host_port_list) {
-	typedef VirtualServer::HostPortList::const_iterator It;
-	for (It it = host_port_list.begin(); it != host_port_list.end(); ++it) {
-		const VirtualServer::HostPortPair &host_port_pair = *it;
-		os << "host: [" << host_port_pair.first << "], port: [" << host_port_pair.second << "]";
-		if (++It(it) != host_port_list.end()) {
-			os << std::endl;
-		}
-	}
+	os << std::endl;
 	return os;
 }
 
@@ -45,11 +21,13 @@ std::ostream &operator<<(std::ostream &os, const VirtualServer::HostPortList &ho
 
 namespace {
 
-typedef server::Location Location;
+typedef server::Location                    Location;
+typedef server::Location::AllowedMethodList AllowedMethodList;
 
-typedef server::VirtualServer::LocationList LocationList;
-typedef server::VirtualServer::HostPortPair HostPortPair;
-typedef server::VirtualServer::HostPortList HostPortList;
+typedef server::VirtualServer::ServerNameList ServerNameList;
+typedef server::VirtualServer::LocationList   LocationList;
+typedef server::VirtualServer::HostPortList   HostPortList;
+typedef server::VirtualServer::ErrorPage      ErrorPage;
 
 typedef server::VirtualServerStorage::VirtualServerAddrList VirtualServerAddrList;
 
@@ -121,8 +99,8 @@ Result TestIsSameVirtualServer(
 		if (!IsSame(vs, expected_vs)) {
 			result.is_ok = false;
 			oss << "virtual_server_addr" << std::endl;
-			oss << "- result   [" << vs << "],[" << vs->GetServerName() << "]" << std::endl;
-			oss << "- expected [" << expected_vs << "],[" << expected_vs->GetServerName() << "]"
+			oss << "- result   [" << vs << "]," << vs->GetServerNameList() << std::endl;
+			oss << "- expected [" << expected_vs << "]," << expected_vs->GetServerNameList()
 				<< std::endl;
 		}
 	}
@@ -140,48 +118,50 @@ Result RunGetVirtualServer(
 	return TestIsSameVirtualServer(vs_addr_list, expected_vs_addr_list);
 }
 
-Location CreateLocation(
-	const std::string &location,
-	const std::string &root,
-	const std::string &index,
-	const std::string &allowed_method
-) {
-	server::Location location_directive;
-	location_directive.location       = location;
-	location_directive.root           = root;
-	location_directive.index          = index;
-	location_directive.allowed_method = allowed_method;
-	return location_directive;
-}
-
 // -----------------------------------------------------------------------------
 // - virtual_serverは以下の想定
-// virtual_server | server_name | locations         | host:port
-// ----------------- ----------------------------------------------
-//       vs1      | localhost   | {"/www/"}         | {host1:8080, host2:12345}
-//       vs2      | localhost2  | {"/", "/static/"} | {host1:8080, host3:9999}
+// virtual_server | server_name          | host:port
+// -----------------------------------------------------------------------------
+//       vs1      | localhost            | {host1:8080, host2:12345}
+//       vs2      | localhost2,test_serv | {host1:8080, host3:9999}
 int RunTestVirtualServerStorage() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- VirtualServer2個用意 -------------- */
-	std::string  expected_server_name1 = "localhost";
-	LocationList expected_locations1;
-	expected_locations1.push_back(CreateLocation("/www/", "/data/", "index.html", "GET"));
-	HostPortList expected_host_port_list1;
+	ServerNameList expected_server_name1;
+	expected_server_name1.push_back("localhost");
+	AllowedMethodList allowed_methods1;
+	LocationList      expected_locations1;
+	HostPortList      expected_host_port_list1;
 	expected_host_port_list1.push_back(std::make_pair("host1", 8080));
 	expected_host_port_list1.push_back(std::make_pair("host2", 12345));
-	server::VirtualServer vs1(expected_server_name1, expected_locations1, expected_host_port_list1);
-
-	std::string  expected_server_name2 = "localhost2";
-	LocationList expected_locations2;
-	expected_locations2.push_back(CreateLocation("/", "/data/www/test", "index.html", "GET POST"));
-	expected_locations2.push_back(
-		CreateLocation("/static/", "/data/www", "index.html", "GET POST DELETE")
+	const std::size_t     expected_client_max_body_size1 = 1024;
+	ErrorPage             error_page1                    = std::make_pair(0, "");
+	server::VirtualServer vs1(
+		expected_server_name1,
+		expected_locations1,
+		expected_host_port_list1,
+		expected_client_max_body_size1,
+		error_page1
 	);
-	HostPortList expected_host_port_list2;
+
+	ServerNameList expected_server_name2;
+	expected_server_name2.push_back("localhost2");
+	expected_server_name2.push_back("test_serv");
+	AllowedMethodList allowed_methods2;
+	LocationList      expected_locations2;
+	HostPortList      expected_host_port_list2;
 	expected_host_port_list1.push_back(std::make_pair("host1", 8080));
 	expected_host_port_list2.push_back(std::make_pair("host3", 9999));
-	server::VirtualServer vs2(expected_server_name2, expected_locations2, expected_host_port_list2);
+	const std::size_t     expected_client_max_body_size2 = 2048;
+	ErrorPage             error_page2                    = std::make_pair(404, "/error_page.html");
+	server::VirtualServer vs2(
+		expected_server_name2,
+		expected_locations2,
+		expected_host_port_list2,
+		expected_client_max_body_size2,
+		error_page2
+	);
 
 	/* -------------- VirtualServerAddrList用意 -------------- */
 	VirtualServerAddrList expected_vs_addr_list1;


### PR DESCRIPTION
PR #374  の後、main merge

---

`srcs/ +79. -50`
`test/unit/ +265, -143`

## したこと
- Server class が Config class から受け取っていなかった情報を全部受け取って使用するようにしました (`config/default.conf` の情報がそのまま Server 実行に使われるようになったので色々試せるように…！)
- 合わせて unit test の関連箇所の更新 (`test/unit/test_virtual_server.cpp`, `test/unit/test_virtual_server_storage.cpp` の 2 つです。構造体のメンバ変数を増やしただけで、挙動は変えていません)


## 実行
```sh
make run
make test
```

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `VirtualServer`クラスが新しいメンバー変数をサポートし、サーバーの設定がより柔軟に行えるようになりました。
  - 複数のサーバー名を扱えるように、関連メソッドが更新されました。

- **バグ修正**
  - `Location`構造体の比較演算子が改良され、より包括的な比較が可能になりました。

- **テスト**
  - 新しいデバッグ出力機能が追加され、テストの可読性が向上しました。
  - サーバー作成ロジックが集中化され、テストケースが新しい関数に合わせて更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->