### PR TITLE
[add] host:port 管理機能変更に伴う virtual_server_storage unit test 追加

### DIFF
--- a/test/unit/message_manager/test_message_manager.cpp
+++ b/test/unit/message_manager/test_message_manager.cpp
@@ -105,7 +105,7 @@ std::ostream &operator<<(std::ostream &os, const ResponseDeque &dq) {
 bool IsSameResponseDeque(
 	server::MessageManager &manager,
 	ResponseDeque          &result_responses,
-	ResponseDeque           expected_responses,
+	const ResponseDeque    &expected_responses,
 	int                     client_fd
 ) {
 	// 単純なgetterがないので比較対象のResponseDequeの中身を取り出す

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -57,6 +57,10 @@ void PrintError(const std::string &message) {
 	std::cerr << utils::color::RED << message << utils::color::RESET << std::endl;
 }
 
+void PrintTitle(const std::string &title) {
+	std::cout << utils::color::BLUE << title << utils::color::RESET << std::endl;
+}
+
 template <typename T>
 bool IsSame(const T &result, const T &expected) {
 	return result == expected;
@@ -138,6 +142,8 @@ CreateVirtualServer(const ServerNameList &server_names, const HostPortList &host
 //       vs1      | localhost            | {host1:8080, host2:12345}
 //       vs2      | localhost2,test_serv | {host1:8080, host3:9999}
 int RunTestVirtualServerStorage1() {
+	PrintTitle(__func__);
+
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- HostPortPair3個用意 -------------- */

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -130,13 +130,14 @@ CreateVirtualServer(const ServerNameList &server_names, const HostPortList &host
 	);
 }
 
+// 同じhost:portが複数VirtualServerにある場合
 // -----------------------------------------------------------------------------
 // - virtual_serverは以下の想定
 // virtual_server | server_name          | host:port
 // -----------------------------------------------------------------------------
 //       vs1      | localhost            | {host1:8080, host2:12345}
 //       vs2      | localhost2,test_serv | {host1:8080, host3:9999}
-int RunTestVirtualServerStorage() {
+int RunTestVirtualServerStorage1() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- HostPortPair3個用意 -------------- */
@@ -178,12 +179,17 @@ int RunTestVirtualServerStorage() {
 	vs_storage.AddVirtualServer(vs1);
 	vs_storage.AddVirtualServer(vs2);
 
+	// 初期化
+	vs_storage.InitHostPortPair(host_port1);
+	vs_storage.InitHostPortPair(host_port2);
+	vs_storage.InitHostPortPair(host_port3);
+
 	// - socket通信した結果のserver_fdとvirtual_serverは以下の想定
-	// fd | virtual_server  | host:port
-	// ----------------------------
-	//  4 |     vs1, vs2    | host1:8080
-	//  5 |       vs1       | host2:12345
-	//  6 |       vs2       | host3:9999
+	// host:port   | virtual_server*
+	// -----------------------------
+	// host1:8080  |   vs1, vs2
+	// host2:12345 |     vs1
+	// host3:9999  |     vs2
 
 	// server_fdとvirtual_serverの紐づけをvirtual_server_storageに追加
 	vs_storage.AddMapping(host_port1, &vs1);
@@ -217,7 +223,7 @@ int RunTestVirtualServerStorage() {
 int main() {
 	int ret_code = EXIT_SUCCESS;
 
-	ret_code |= RunTestVirtualServerStorage();
+	ret_code |= RunTestVirtualServerStorage1();
 
 	return ret_code;
 }

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -350,6 +350,96 @@ int RunTestVirtualServerStorage3() {
 	return ret_code;
 }
 
+// 0.0.0.0がある &&
+// 0.0.0.0のportと同じportで異なるhostのhost:portが、異なるVirtualServerに存在する場合
+// -----------------------------------------------------------------------------
+// - virtual_serverは以下の想定
+// virtual_server | server_name           | host:port
+// -----------------------------------------------------------------------------
+//       vs1      | localhost1            | {127.0.0.1:8080}
+//       vs2      | localhost2,serv_name2 | {0.0.0.0:8080}
+//       vs3      | serv_name3            | {127.0.0.1:8080, 172.19.0.1:8080}
+int RunTestVirtualServerStorage4() {
+	PrintTitle(__func__);
+
+	int ret_code = EXIT_SUCCESS;
+
+	/* -------------- HostPortPair4個用意 -------------- */
+	const HostPortPair host_port1 = std::make_pair("127.0.0.1", 8080);
+	const HostPortPair host_port2 = std::make_pair("0.0.0.0", 8080);
+	const HostPortPair host_port3 = std::make_pair("172.19.0.1", 8080);
+	const HostPortPair host_port4 = std::make_pair("other", 8080);
+
+	/* -------------- VirtualServer3個用意 -------------- */
+	ServerNameList server_name1;
+	server_name1.push_back("localhost1");
+	HostPortList host_ports;
+	host_ports.push_back(host_port1);
+	const server::VirtualServer vs1 = CreateVirtualServer(server_name1, host_ports);
+
+	ServerNameList server_name2;
+	server_name2.push_back("localhost2");
+	server_name2.push_back("serv_name2");
+	HostPortList host_ports2;
+	host_ports2.push_back(host_port2);
+	const server::VirtualServer vs2 = CreateVirtualServer(server_name2, host_ports2);
+
+	ServerNameList server_name3;
+	server_name3.push_back("serv_name3");
+	HostPortList host_ports3;
+	host_ports3.push_back(host_port1);
+	host_ports3.push_back(host_port3);
+	const server::VirtualServer vs3 = CreateVirtualServer(server_name3, host_ports3);
+
+	/* -------------- VirtualServerAddrList用意 -------------- */
+	VirtualServerAddrList expected_vs_addr_list1;
+	expected_vs_addr_list1.push_back(&vs1);
+	expected_vs_addr_list1.push_back(&vs2);
+	expected_vs_addr_list1.push_back(&vs3);
+
+	VirtualServerAddrList expected_vs_addr_list2;
+	expected_vs_addr_list2.push_back(&vs2);
+
+	VirtualServerAddrList expected_vs_addr_list3;
+	expected_vs_addr_list3.push_back(&vs2);
+	expected_vs_addr_list3.push_back(&vs3);
+
+	/* -------------- VirtualServerStorage -------------- */
+	server::VirtualServerStorage vs_storage;
+
+	// virtual_server3個をvirtual_server_storageに追加
+	vs_storage.AddVirtualServer(vs1);
+	vs_storage.AddVirtualServer(vs2);
+	vs_storage.AddVirtualServer(vs3);
+
+	// 初期化
+	vs_storage.InitHostPortPair(host_port1);
+	vs_storage.InitHostPortPair(host_port2);
+	vs_storage.InitHostPortPair(host_port3);
+
+	// - socket通信した結果のserver_fdとvirtual_serverは以下の想定
+	// host:port       | virtual_server*
+	// ---------------------------------
+	// 127.0.0.1:8080  | vs1, vs2, vs3
+	// 0.0.0.0:8080    |      vs2
+	// 172.19.0.1:8080 |   vs2, vs3
+	// other:8080      |      vs2
+
+	// server_fdとvirtual_serverの紐づけをvirtual_server_storageに追加(vs順に呼ぶ)
+	vs_storage.AddMapping(host_port1, &vs1);
+	vs_storage.AddMapping(host_port2, &vs2);
+	vs_storage.AddMapping(host_port1, &vs3);
+	vs_storage.AddMapping(host_port3, &vs3);
+
+	// getterを使用して期待通りvirtual_serverが追加されてるか・紐づけられているかテスト
+	ret_code |= Test(RunGetVirtualServer(vs_storage, host_port1, expected_vs_addr_list1));
+	ret_code |= Test(RunGetVirtualServer(vs_storage, host_port2, expected_vs_addr_list2));
+	ret_code |= Test(RunGetVirtualServer(vs_storage, host_port3, expected_vs_addr_list3));
+	ret_code |= Test(RunGetVirtualServer(vs_storage, host_port4, expected_vs_addr_list2));
+
+	return ret_code;
+}
+
 } // namespace
 
 int main() {
@@ -358,6 +448,7 @@ int main() {
 	ret_code |= RunTestVirtualServerStorage1();
 	ret_code |= RunTestVirtualServerStorage2();
 	ret_code |= RunTestVirtualServerStorage3();
+	ret_code |= RunTestVirtualServerStorage4();
 
 	return ret_code;
 }

--- a/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
+++ b/test/unit/virtual_server_storage/test_virtual_server_storage.cpp
@@ -147,9 +147,9 @@ int RunTestVirtualServerStorage1() {
 	int ret_code = EXIT_SUCCESS;
 
 	/* -------------- HostPortPair3個用意 -------------- */
-	HostPortPair host_port1 = std::make_pair("host1", 8080);
-	HostPortPair host_port2 = std::make_pair("host2", 12345);
-	HostPortPair host_port3 = std::make_pair("host3", 9999);
+	const HostPortPair host_port1 = std::make_pair("host1", 8080);
+	const HostPortPair host_port2 = std::make_pair("host2", 12345);
+	const HostPortPair host_port3 = std::make_pair("host3", 9999);
 
 	/* -------------- VirtualServer2個用意 -------------- */
 	ServerNameList server_name1;


### PR DESCRIPTION
host:port の管理機能が増えたのでテストも増やしました
特に listen ディレクティブに `0.0.0.0` が含まれるケースを追加しています

## todo
- conf を色々用意して webserv 起動してみるテスト欲しい


<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
  - テスト出力の可読性を向上させるために、タイトルをフォーマットして出力する新しい関数 `PrintTitle` を追加しました。
  - 複数の新しいテスト関数 (`RunTestVirtualServerStorage2`, `RunTestVirtualServerStorage3`, `RunTestVirtualServerStorage4`) を追加し、異なる仮想サーバーのシナリオをテストします。

- **改善**
  - 既存のテスト関数のパラメータを変更し、より安全で効率的な処理を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->