### PR TITLE
[add] cgi_parseを追加

### DIFF
--- a/sandbox/sawa/cgi_env/cgi.cpp
+++ b/sandbox/sawa/cgi_env/cgi.cpp
@@ -5,7 +5,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-namespace http {
 namespace cgi {
 
 Cgi::Cgi() : argv_(NULL), env_(NULL), exit_status_(0) {}
@@ -122,4 +121,3 @@ char *const *Cgi::SetCgiEnv(const MetaMap &meta_variables) {
 }
 
 } // namespace cgi
-} // namespace http

--- a/sandbox/sawa/cgi_env/cgi.cpp
+++ b/sandbox/sawa/cgi_env/cgi.cpp
@@ -5,6 +5,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+namespace http {
 namespace cgi {
 
 Cgi::Cgi() : argv_(NULL), env_(NULL), exit_status_(0) {}
@@ -121,3 +122,4 @@ char *const *Cgi::SetCgiEnv(const MetaMap &meta_variables) {
 }
 
 } // namespace cgi
+} // namespace http

--- a/sandbox/sawa/cgi_env/cgi.hpp
+++ b/sandbox/sawa/cgi_env/cgi.hpp
@@ -4,7 +4,6 @@
 #include <map>
 #include <string>
 
-namespace http {
 namespace cgi {
 
 struct CgiRequest;
@@ -38,6 +37,5 @@ class Cgi {
 };
 
 } // namespace cgi
-} // namespace http
 
 #endif

--- a/sandbox/sawa/cgi_env/cgi.hpp
+++ b/sandbox/sawa/cgi_env/cgi.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 
+namespace http {
 namespace cgi {
 
 struct CgiRequest;
@@ -17,25 +18,26 @@ class Cgi {
 
   private:
 	Cgi(const Cgi &cgi);
-	Cgi   &operator=(const Cgi &cgi);
-	void   SetCgiMember(cgi::CgiRequest request);
-	char *const* SetCgiEnv(const MetaMap &meta_variables);
-	char *const* SetCgiArgv();
-	void   Execve();
-	void   ExecveCgiScript();
-	void   Free();
+	Cgi         &operator=(const Cgi &cgi);
+	void         SetCgiMember(cgi::CgiRequest request);
+	char *const *SetCgiEnv(const MetaMap &meta_variables);
+	char *const *SetCgiArgv();
+	void         Execve();
+	void         ExecveCgiScript();
+	void         Free();
 	// cgi info;
-	std::string method_;
-	std::string cgi_script_;
-	std::string body_message_;
-	char      *const* argv_;
-	char      *const* env_;
-	int         exit_status_;
+	std::string  method_;
+	std::string  cgi_script_;
+	std::string  body_message_;
+	char *const *argv_;
+	char *const *env_;
+	int          exit_status_;
 
-	static const int READ = 0;
+	static const int READ  = 0;
 	static const int WRITE = 1;
 };
 
 } // namespace cgi
+} // namespace http
 
 #endif

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -25,17 +25,16 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables() {
 	return request_meta_variables;
 }
 
-CgiRequest CgiParse::Parse(const std::string &http_request) {
-	CgiRequest request;
+utils::Result<CgiRequest> CgiParse::Parse(const HttpRequestFormat &request) {
+	utils::Result<CgiRequest> result;
 
-	(void)http_request;
 	// todo: メタ変数とボディメッセージをHTTPリクエスト情報か取得する
 	// -
 	// メタ変数（要相談:引数は現在HTTPリクエストの文字列やけどクライアントとサーバーの情報もいるから構造体がいい）
 	// - ボディメッセージ（定数）
-	request.meta_variables = CreateRequestMetaVariables();
-	request.body_message   = "name=ChatGPT&message=Hello";
-	return request;
+	// request.meta_variables = CreateRequestMetaVariables();
+	// request.body_message   = "name=ChatGPT&message=Hello";
+	return result;
 }
 
 } // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -41,7 +41,7 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
 	request_meta_variables["QUERY_STRING"]    = "";
 	request_meta_variables["REMOTE_ADDR"]     = "";
-	request_meta_variables["REMOTE_HOST"]     = "";
+	request_meta_variables["REMOTE_HOST"]     = ""; // 追加する？
 	request_meta_variables["REMOTE_IDENT"]    = "";
 	request_meta_variables["REMOTE_USER"]     = "";
 	request_meta_variables["REQUEST_METHOD"]  = request.request_line.method;
@@ -53,12 +53,16 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	return request_meta_variables;
 }
 
