### PR TITLE
HttpResponseFormat初期化子リスト追加

### DIFF
--- a/srcs/http/http_format.hpp
+++ b/srcs/http/http_format.hpp
@@ -13,8 +13,10 @@ struct RequestLine {
 };
 
 struct StatusLine {
-	StatusLine(const std::string& version, const std::string& status_code, const std::string& reason_phrase) :
-	 version(version), status_code(status_code), reason_phrase(reason_phrase) {};
+	StatusLine(
+		const std::string &version, const std::string &status_code, const std::string &reason_phrase
+	)
+		: version(version), status_code(status_code), reason_phrase(reason_phrase) {};
 	std::string version;
 	std::string status_code;
 	std::string reason_phrase;
@@ -29,7 +31,12 @@ struct HttpRequestFormat {
 };
 
 struct HttpResponseFormat {
-	HttpResponseFormat(const StatusLine& status_line, const HeaderFields& header_fields, const std::string& body_message) : status_line(status_line), header_fields(header_fields), body_message(body_message) {};
+	HttpResponseFormat(
+		const StatusLine   &status_line,
+		const HeaderFields &header_fields,
+		const std::string  &body_message
+	)
+		: status_line(status_line), header_fields(header_fields), body_message(body_message) {};
 	StatusLine   status_line;
 	HeaderFields header_fields;
 	std::string  body_message;

--- a/srcs/http/http_format.hpp
+++ b/srcs/http/http_format.hpp
@@ -13,6 +13,8 @@ struct RequestLine {
 };
 
 struct StatusLine {
+	StatusLine(const std::string& version, const std::string& status_code, const std::string& reason_phrase) :
+	 version(version), status_code(status_code), reason_phrase(reason_phrase) {};
 	std::string version;
 	std::string status_code;
 	std::string reason_phrase;
@@ -27,6 +29,7 @@ struct HttpRequestFormat {
 };
 
 struct HttpResponseFormat {
+	HttpResponseFormat(const StatusLine& status_line, const HeaderFields& header_fields, const std::string& body_message) : status_line(status_line), header_fields(header_fields), body_message(body_message) {};
 	StatusLine   status_line;
 	HeaderFields header_fields;
 	std::string  body_message;

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -67,13 +67,11 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 		// 	response_message = ReadFile(server_info.error_page.GetValue().second);
 		// 	// check the path of error_page
 		// }
-		status_code = e.GetStatusCode();
+		status_code           = e.GetStatusCode();
 		response_body_message = CreateDefaultBodyMessageFormat(status_code);
 	}
-	return HttpResponseFormat(StatusLine(
-		HTTP_VERSION,
-		status_code.GetStatusCode(),
-		status_code.GetReasonPhrase()),
+	return HttpResponseFormat(
+		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),
 		header_fields,
 		response_body_message
 	);

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -82,20 +82,6 @@ std::string HttpResponse::CreateDefaultBodyMessageFormat(const StatusCode &statu
 	return body_message.str();
 }
 
-// mock
-HttpResponseFormat HttpResponse::CreateDefaultHttpResponseFormat(const StatusCode &status_code) {
-	HttpResponseFormat response;
-	response.status_line.version           = HTTP_VERSION;
-	response.status_line.status_code       = status_code.GetStatusCode();
-	response.status_line.reason_phrase     = status_code.GetReasonPhrase();
-	response.header_fields[CONTENT_TYPE]   = "text/html";
-	response.header_fields[SERVER]         = SERVER_VERSION;
-	response.header_fields[CONNECTION]     = "close";
-	response.body_message                  = CreateDefaultBodyMessageFormat(status_code);
-	response.header_fields[CONTENT_LENGTH] = utils::ToString(response.body_message.length());
-	return response;
-}
-
 std::string HttpResponse::CreateHttpResponse(const HttpResponseFormat &response) {
 	std::ostringstream response_stream;
 	response_stream << response.status_line.version << SP << response.status_line.status_code << SP

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -51,7 +51,7 @@ class HttpResponse {
 		const MockDtoServerInfos &server_info,
 		const HttpRequestResult  &request_info
 	);
-		static HeaderFields       InitHeaderFields(const HttpRequestResult &request_info);
+	static HeaderFields       InitHeaderFields(const HttpRequestResult &request_info);
 };
 
 } // namespace http

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -51,7 +51,7 @@ class HttpResponse {
 		const MockDtoServerInfos &server_info,
 		const HttpRequestResult  &request_info
 	);
-	static HeaderFields       InitHeaderFields(const HttpRequestResult &request_info);
+	static HeaderFields InitHeaderFields(const HttpRequestResult &request_info);
 };
 
 } // namespace http

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -51,8 +51,7 @@ class HttpResponse {
 		const MockDtoServerInfos &server_info,
 		const HttpRequestResult  &request_info
 	);
-	static HttpResponseFormat CreateDefaultHttpResponseFormat(const StatusCode &status_code);
-	static HeaderFields       InitHeaderFields(const HttpRequestResult &request_info);
+		static HeaderFields       InitHeaderFields(const HttpRequestResult &request_info);
 };
 
 } // namespace http


### PR DESCRIPTION
### 変更点
- HttpResponse::CreateDefaultHttpResponseFormatを削除
- HttpResponseFormat, StatusLineの初期化子リスト追加
- 上記に伴って、HttpResponse::CreateHttpResponseFormatの修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `StatusLine`および`HttpResponseFormat`構造体にコンストラクタを追加し、初期化機能を強化。
  - HTTPメソッドハンドリングにおいて、`HeaderFields`を新たに導入し、HTTPヘッダーの管理を改善。
  - `MethodArgument`構造体を導入し、HTTPメソッド処理を簡素化。

- **バグ修正**
  - エラーハンドリングの改善により、HTTPメソッドテストの一貫性と情報性を向上。

- **ドキュメント**
  - メソッドのシグネチャを明確にし、可読性を向上。

- **リファクタリング**
  - HTTPレスポンスの作成プロセスをよりモジュール化し、コードの整理を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->