### PR TITLE
Method Class作成

### DIFF
--- a/srcs/http/response/http_handle_method.cpp
+++ b/srcs/http/response/http_handle_method.cpp
@@ -1,6 +1,7 @@
 #include "http_exception.hpp"
 #include "http_message.hpp"
 #include "http_response.hpp"
+#include "http_method.hpp"
 #include "http_serverinfo_check.hpp"
 #include "stat.hpp"
 #include "system_exception.hpp"
@@ -43,7 +44,7 @@ std::string ReadFile(const std::string &file_path) {
 
 namespace http {
 
-StatusCode HttpResponse::MethodHandler(
+StatusCode Method::Handler(
 	const std::string            &path,
 	const std::string            &method,
 	const std::list<std::string> &allow_method,
@@ -60,21 +61,21 @@ StatusCode HttpResponse::MethodHandler(
 		status_code = DeleteHandler(path, response_body_message);
 	} else {
 		status_code           = StatusCode(NOT_IMPLEMENTED);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Not Implemented", status_code);
 	}
 	return status_code;
 }
 
 // todo: refactor
-StatusCode HttpResponse::GetHandler(const std::string &path, std::string &response_body_message) {
+StatusCode Method::GetHandler(const std::string &path, std::string &response_body_message) {
 	StatusCode status_code(OK);
 	Stat       info = TryStat(path, response_body_message);
 	if (info.IsDirectory()) {
 		// No empty string because the path has '/'
 		if (path[path.size() - 1] != '/') {
 			status_code           = StatusCode(MOVED_PERMANENTLY);
-			response_body_message = CreateDefaultBodyMessageFormat(status_code);
+			response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 			throw HttpException("Error: Moved Permanently", status_code);
 		}
 		// todo: Check for index directive and handle ReadFile function
@@ -83,20 +84,20 @@ StatusCode HttpResponse::GetHandler(const std::string &path, std::string &respon
 	} else if (info.IsRegularFile()) {
 		if (!info.IsReadableFile()) {
 			status_code           = StatusCode(FORBIDDEN);
-			response_body_message = CreateDefaultBodyMessageFormat(status_code);
+			response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 			throw HttpException("Error: Forbidden", status_code);
 		} else {
 			response_body_message = ReadFile(path);
 		}
 	} else {
 		status_code           = StatusCode(NOT_FOUND);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Not Found", status_code);
 	}
 	return status_code;
 }
 
-StatusCode HttpResponse::PostHandler(
+StatusCode Method::PostHandler(
 	const std::string &path,
 	const std::string &request_body_message,
 	std::string       &response_body_message
@@ -108,10 +109,10 @@ StatusCode HttpResponse::PostHandler(
 	StatusCode  status_code(NO_CONTENT);
 	if (info.IsDirectory()) {
 		status_code           = StatusCode(FORBIDDEN);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Forbidden", status_code);
 	} else if (info.IsRegularFile()) {
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 	} else {
 		// Location header fields: URI-reference
 		// ex) POST /save/test.txt HTTP/1.1
@@ -122,42 +123,42 @@ StatusCode HttpResponse::PostHandler(
 }
 
 StatusCode
-HttpResponse::DeleteHandler(const std::string &path, std::string &response_body_message) {
+Method::DeleteHandler(const std::string &path, std::string &response_body_message) {
 	const Stat &info        = TryStat(path, response_body_message);
 	StatusCode  status_code = StatusCode(NO_CONTENT);
 	if (info.IsDirectory()) {
 		status_code           = StatusCode(FORBIDDEN);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Forbidden", status_code);
 	} else if (std::remove(path.c_str()) == 0) {
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 	} else {
 		throw utils::SystemException(std::strerror(errno), errno);
 	}
 	return status_code;
 }
 
-void HttpResponse::SystemExceptionHandler(
+void Method::SystemExceptionHandler(
 	const utils::SystemException &e, std::string &response_body_message
 ) {
 	StatusCode status_code  = StatusCode(INTERNAL_SERVER_ERROR);
 	int        error_number = e.GetErrorNumber();
 	if (error_number == EACCES || error_number == EPERM) {
 		status_code           = StatusCode(FORBIDDEN);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Forbidden", status_code);
 	} else if (error_number == ENOENT || error_number == ENOTDIR || error_number == ELOOP ||
 			   error_number == ENAMETOOLONG) {
 		status_code           = StatusCode(NOT_FOUND);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Not Found", status_code);
 	} else {
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Internal Server Error", status_code);
 	}
 }
 
-StatusCode HttpResponse::FileCreationHandler(
+StatusCode Method::FileCreationHandler(
 	const std::string &path,
 	const std::string &request_body_message,
 	std::string       &response_body_message
@@ -166,7 +167,7 @@ StatusCode HttpResponse::FileCreationHandler(
 	std::ofstream file(path.c_str(), std::ios::binary);
 	if (file.fail()) {
 		status_code           = StatusCode(FORBIDDEN);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Forbidden", status_code);
 	}
 	file.write(request_body_message.c_str(), request_body_message.length());
@@ -176,14 +177,14 @@ StatusCode HttpResponse::FileCreationHandler(
 			throw utils::SystemException(std::strerror(errno), errno);
 		}
 		status_code           = StatusCode(FORBIDDEN);
-		response_body_message = CreateDefaultBodyMessageFormat(status_code);
+		response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 		throw HttpException("Error: Forbidden", status_code);
 	}
-	response_body_message = CreateDefaultBodyMessageFormat(status_code);
+	response_body_message = HttpResponse::CreateDefaultBodyMessageFormat(status_code);
 	return status_code;
 }
 
-Stat HttpResponse::TryStat(const std::string &path, std::string &response_body_message) {
+Stat Method::TryStat(const std::string &path, std::string &response_body_message) {
 	struct stat stat_buf;
 	try {
 		if (stat(path.c_str(), &stat_buf) == -1) {
@@ -198,7 +199,7 @@ Stat HttpResponse::TryStat(const std::string &path, std::string &response_body_m
 	return info;
 }
 
-bool HttpResponse::IsAllowedMethod(
+bool Method::IsAllowedMethod(
 	const std::string &method, const std::list<std::string> &allow_method
 ) {
 	if (allow_method.empty()) {

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -20,8 +20,6 @@ class Method {
 		const std::string            &request_body_message,
 		std::string                  &response_body_message
 	);
-
-  private:
 	static StatusCode GetHandler(const std::string &path, std::string &body_message);
 	static StatusCode PostHandler(
 		const std::string &path,
@@ -29,6 +27,8 @@ class Method {
 		std::string       &response_body_message
 	);
 	static StatusCode DeleteHandler(const std::string &path, std::string &response_body_message);
+
+  private:
 	static Stat       TryStat(const std::string &path, std::string &response_body_message);
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_method);
@@ -39,7 +39,7 @@ class Method {
 		const std::string &request_body_message,
 		std::string       &response_body_message
 	);
-}
+};
 
 } // namespace http
 

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -1,0 +1,46 @@
+#ifndef HTTP_METHOD_HPP_
+#define HTTP_METHOD_HPP_
+
+#include "status_code.hpp"
+#include "stat.hpp"
+#include <list>
+
+namespace utils {
+	class SystemException;
+}
+
+namespace http {
+
+class Method {
+  public:
+	static StatusCode Handler(
+		const std::string            &path,
+		const std::string            &method,
+		const std::list<std::string> &allow_method,
+		const std::string            &request_body_message,
+		std::string                  &response_body_message
+	);
+
+  private:
+	static StatusCode GetHandler(const std::string &path, std::string &body_message);
+	static StatusCode PostHandler(
+		const std::string &path,
+		const std::string &request_body_message,
+		std::string       &response_body_message
+	);
+	static StatusCode DeleteHandler(const std::string &path, std::string &response_body_message);
+	static Stat       TryStat(const std::string &path, std::string &response_body_message);
+	static bool
+	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_method);
+	static void
+	SystemExceptionHandler(const utils::SystemException &e, std::string &response_body_message);
+	static StatusCode FileCreationHandler(
+		const std::string &path,
+		const std::string &request_body_message,
+		std::string       &response_body_message
+	);
+}
+
+} // namespace http
+
+#endif

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -4,6 +4,7 @@
 #include "http_message.hpp"
 #include "http_parse.hpp"
 #include "server_infos.hpp"
+#include "http_method.hpp"
 #include <iostream>
 #include <sstream>
 
@@ -49,7 +50,7 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 		(void)client_info;
 		(void)server_info_result;
 		std::string       response_body_message;
-		const StatusCode &status_code = MethodHandler(
+		const StatusCode &status_code = Method::Handler(
 			server_info_result.path,
 			request_info.request.request_line.method,
 			server_info_result.allowed_methods,

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -38,20 +38,6 @@ class HttpResponse {
 					  Run(const MockDtoClientInfos &client_info,
 						  const MockDtoServerInfos &server_info,
 						  const HttpRequestResult  &request_info);
-	static StatusCode GetHandler(const std::string &path, std::string &body_message);
-	static StatusCode PostHandler(
-		const std::string &path,
-		const std::string &request_body_message,
-		std::string       &response_body_message
-	);
-	static StatusCode DeleteHandler(const std::string &path, std::string &response_body_message);
-	static StatusCode MethodHandler(
-		const std::string            &path,
-		const std::string            &method,
-		const std::list<std::string> &allow_method,
-		const std::string            &request_body_message,
-		std::string                  &response_body_message
-	);
 	static std::string CreateDefaultBodyMessageFormat(const StatusCode &status_code);
 	// static std::string CreateBadRequestResponse(const HttpRequestResult &request_info);
 
@@ -66,16 +52,6 @@ class HttpResponse {
 		const HttpRequestResult  &request_info
 	);
 	static HttpResponseFormat CreateDefaultHttpResponseFormat(const StatusCode &status_code);
-	static Stat               TryStat(const std::string &path, std::string &response_body_message);
-	static bool
-	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_method);
-	static void
-	SystemExceptionHandler(const utils::SystemException &e, std::string &response_body_message);
-	static StatusCode FileCreationHandler(
-		const std::string &path,
-		const std::string &request_body_message,
-		std::string       &response_body_message
-	);
 };
 
 } // namespace http

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -1,6 +1,6 @@
 #include "http_exception.hpp"
 #include "http_message.hpp"
-#include "http_response.hpp"
+#include "http_method.hpp"
 #include "utils.hpp"
 #include <cstdlib>
 #include <fstream>
@@ -40,7 +40,7 @@ int HandleResult(const T &result, const T &expected) {
 
 void TryGetHandler(const std::string &path, std::string &response_body_message) {
 	try {
-		http::HttpResponse::GetHandler(path, response_body_message);
+		http::Method::GetHandler(path, response_body_message);
 	} catch (const http::HttpException &e) {
 		// ステータスコードが300番台以上の場合
 		std::cerr << e.what() << std::endl;
@@ -51,7 +51,7 @@ void TryPostHandler(
 	const std::string &path, std::string &request_body_message, std::string &response_body_message
 ) {
 	try {
-		http::HttpResponse::PostHandler(path, request_body_message, response_body_message);
+		http::Method::PostHandler(path, request_body_message, response_body_message);
 	} catch (const http::HttpException &e) {
 		// ステータスコードが300番台以上の場合
 		std::cerr << e.what() << std::endl;
@@ -60,7 +60,7 @@ void TryPostHandler(
 
 void TryDeleteHandler(const std::string &path, std::string &response_body_message) {
 	try {
-		http::HttpResponse::DeleteHandler(path, response_body_message);
+		http::Method::DeleteHandler(path, response_body_message);
 	} catch (const http::HttpException &e) {
 		// ステータスコードが300番台以上の場合
 		std::cerr << e.what() << std::endl;


### PR DESCRIPTION
### 変更点
HttpResponseクラスにあるMethodHandlerに必要な関数ををMethodクラスへ移行

### してないこと
Methodクラスにある各メソッドのハンドラーをプライベート関数にする / 各メソッド関数ごとにテストしているため、今後`Method::Handler`で呼び出して、各メソッド関数をテストするよう作成する。

### 今後
#### http統合するまでの流れ

1. MethodHandlerの修正
#388 
~~2.MethodHandlerの引数がresponse_body_messageからHttpResponseFormatを参照渡しするため~~
~~https://github.com/sawamura-hayato/webserv/issues/380~~
-> Method::Handlerの返り値が`StatusCode`のため`header_fields`と`response_body_message`をそれぞれ参照渡しすることにした
3. HeaderFieldsの初期値( Content-Type, Server,Connection)とボディが決まれば追加するContent-Length作成
https://github.com/sawamura-hayato/webserv/issues/383
4. Http統合用のテスト書く
https://github.com/sawamura-hayato/webserv/issues/384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTPメソッドの処理を改善するために、新しい`Method`クラスを導入しました。
  - HTTPリクエストの処理をより構造化し、保守性を向上させました。

- **バグ修正**
  - `HttpResponse`クラスのメソッド呼び出しを更新し、HTTPレスポンス生成の流れを改善しました。

- **ドキュメント**
  - 新しい`http_method.hpp`ファイルに関する説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->