-utils::Result<CgiRequest> CgiParse::Parse(const HttpRequestFormat &request) {
-	utils::Result<CgiRequest> result;
-	CgiRequest                cgi_request;
+utils::Result<CgiRequest> CgiParse::Parse(
+	const HttpRequestFormat &request,
+	const std::string       &cgi_script,
+	const std::string       &cgi_extension
+) {
+	CgiRequest cgi_request;
 
-	// cgi_request.meta_variables = CreateRequestMetaVariables(request);
-	// request.body_message   = "name=ChatGPT&message=Hello";
+	cgi_request.meta_variables = CreateRequestMetaVariables(request, cgi_script, cgi_extension);
+	cgi_request.body_message   = request.body_message;
+	utils::Result<CgiRequest> result(cgi_request);
 	return result;
 }
 

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -3,11 +3,12 @@
 namespace http {
 namespace cgi {
 
-Cgi::MetaMap CgiParse::CreateRequestMetaVariables() {
+Cgi::MetaMap CgiParse::CreateRequestMetaVariables(const HttpRequestFormat &request) {
 	Cgi::MetaMap request_meta_variables;
+	// at()の要素がない場合どこかで弾く
 	request_meta_variables["AUTH_TYPE"]         = "";
-	request_meta_variables["CONTENT_LENGTH"]    = "26";
-	request_meta_variables["CONTENT_TYPE"]      = "";
+	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
+	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");
 	request_meta_variables["GATEWAY_INTERFACE"] = "CGI/1.1";
 	request_meta_variables["PATH_INFO"]         = "";
 	request_meta_variables["PATH_TRANSLATED"]   = "";
@@ -16,23 +17,20 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables() {
 	request_meta_variables["REMOTE_HOST"]       = "";
 	request_meta_variables["REMOTE_IDENT"]      = "";
 	request_meta_variables["REMOTE_USER"]       = "";
-	request_meta_variables["REQUEST_METHOD"]    = "POST";
+	request_meta_variables["REQUEST_METHOD"]    = request.request_line.method;
 	request_meta_variables["SCRIPT_NAME"]       = "../../../test/apache/cgi/print_stdin.pl";
-	request_meta_variables["SERVER_NAME"]       = "localhost";
+	request_meta_variables["SERVER_NAME"]       = request.header_fields.at("Host");
 	request_meta_variables["SERVER_PORT"]       = "8080";
-	request_meta_variables["SERVER_PROTOCOL"]   = "HTTP/1.1";
+	request_meta_variables["SERVER_PROTOCOL"]   = request.request_line.version;
 	request_meta_variables["SERVER_SOFTWARE"]   = "Webserv/1.1";
 	return request_meta_variables;
 }
 
 utils::Result<CgiRequest> CgiParse::Parse(const HttpRequestFormat &request) {
 	utils::Result<CgiRequest> result;
+	CgiRequest                cgi_request;
 
-	// todo: メタ変数とボディメッセージをHTTPリクエスト情報か取得する
-	// -
-	// メタ変数（要相談:引数は現在HTTPリクエストの文字列やけどクライアントとサーバーの情報もいるから構造体がいい）
-	// - ボディメッセージ（定数）
-	// request.meta_variables = CreateRequestMetaVariables();
+	cgi_request.meta_variables = CreateRequestMetaVariables(request);
 	// request.body_message   = "name=ChatGPT&message=Hello";
 	return result;
 }

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -2,27 +2,54 @@
 
 namespace http {
 namespace cgi {
+namespace {
 
-Cgi::MetaMap CgiParse::CreateRequestMetaVariables(const HttpRequestFormat &request) {
+std::string CreatePathInfo(const std::string &cgi_extension, const std::string &request_target) {
+	std::string::size_type pos = request_target.find(cgi_extension);
+	if (pos != std::string::npos) {
+		return request_target.substr(pos + cgi_extension.length());
+	}
+	return "";
+}
+
+std::string TranslateToCgiPath(const std::string &request_target) {
+	// from cgi_parse dir to cgi dir
+	return "../../../../cgi" + request_target;
+}
+
+std::string TranslateToHtmlPath(const std::string &request_target) {
+	// from cgi_parse dir to html dir
+	return "../../../../html" + request_target;
+}
+
+} // namespace
+
+Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
+	const HttpRequestFormat &request,
+	const std::string       &cgi_script,
+	const std::string       &cgi_extension
+) {
 	Cgi::MetaMap request_meta_variables;
 	// at()の要素がない場合どこかで弾く
 	request_meta_variables["AUTH_TYPE"]         = "";
 	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
 	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");
 	request_meta_variables["GATEWAY_INTERFACE"] = "CGI/1.1";
-	request_meta_variables["PATH_INFO"]         = "";
-	request_meta_variables["PATH_TRANSLATED"]   = "";
-	request_meta_variables["QUERY_STRING"]      = "";
-	request_meta_variables["REMOTE_ADDR"]       = "";
-	request_meta_variables["REMOTE_HOST"]       = "";
-	request_meta_variables["REMOTE_IDENT"]      = "";
-	request_meta_variables["REMOTE_USER"]       = "";
-	request_meta_variables["REQUEST_METHOD"]    = request.request_line.method;
-	request_meta_variables["SCRIPT_NAME"]       = "../../../test/apache/cgi/print_stdin.pl";
-	request_meta_variables["SERVER_NAME"]       = request.header_fields.at("Host");
-	request_meta_variables["SERVER_PORT"]       = "8080";
-	request_meta_variables["SERVER_PROTOCOL"]   = request.request_line.version;
-	request_meta_variables["SERVER_SOFTWARE"]   = "Webserv/1.1";
+	request_meta_variables["PATH_INFO"] =
+		CreatePathInfo(cgi_extension, request.request_line.request_target);
+	request_meta_variables["PATH_TRANSLATED"] =
+		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
+	request_meta_variables["QUERY_STRING"]    = "";
+	request_meta_variables["REMOTE_ADDR"]     = "";
+	request_meta_variables["REMOTE_HOST"]     = "";
+	request_meta_variables["REMOTE_IDENT"]    = "";
+	request_meta_variables["REMOTE_USER"]     = "";
+	request_meta_variables["REQUEST_METHOD"]  = request.request_line.method;
+	request_meta_variables["SCRIPT_NAME"]     = TranslateToCgiPath(cgi_script);
+	request_meta_variables["SERVER_NAME"]     = request.header_fields.at("Host");
+	request_meta_variables["SERVER_PORT"]     = "8080";
+	request_meta_variables["SERVER_PROTOCOL"] = request.request_line.version;
+	request_meta_variables["SERVER_SOFTWARE"] = "Webserv/1.1";
 	return request_meta_variables;
 }
 
@@ -30,7 +57,7 @@ utils::Result<CgiRequest> CgiParse::Parse(const HttpRequestFormat &request) {
 	utils::Result<CgiRequest> result;
 	CgiRequest                cgi_request;
 
-	cgi_request.meta_variables = CreateRequestMetaVariables(request);
+	// cgi_request.meta_variables = CreateRequestMetaVariables(request);
 	// request.body_message   = "name=ChatGPT&message=Hello";
 	return result;
 }

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -14,7 +14,7 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 
 std::string TranslateToCgiPath(const std::string &request_target) {
 	// from cgi_parse dir to cgi dir
-	return "../../../../cgi" + request_target;
+	return "../../../../cgi-bin" + request_target;
 }
 
 std::string TranslateToHtmlPath(const std::string &request_target) {
@@ -27,7 +27,8 @@ std::string TranslateToHtmlPath(const std::string &request_target) {
 Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	const HttpRequestFormat &request,
 	const std::string       &cgi_script,
-	const std::string       &cgi_extension
+	const std::string       &cgi_extension,
+	const std::string       &server_port
 ) {
 	Cgi::MetaMap request_meta_variables;
 	request_meta_variables["AUTH_TYPE"]         = "";
@@ -39,14 +40,14 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	request_meta_variables["PATH_TRANSLATED"] =
 		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
 	request_meta_variables["QUERY_STRING"]    = "";
-	request_meta_variables["REMOTE_ADDR"]     = "";
-	request_meta_variables["REMOTE_HOST"]     = ""; // 追加する？
+	request_meta_variables["REMOTE_ADDR"]     = ""; // 追加する？
+	request_meta_variables["REMOTE_HOST"]     = "";
 	request_meta_variables["REMOTE_IDENT"]    = "";
 	request_meta_variables["REMOTE_USER"]     = "";
 	request_meta_variables["REQUEST_METHOD"]  = request.request_line.method;
 	request_meta_variables["SCRIPT_NAME"]     = TranslateToCgiPath(cgi_script);
 	request_meta_variables["SERVER_NAME"]     = request.header_fields.at("Host");
-	request_meta_variables["SERVER_PORT"]     = "8080";
+	request_meta_variables["SERVER_PORT"]     = server_port;
 	request_meta_variables["SERVER_PROTOCOL"] = request.request_line.version;
 	request_meta_variables["SERVER_SOFTWARE"] = "Webserv/1.1";
 	return request_meta_variables;
@@ -55,14 +56,16 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 utils::Result<CgiRequest> CgiParse::Parse(
 	const HttpRequestFormat &request,
 	const std::string       &cgi_script,
-	const std::string       &cgi_extension
+	const std::string       &cgi_extension,
+	const std::string       &server_port
 ) {
 	CgiRequest                cgi_request;
 	utils::Result<CgiRequest> result;
 
 	try {
-		cgi_request.meta_variables = CreateRequestMetaVariables(request, cgi_script, cgi_extension);
-		cgi_request.body_message   = request.body_message;
+		cgi_request.meta_variables =
+			CreateRequestMetaVariables(request, cgi_script, cgi_extension, server_port);
+		cgi_request.body_message = request.body_message;
 		result.SetValue(cgi_request);
 	} catch (const std::exception &e) {
 		result.Set(false); // atで例外が投げられる

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -1,0 +1,40 @@
+#include "cgi_parse.hpp"
+
+namespace cgi {
+
+Cgi::MetaMap CgiParse::CreateRequestMetaVariables() {
+	Cgi::MetaMap request_meta_variables;
+	request_meta_variables["AUTH_TYPE"]         = "";
+	request_meta_variables["CONTENT_LENGTH"]    = "26";
+	request_meta_variables["CONTENT_TYPE"]      = "";
+	request_meta_variables["GATEWAY_INTERFACE"] = "CGI/1.1";
+	request_meta_variables["PATH_INFO"]         = "";
+	request_meta_variables["PATH_TRANSLATED"]   = "";
+	request_meta_variables["QUERY_STRING"]      = "";
+	request_meta_variables["REMOTE_ADDR"]       = "";
+	request_meta_variables["REMOTE_HOST"]       = "";
+	request_meta_variables["REMOTE_IDENT"]      = "";
+	request_meta_variables["REMOTE_USER"]       = "";
+	request_meta_variables["REQUEST_METHOD"]    = "POST";
+	request_meta_variables["SCRIPT_NAME"]       = "../../../test/apache/cgi/print_stdin.pl";
+	request_meta_variables["SERVER_NAME"]       = "localhost";
+	request_meta_variables["SERVER_PORT"]       = "8080";
+	request_meta_variables["SERVER_PROTOCOL"]   = "HTTP/1.1";
+	request_meta_variables["SERVER_SOFTWARE"]   = "Webserv/1.1";
+	return request_meta_variables;
+}
+
+CgiRequest CgiParse::Parse(const std::string &http_request) {
+	CgiRequest request;
+
+	(void)http_request;
+	// todo: メタ変数とボディメッセージをHTTPリクエスト情報か取得する
+	// -
+	// メタ変数（要相談:引数は現在HTTPリクエストの文字列やけどクライアントとサーバーの情報もいるから構造体がいい）
+	// - ボディメッセージ（定数）
+	request.meta_variables = CreateRequestMetaVariables();
+	request.body_message   = "name=ChatGPT&message=Hello";
+	return request;
+}
+
+} // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -1,5 +1,6 @@
 #include "cgi_parse.hpp"
 
+namespace http {
 namespace cgi {
 
 Cgi::MetaMap CgiParse::CreateRequestMetaVariables() {
@@ -38,3 +39,4 @@ CgiRequest CgiParse::Parse(const std::string &http_request) {
 }
 
 } // namespace cgi
+} // namespace http

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -30,7 +30,6 @@ Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	const std::string       &cgi_extension
 ) {
 	Cgi::MetaMap request_meta_variables;
-	// at()の要素がない場合どこかで弾く
 	request_meta_variables["AUTH_TYPE"]         = "";
 	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
 	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");
@@ -58,11 +57,16 @@ utils::Result<CgiRequest> CgiParse::Parse(
 	const std::string       &cgi_script,
 	const std::string       &cgi_extension
 ) {
-	CgiRequest cgi_request;
+	CgiRequest                cgi_request;
+	utils::Result<CgiRequest> result;
 
-	cgi_request.meta_variables = CreateRequestMetaVariables(request, cgi_script, cgi_extension);
-	cgi_request.body_message   = request.body_message;
-	utils::Result<CgiRequest> result(cgi_request);
+	try {
+		cgi_request.meta_variables = CreateRequestMetaVariables(request, cgi_script, cgi_extension);
+		cgi_request.body_message   = request.body_message;
+		result.SetValue(cgi_request);
+	} catch (const std::exception &e) {
+		result.Set(false); // atで例外が投げられる
+	}
 	return result;
 }
 

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -12,8 +12,13 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 	return "";
 }
 
-std::string TranslateToCgiPath(const std::string &request_target) {
+std::string
+TranslateToCgiPath(const std::string &cgi_extension, const std::string &request_target) {
 	// from cgi_parse dir to cgi dir
+	std::string::size_type pos = request_target.find(cgi_extension);
+	if (pos != std::string::npos) { // for /aa.cgi/bb only return /aa.cgi
+		return "../../../../cgi-bin" + request_target.substr(0, pos + cgi_extension.length());
+	}
 	return "../../../../cgi-bin" + request_target;
 }
 
@@ -35,8 +40,7 @@ MetaMap CgiParse::CreateRequestMetaVariables(
 	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
 	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");
 	request_meta_variables["GATEWAY_INTERFACE"] = "CGI/1.1";
-	request_meta_variables["PATH_INFO"] =
-		CreatePathInfo(cgi_extension, request.request_line.request_target);
+	request_meta_variables["PATH_INFO"]         = CreatePathInfo(cgi_extension, cgi_script);
 	request_meta_variables["PATH_TRANSLATED"] =
 		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
 	request_meta_variables["QUERY_STRING"]    = "";
@@ -45,7 +49,7 @@ MetaMap CgiParse::CreateRequestMetaVariables(
 	request_meta_variables["REMOTE_IDENT"]    = "";
 	request_meta_variables["REMOTE_USER"]     = "";
 	request_meta_variables["REQUEST_METHOD"]  = request.request_line.method;
-	request_meta_variables["SCRIPT_NAME"]     = TranslateToCgiPath(cgi_script);
+	request_meta_variables["SCRIPT_NAME"]     = TranslateToCgiPath(cgi_extension, cgi_script);
 	request_meta_variables["SERVER_NAME"]     = request.header_fields.at("Host");
 	request_meta_variables["SERVER_PORT"]     = server_port;
 	request_meta_variables["SERVER_PROTOCOL"] = request.request_line.version;

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -29,6 +29,24 @@ std::string TranslateToHtmlPath(const std::string &request_target) {
 
 } // namespace
 
+const std::string AUTH_TYPE         = "AUTH_TYPE";
+const std::string CONTENT_LENGTH    = "CONTENT_LENGTH";
+const std::string CONTENT_TYPE      = "CONTENT_TYPE";
+const std::string GATEWAY_INTERFACE = "GATEWAY_INTERFACE";
+const std::string PATH_INFO         = "PATH_INFO";
+const std::string PATH_TRANSLATED   = "PATH_TRANSLATED";
+const std::string QUERY_STRING      = "QUERY_STRING";
+const std::string REMOTE_ADDR       = "REMOTE_ADDR";
+const std::string REMOTE_HOST       = "REMOTE_HOST";
+const std::string REMOTE_IDENT      = "REMOTE_IDENT";
+const std::string REMOTE_USER       = "REMOTE_USER";
+const std::string REQUEST_METHOD    = "REQUEST_METHOD";
+const std::string SCRIPT_NAME       = "SCRIPT_NAME";
+const std::string SERVER_NAME       = "SERVER_NAME";
+const std::string SERVER_PORT       = "SERVER_PORT";
+const std::string SERVER_PROTOCOL   = "SERVER_PROTOCOL";
+const std::string SERVER_SOFTWARE   = "SERVER_SOFTWARE";
+
 MetaMap CgiParse::CreateRequestMetaVariables(
 	const HttpRequestFormat &request,
 	const std::string       &cgi_script,
@@ -36,24 +54,24 @@ MetaMap CgiParse::CreateRequestMetaVariables(
 	const std::string       &server_port
 ) {
 	MetaMap request_meta_variables;
-	request_meta_variables["AUTH_TYPE"]         = "";
-	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
-	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");
-	request_meta_variables["GATEWAY_INTERFACE"] = "CGI/1.1";
-	request_meta_variables["PATH_INFO"]         = CreatePathInfo(cgi_extension, cgi_script);
-	request_meta_variables["PATH_TRANSLATED"] =
+	request_meta_variables[AUTH_TYPE]         = "";
+	request_meta_variables[CONTENT_LENGTH]    = request.header_fields.at("Content-Length");
+	request_meta_variables[CONTENT_TYPE]      = request.header_fields.at("Content-Type");
+	request_meta_variables[GATEWAY_INTERFACE] = "CGI/1.1";
+	request_meta_variables[PATH_INFO]         = CreatePathInfo(cgi_extension, cgi_script);
+	request_meta_variables[PATH_TRANSLATED] =
 		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
-	request_meta_variables["QUERY_STRING"]    = "";
-	request_meta_variables["REMOTE_ADDR"]     = ""; // 追加する？
-	request_meta_variables["REMOTE_HOST"]     = "";
-	request_meta_variables["REMOTE_IDENT"]    = "";
-	request_meta_variables["REMOTE_USER"]     = "";
-	request_meta_variables["REQUEST_METHOD"]  = request.request_line.method;
-	request_meta_variables["SCRIPT_NAME"]     = TranslateToCgiPath(cgi_extension, cgi_script);
-	request_meta_variables["SERVER_NAME"]     = request.header_fields.at("Host");
-	request_meta_variables["SERVER_PORT"]     = server_port;
-	request_meta_variables["SERVER_PROTOCOL"] = request.request_line.version;
-	request_meta_variables["SERVER_SOFTWARE"] = "Webserv/1.1";
+	request_meta_variables[QUERY_STRING]    = "";
+	request_meta_variables[REMOTE_ADDR]     = ""; // 追加する？
+	request_meta_variables[REMOTE_HOST]     = "";
+	request_meta_variables[REMOTE_IDENT]    = "";
+	request_meta_variables[REMOTE_USER]     = "";
+	request_meta_variables[REQUEST_METHOD]  = request.request_line.method;
+	request_meta_variables[SCRIPT_NAME]     = TranslateToCgiPath(cgi_extension, cgi_script);
+	request_meta_variables[SERVER_NAME]     = request.header_fields.at("Host");
+	request_meta_variables[SERVER_PORT]     = server_port;
+	request_meta_variables[SERVER_PROTOCOL] = request.request_line.version;
+	request_meta_variables[SERVER_SOFTWARE] = "Webserv/1.1";
 	return request_meta_variables;
 }
 

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -24,13 +24,13 @@ std::string TranslateToHtmlPath(const std::string &request_target) {
 
 } // namespace
 
-Cgi::MetaMap CgiParse::CreateRequestMetaVariables(
+MetaMap CgiParse::CreateRequestMetaVariables(
 	const HttpRequestFormat &request,
 	const std::string       &cgi_script,
 	const std::string       &cgi_extension,
 	const std::string       &server_port
 ) {
-	Cgi::MetaMap request_meta_variables;
+	MetaMap request_meta_variables;
 	request_meta_variables["AUTH_TYPE"]         = "";
 	request_meta_variables["CONTENT_LENGTH"]    = request.header_fields.at("Content-Length");
 	request_meta_variables["CONTENT_TYPE"]      = request.header_fields.at("Content-Type");

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -8,6 +8,25 @@ namespace cgi {
 
 typedef std::map<std::string, std::string> MetaMap;
 
+// namespace cgi用
+extern const std::string AUTH_TYPE;
+extern const std::string CONTENT_LENGTH;
+extern const std::string CONTENT_TYPE;
+extern const std::string GATEWAY_INTERFACE;
+extern const std::string PATH_INFO;
+extern const std::string PATH_TRANSLATED;
+extern const std::string QUERY_STRING;
+extern const std::string REMOTE_ADDR;
+extern const std::string REMOTE_HOST;
+extern const std::string REMOTE_IDENT;
+extern const std::string REMOTE_USER;
+extern const std::string REQUEST_METHOD;
+extern const std::string SCRIPT_NAME;
+extern const std::string SERVER_NAME;
+extern const std::string SERVER_PORT;
+extern const std::string SERVER_PROTOCOL;
+extern const std::string SERVER_SOFTWARE;
+
 struct CgiRequest {
 	MetaMap     meta_variables;
 	std::string body_message;

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -1,4 +1,3 @@
-#include "cgi.hpp"
 #include "http_format.hpp"
 #include "result.hpp"
 #include <iostream>
@@ -9,9 +8,11 @@
 namespace http {
 namespace cgi {
 
+typedef std::map<std::string, std::string> MetaMap;
+
 struct CgiRequest {
-	Cgi::MetaMap meta_variables;
-	std::string  body_message;
+	MetaMap     meta_variables;
+	std::string body_message;
 };
 
 class CgiParse {
@@ -27,8 +28,8 @@ class CgiParse {
 	CgiParse();
 	~CgiParse();
 	CgiParse(const CgiParse &other);
-	CgiParse           &operator=(const CgiParse &other);
-	static Cgi::MetaMap CreateRequestMetaVariables(
+	CgiParse      &operator=(const CgiParse &other);
+	static MetaMap CreateRequestMetaVariables(
 		const HttpRequestFormat &request,
 		const std::string       &cgi_script,
 		const std::string       &cgi_extension,

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -24,7 +24,7 @@ class CgiParse {
 	CgiParse(const CgiParse &other);
 	CgiParse &operator=(const CgiParse &other);
 	// todo メタ変数を作成するにはサーバーの情報、クライアントの情報、HTTPリクエスト情報が必要
-	static Cgi::MetaMap CreateRequestMetaVariables();
+	static Cgi::MetaMap CreateRequestMetaVariables(const HttpRequestFormat &request);
 }; // namespace cgi class CgiParse
 
 } // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -32,7 +32,7 @@ class CgiParse {
 		const std::string       &cgi_script,
 		const std::string       &cgi_extension,
 		const std::string       &server_port
-	); // alias等を通過したパスが必要なため
+	); // alias等を通過したパスが必要なため、requestのpathではなくcgi_scriptをpathとして使用する
 };
 
 } // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -19,7 +19,8 @@ class CgiParse {
 	static utils::Result<CgiRequest> Parse(
 		const HttpRequestFormat &request,
 		const std::string       &cgi_script,
-		const std::string       &cgi_extension
+		const std::string       &cgi_extension,
+		const std::string       &server_port
 	);
 
   private:
@@ -30,7 +31,8 @@ class CgiParse {
 	static Cgi::MetaMap CreateRequestMetaVariables(
 		const HttpRequestFormat &request,
 		const std::string       &cgi_script,
-		const std::string       &cgi_extension
+		const std::string       &cgi_extension,
+		const std::string       &server_port
 	); // alias等を通過したパスが必要なため
 };
 

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -22,10 +22,14 @@ class CgiParse {
 	CgiParse();
 	~CgiParse();
 	CgiParse(const CgiParse &other);
-	CgiParse &operator=(const CgiParse &other);
-	// todo メタ変数を作成するにはサーバーの情報、クライアントの情報、HTTPリクエスト情報が必要
-	static Cgi::MetaMap CreateRequestMetaVariables(const HttpRequestFormat &request);
-}; // namespace cgi class CgiParse
+	CgiParse           &operator=(const CgiParse &other);
+	static Cgi::MetaMap CreateRequestMetaVariables(
+		const HttpRequestFormat &request,
+		const std::string       &cgi_script,
+		const std::string       &cgi_extension
+	);
+	// alias等を通過したパスが必要なため
+};
 
 } // namespace cgi
 } // namespace http

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -1,0 +1,28 @@
+#include "cgi.hpp"
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace cgi {
+
+struct CgiRequest {
+	Cgi::MetaMap meta_variables;
+	std::string  body_message;
+};
+
+class CgiParse {
+  public:
+	// todo 引数は要相談（クライアントとサーバーの情報を追加するかも）
+	static CgiRequest Parse(const std::string &http_request);
+
+  private:
+	CgiParse();
+	~CgiParse();
+	CgiParse(const CgiParse &other);
+	CgiParse &operator=(const CgiParse &other);
+	// todo メタ変数を作成するにはサーバーの情報、クライアントの情報、HTTPリクエスト情報が必要
+	static Cgi::MetaMap CreateRequestMetaVariables();
+}; // namespace cgi class CgiParse
+
+} // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -16,7 +16,11 @@ struct CgiRequest {
 
 class CgiParse {
   public:
-	static utils::Result<CgiRequest> Parse(const HttpRequestFormat &request);
+	static utils::Result<CgiRequest> Parse(
+		const HttpRequestFormat &request,
+		const std::string       &cgi_script,
+		const std::string       &cgi_extension
+	);
 
   private:
 	CgiParse();
@@ -27,8 +31,7 @@ class CgiParse {
 		const HttpRequestFormat &request,
 		const std::string       &cgi_script,
 		const std::string       &cgi_extension
-	);
-	// alias等を通過したパスが必要なため
+	); // alias等を通過したパスが必要なため
 };
 
 } // namespace cgi

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -1,5 +1,6 @@
 #include "cgi.hpp"
 #include "http_format.hpp"
+#include "result.hpp"
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -15,7 +16,7 @@ struct CgiRequest {
 
 class CgiParse {
   public:
-	static CgiRequest Parse(const HttpRequestFormat &request);
+	static utils::Result<CgiRequest> Parse(const HttpRequestFormat &request);
 
   private:
 	CgiParse();

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -1,9 +1,11 @@
 #include "cgi.hpp"
+#include "http_format.hpp"
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
 
+namespace http {
 namespace cgi {
 
 struct CgiRequest {
@@ -13,8 +15,7 @@ struct CgiRequest {
 
 class CgiParse {
   public:
-	// todo 引数は要相談（クライアントとサーバーの情報を追加するかも）
-	static CgiRequest Parse(const std::string &http_request);
+	static CgiRequest Parse(const HttpRequestFormat &request);
 
   private:
 	CgiParse();
@@ -26,3 +27,4 @@ class CgiParse {
 }; // namespace cgi class CgiParse
 
 } // namespace cgi
+} // namespace http

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -1,8 +1,6 @@
 #include "http_format.hpp"
 #include "result.hpp"
-#include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 
 namespace http {

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -6,6 +6,7 @@ TEST_DIRS	:=	convert_str \
 				http_storage \
 				http_status_code \
 				http_serverinfo_check \
+				http_cgi_parse \
 				sock_context \
 				split_str \
 				virtual_server \

--- a/test/unit/http_cgi_parse/Makefile
+++ b/test/unit/http_cgi_parse/Makefile
@@ -1,0 +1,81 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	http_cgi_parse
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR				:=	../../../srcs
+WS_UTILS_DIR			:= $(WS_SRCS_DIR)/utils
+WS_HTTP_DIR				:=	$(WS_SRCS_DIR)/http
+WS_HTTP_RESPONSE_DIR	:=	$(WS_HTTP_DIR)/response
+WS_HTTP_CGI_PARSE		:=	$(WS_HTTP_RESPONSE_DIR)/cgi_parse
+
+SRCS				+=	$(WS_HTTP_CGI_PARSE)/cgi_parse.cpp \
+						$(WS_HTTP_DIR)/http_message.cpp \
+						$(WS_UTILS_DIR)/color.cpp
+
+# 3. Add unit test files
+SRCS	+=	test_http_cgi_parse.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_UTILS_DIR) \
+				$(WS_HTTP_DIR) \
+				$(WS_HTTP_RESPONSE_DIR) \
+				$(WS_HTTP_CGI_PARSE)
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
+++ b/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
@@ -1,0 +1,103 @@
+#include "cgi_parse.hpp"
+#include "http_format.hpp"
+#include "http_message.hpp"
+#include "utils.hpp"
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+namespace {
+
+using namespace http;
+
+// ==================== Test汎用 ==================== //
+
+int GetTestCaseNum() {
+	static int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+void PrintOk() {
+	std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintNg() {
+	std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+			  << std::endl;
+}
+
+template <typename T>
+void IsSame(const T &a, const T &b, const char *file, int line) {
+	if (a != b) {
+		std::stringstream ss;
+		ss << line;
+		throw std::logic_error(std::string("Error at ") + file + ":" + ss.str());
+	}
+}
+
+/**
+ * @brief Output where is the error
+ */
+#define COMPARE(a, b) IsSame(a, b, __FILE__, __LINE__)
+
+template <class InputIt>
+InputIt Next(InputIt it, typename std::iterator_traits<InputIt>::difference_type n = 1) {
+	std::advance(it, n);
+	return it;
+} // std::next for c++98
+
+// ================================================= //
+
+// cgi_parseから見た相対パス
+const std::string html_dir_path    = "../../../../html";
+const std::string cgi_bin_dir_path = "../../../../cgi-bin";
+
+int Test1() {
+	// request
+	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
+	HttpRequestFormat request;
+	request.request_line                  = request_line;
+	request.header_fields[HOST]           = "host1";
+	request.header_fields[CONNECTION]     = "keep-alive";
+	request.header_fields[CONTENT_LENGTH] = "0";
+	request.header_fields[CONTENT_TYPE]   = "text/plain";
+
+	std::string cgi_script    = "/test.cgi";
+	std::string cgi_path_info = "/aa/b";
+	std::string cgi_extension = ".cgi";
+	std::string server_port   = "8080";
+
+	utils::Result<cgi::CgiRequest> parse_result =
+		cgi::CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port);
+	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
+
+	try {
+		COMPARE(meta_variables.at("CONTENT_LENGTH"), request.header_fields.at("Content-Length"));
+		COMPARE(meta_variables.at("CONTENT_TYPE"), request.header_fields.at("Content-Type"));
+		COMPARE(meta_variables.at("PATH_INFO"), cgi_path_info);
+		COMPARE(meta_variables.at("PATH_TRANSLATED"), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at("REQUEST_METHOD"), request_line.method);
+		COMPARE(meta_variables.at("SCRIPT_NAME"), cgi_bin_dir_path + cgi_script);
+		COMPARE(meta_variables.at("SERVER_NAME"), request.header_fields.at("Host"));
+		COMPARE(meta_variables.at("SERVER_PORT"), server_port);
+		COMPARE(meta_variables.at("SERVER_PROTOCOL"), request_line.version);
+	} catch (const std::exception &e) {
+		PrintNg();
+		std::cerr << e.what() << '\n';
+		return EXIT_FAILURE;
+	}
+	PrintOk();
+	return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main() {
+	int ret = EXIT_SUCCESS;
+
+	ret |= Test1();
+
+	return ret;
+}

--- a/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
+++ b/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
@@ -32,7 +32,10 @@ void IsSame(const T &a, const T &b, const char *file, int line) {
 	if (a != b) {
 		std::stringstream ss;
 		ss << line;
-		throw std::logic_error(std::string("Error at ") + file + ":" + ss.str());
+		throw std::logic_error(
+			std::string("Error at ") + file + ":" + ss.str() + " - Expected: " + std::string(b) +
+			", Got: " + std::string(a)
+		);
 	}
 }
 

--- a/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
+++ b/test/unit/http_cgi_parse/test_http_cgi_parse.cpp
@@ -75,15 +75,15 @@ int Test1() {
 	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
 
 	try {
-		COMPARE(meta_variables.at("CONTENT_LENGTH"), request.header_fields.at("Content-Length"));
-		COMPARE(meta_variables.at("CONTENT_TYPE"), request.header_fields.at("Content-Type"));
-		COMPARE(meta_variables.at("PATH_INFO"), cgi_path_info);
-		COMPARE(meta_variables.at("PATH_TRANSLATED"), html_dir_path + cgi_path_info);
-		COMPARE(meta_variables.at("REQUEST_METHOD"), request_line.method);
-		COMPARE(meta_variables.at("SCRIPT_NAME"), cgi_bin_dir_path + cgi_script);
-		COMPARE(meta_variables.at("SERVER_NAME"), request.header_fields.at("Host"));
-		COMPARE(meta_variables.at("SERVER_PORT"), server_port);
-		COMPARE(meta_variables.at("SERVER_PROTOCOL"), request_line.version);
+		COMPARE(meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH));
+		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
+		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
+		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
+		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
+		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
+		COMPARE(meta_variables.at(cgi::SERVER_PORT), server_port);
+		COMPARE(meta_variables.at(cgi::SERVER_PROTOCOL), request_line.version);
 	} catch (const std::exception &e) {
 		PrintNg();
 		std::cerr << e.what() << '\n';
@@ -112,15 +112,15 @@ int Test2() {
 	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
 
 	try {
-		COMPARE(meta_variables.at("CONTENT_LENGTH"), request.header_fields.at("Content-Length"));
-		COMPARE(meta_variables.at("CONTENT_TYPE"), request.header_fields.at("Content-Type"));
-		COMPARE(meta_variables.at("PATH_INFO"), cgi_path_info);
-		COMPARE(meta_variables.at("PATH_TRANSLATED"), html_dir_path + cgi_path_info);
-		COMPARE(meta_variables.at("REQUEST_METHOD"), request_line.method);
-		COMPARE(meta_variables.at("SCRIPT_NAME"), cgi_bin_dir_path + cgi_script);
-		COMPARE(meta_variables.at("SERVER_NAME"), request.header_fields.at("Host"));
-		COMPARE(meta_variables.at("SERVER_PORT"), server_port);
-		COMPARE(meta_variables.at("SERVER_PROTOCOL"), request_line.version);
+		COMPARE(meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH));
+		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
+		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
+		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
+		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
+		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
+		COMPARE(meta_variables.at(cgi::SERVER_PORT), server_port);
+		COMPARE(meta_variables.at(cgi::SERVER_PROTOCOL), request_line.version);
 	} catch (const std::exception &e) {
 		PrintOk();
 		utils::Debug("Test2", e.what());


### PR DESCRIPTION
## Cgi用のCgiRequestを用意するParseクラスを追加しました

- Request, Server情報等からMetaMapを作成
- body_messageはrequestのbody_messageのまま
- requestのヘッダーにないキーは一旦エラー(仕様は変えるかも)
- namesp cgiをnames httpの中に

sandboxのやつを少し修正したものです。渡す側がCheckServerInfoやリクエストの情報から選んで渡す想定です。

## Further
- REMOTE_ADDR(クライアントのip)は追加するか
- SERVER_PORTをどの様にして持ってくるか(CheckServerInfoを少し変える必要がありそう)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- CGIリクエストを解析するための新しい機能を追加しました。
	- HTTPリクエストからCGIメタ変数を生成する機能を実装しました。

- **ドキュメント**
	- CGI解析に関連する新しいテスト用のMakefileを追加しました。

- **テスト**
	- CGI解析機能に対するユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->