### PR TITLE
[add] index autoindex handler

### DIFF
--- a/sandbox/rin/main.cpp
+++ b/sandbox/rin/main.cpp
@@ -1,5 +1,6 @@
 #include <dirent.h>
 #include <iostream>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -13,8 +14,16 @@ int main() {
 	}
 
 	struct dirent *entry;
-	while ((entry = readdir(dir)) != nullptr) {  // ディレクトリの内容を読み込む
-		std::cout << entry->d_name << std::endl; // ファイル名を表示
+	while ((entry = readdir(dir)) != nullptr) { // ディレクトリの内容を読み込む
+		std::string fullPath = std::string(path) + "/" + entry->d_name;
+		struct stat fileStat;
+		if (stat(fullPath.c_str(), &fileStat) == 0) {
+			std::cout << "File: " << entry->d_name << std::endl;
+			std::cout << "Size: " << fileStat.st_size << " bytes" << std::endl;
+			std::cout << "Last modified: " << std::ctime(&fileStat.st_mtime);
+		} else {
+			std::cerr << "Error getting stats for " << entry->d_name << std::endl;
+		}
 	}
 
 	if (access("main.cpp", F_OK) == 0)

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -52,6 +52,7 @@ StatusCode Method::Handler(
 	const bool         &autoindex_on
 ) {
 	StatusCode status_code(OK);
+	response_body_message.clear();
 	if (!IsAllowedMethod(method, allow_methods)) {
 		throw HttpException("Error: Not Implemented", StatusCode(NOT_IMPLEMENTED));
 	}
@@ -83,7 +84,7 @@ StatusCode Method::GetHandler(
 		if (path[path.size() - 1] != '/') {
 			throw HttpException("Error: Moved Permanently", StatusCode(MOVED_PERMANENTLY));
 		} else if (!index_file_path.empty()) {
-			response_body_message = ReadFile(index_file_path);
+			response_body_message = ReadFile(path + index_file_path);
 			response_header_fields[CONTENT_LENGTH] =
 				utils::ToString(response_body_message.length());
 		} else if (autoindex_on) {

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -256,7 +256,7 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 	response_body_message += "</pre><hr></body></html>";
 	closedir(dir);
 
-	return utils::Result<void>();
+	return result;
 }
 
 } // namespace http

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -221,6 +221,7 @@ bool Method::IsAllowedMethod(
 	}
 }
 
+// ./と../はいらないかも？
 utils::Result<void>
 Method::AutoindexHandler(const std::string &path, std::string &response_body_message) {
 	utils::Result<void> result;

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -50,7 +50,7 @@ StatusCode Method::Handler(
 	std::string        &response_body_message,
 	HeaderFields       &response_header_fields,
 	const std::string  &index_file_path,
-	const bool         &autoindex_on
+	bool                autoindex_on
 ) {
 	StatusCode status_code(OK);
 	response_body_message.clear();
@@ -76,7 +76,7 @@ StatusCode Method::GetHandler(
 	std::string       &response_body_message,
 	HeaderFields      &response_header_fields,
 	const std::string &index_file_path,
-	const bool        &autoindex_on
+	bool               autoindex_on
 ) {
 	StatusCode  status_code(OK);
 	const Stat &info = TryStat(path);

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -248,7 +248,7 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 									 std::string(entry->d_name) + "</a> ";
 			response_body_message += utils::ToString(file_stat.st_size) + " bytes ";
 			response_body_message += std::ctime(&file_stat.st_mtime);
-		} else {
+		} else { // tmp
 			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
 									 std::string(entry->d_name) + "</a> ";
 			response_body_message += "Error getting file stats\n";

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -238,13 +238,13 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 							 "<body><h1>Index of /</h1><hr><pre>"
 							 "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
-		std::string fullPath = std::string(path) + "/" + entry->d_name;
-		struct stat fileStat;
-		if (stat(fullPath.c_str(), &fileStat) == 0) {
+		std::string full_path = std::string(path) + "/" + entry->d_name;
+		struct stat file_stat;
+		if (stat(full_path.c_str(), &file_stat) == 0) {
 			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
 									 std::string(entry->d_name) + "</a> ";
-			response_body_message += utils::ToString(fileStat.st_size) + " bytes ";
-			response_body_message += std::ctime(&fileStat.st_mtime);
+			response_body_message += utils::ToString(file_stat.st_size) + " bytes ";
+			response_body_message += std::ctime(&file_stat.st_mtime);
 		} else {
 			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
 									 std::string(entry->d_name) + "</a> ";

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -8,6 +8,7 @@
 #include "system_exception.hpp"
 #include <algorithm> // std::find
 #include <cstring>
+#include <ctime>    // ctime
 #include <dirent.h> // opendir, readdir, closedir
 #include <fstream>
 #include <iostream>

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -243,7 +243,7 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 	while ((entry = readdir(dir)) != NULL) {
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
-		if (stat(full_path.c_str(), &file_stat) == 0) {
+		if (stat(full_path.c_str(), &file_stat) == 0 && errno != 0) {
 			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
 									 std::string(entry->d_name) + "</a> ";
 			response_body_message += utils::ToString(file_stat.st_size) + " bytes ";

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -46,15 +46,17 @@ StatusCode Method::Handler(
 	const std::string  &request_body_message,
 	std::string        &response_body_message,
 	HeaderFields       &response_header_fields,
-	const std::string  &index_file_path
+	const std::string  &index_file_path,
+	const bool         &autoindex_on
 ) {
 	StatusCode status_code(OK);
 	if (!IsAllowedMethod(method, allow_methods)) {
 		throw HttpException("Error: Not Implemented", StatusCode(NOT_IMPLEMENTED));
 	}
 	if (method == GET) {
-		status_code =
-			GetHandler(path, response_body_message, response_header_fields, index_file_path);
+		status_code = GetHandler(
+			path, response_body_message, response_header_fields, index_file_path, autoindex_on
+		);
 	} else if (method == POST) {
 		status_code =
 			PostHandler(path, request_body_message, response_body_message, response_header_fields);
@@ -69,7 +71,8 @@ StatusCode Method::GetHandler(
 	const std::string &path,
 	std::string       &response_body_message,
 	HeaderFields      &response_header_fields,
-	const std::string &index_file_path
+	const std::string &index_file_path,
+	const bool        &autoindex_on
 ) {
 	StatusCode  status_code(OK);
 	const Stat &info = TryStat(path);
@@ -81,6 +84,7 @@ StatusCode Method::GetHandler(
 			response_body_message = ReadFile(index_file_path);
 			response_header_fields[CONTENT_LENGTH] =
 				utils::ToString(response_body_message.length());
+		} else if (autoindex_on) {
 		}
 		// todo: Check for index directive and handle ReadFile function -> ok
 		// todo: Check for autoindex directive and handle AutoindexHandler function
@@ -210,5 +214,7 @@ bool Method::IsAllowedMethod(
 		return std::find(allow_methods.begin(), allow_methods.end(), method) != allow_methods.end();
 	}
 }
+
+utils::Result<void> AutoindexHandler() {}
 
 } // namespace http

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -88,7 +88,8 @@ StatusCode Method::GetHandler(
 			response_header_fields[CONTENT_LENGTH] =
 				utils::ToString(response_body_message.length());
 		} else if (autoindex_on) {
-			utils::Result<void> result = AutoindexHandler(path, response_body_message);
+			utils::Result<std::string> result = AutoindexHandler(path);
+			response_body_message             = result.GetValue();
 			response_header_fields[CONTENT_LENGTH] =
 				utils::ToString(response_body_message.length());
 			if (!result.IsOk()) {
@@ -224,10 +225,10 @@ bool Method::IsAllowedMethod(
 }
 
 // ./と../はいらないかも？
-utils::Result<void>
-Method::AutoindexHandler(const std::string &path, std::string &response_body_message) {
-	utils::Result<void> result;
-	DIR                *dir = opendir(path.c_str());
+utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
+	utils::Result<std::string> result;
+	DIR                       *dir = opendir(path.c_str());
+	std::string                response_body_message;
 
 	if (dir == NULL) { // system exception?
 		result.Set(false);
@@ -257,6 +258,7 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 	response_body_message += "</pre><hr></body></html>";
 	closedir(dir);
 
+	result.SetValue(response_body_message);
 	return result;
 }
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -89,6 +89,8 @@ StatusCode Method::GetHandler(
 				utils::ToString(response_body_message.length());
 		} else if (autoindex_on) {
 			utils::Result<void> result = AutoindexHandler(path, response_body_message);
+			response_header_fields[CONTENT_LENGTH] =
+				utils::ToString(response_body_message.length());
 			if (!result.IsOk()) {
 				throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN)); // system exception?
 			}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -53,7 +53,6 @@ StatusCode Method::Handler(
 	bool                autoindex_on
 ) {
 	StatusCode status_code(OK);
-	response_body_message.clear();
 	if (!IsAllowedMethod(method, allow_methods)) {
 		throw HttpException("Error: Not Implemented", StatusCode(NOT_IMPLEMENTED));
 	}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -254,6 +254,7 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 		}
 	}
 	response_body_message += "</pre><hr></body></html>";
+	closedir(dir);
 
 	return utils::Result<void>();
 }

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -239,7 +239,7 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 							 "<body><h1>Index of /</h1><hr><pre>"
 							 "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
-		std::string full_path = std::string(path) + "/" + entry->d_name;
+		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
 			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -94,9 +94,6 @@ StatusCode Method::GetHandler(
 		} else {
 			throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
 		}
-		// todo: Check for index directive and handle ReadFile function -> ok
-		// todo: Check for autoindex directive and handle AutoindexHandler function -> ok
-		// todo: Return 403 Forbidden if neither index nor autoindex directives exist -> ok
 	} else if (info.IsRegularFile()) {
 		if (!info.IsReadableFile()) {
 			throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
@@ -234,10 +231,10 @@ Method::AutoindexHandler(const std::string &path, std::string &response_body_mes
 	}
 
 	struct dirent *entry;
-	response_body_message += "<html>"
-							 "<head><title>Index of /</title></head>"
+	response_body_message += "<html>\n"
+							 "<head><title>Index of /</title></head>\n"
 							 "<body><h1>Index of /</h1><hr><pre>"
-							 "<a href=\"../\">../</a>";
+							 "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
 		std::string fullPath = std::string(path) + "/" + entry->d_name;
 		struct stat fileStat;

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -24,14 +24,18 @@ class Method {
 					 const AllowMethods &allow_methods,
 					 const std::string  &request_body_message,
 					 std::string        &response_body_message,
-					 HeaderFields       &response_header_fields
+					 HeaderFields       &response_header_fields,
+					 const std::string  &index_file_path
 				 );
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
 
   private:
 	static StatusCode GetHandler(
-		const std::string &path, std::string &body_message, HeaderFields &response_header_fields
+		const std::string &path,
+		std::string       &body_message,
+		HeaderFields      &response_header_fields,
+		const std::string &index_file_path
 	);
 	static StatusCode PostHandler(
 		const std::string &path,

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -59,8 +59,7 @@ class Method {
 		std::string       &response_body_message,
 		HeaderFields      &response_header_fields
 	);
-	static utils::Result<void>
-	AutoindexHandler(const std::string &path, std::string &response_body_message);
+	static utils::Result<std::string> AutoindexHandler(const std::string &path);
 };
 
 } // namespace http

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -3,6 +3,7 @@
 
 #include "stat.hpp"
 #include "status_code.hpp"
+#include "utils.hpp"
 #include <list>
 
 namespace utils {
@@ -58,6 +59,8 @@ class Method {
 		std::string       &response_body_message,
 		HeaderFields      &response_header_fields
 	);
+	static utils::Result<void>
+	AutoindexHandler(const std::string &path, std::string &response_body_message);
 };
 
 } // namespace http

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -27,7 +27,7 @@ class Method {
 					 std::string        &response_body_message,
 					 HeaderFields       &response_header_fields,
 					 const std::string  &index_file_path,
-					 const bool         &autoindex_on
+					 bool                autoindex_on
 				 );
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
@@ -38,7 +38,7 @@ class Method {
 		std::string       &body_message,
 		HeaderFields      &response_header_fields,
 		const std::string &index_file_path,
-		const bool        &autoindex_on
+		bool               autoindex_on
 	);
 	static StatusCode PostHandler(
 		const std::string &path,

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -25,7 +25,8 @@ class Method {
 					 const std::string  &request_body_message,
 					 std::string        &response_body_message,
 					 HeaderFields       &response_header_fields,
-					 const std::string  &index_file_path
+					 const std::string  &index_file_path,
+					 const bool         &autoindex_on
 				 );
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
@@ -35,7 +36,8 @@ class Method {
 		const std::string &path,
 		std::string       &body_message,
 		HeaderFields      &response_header_fields,
-		const std::string &index_file_path
+		const std::string &index_file_path,
+		const bool        &autoindex_on
 	);
 	static StatusCode PostHandler(
 		const std::string &path,

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -69,7 +69,8 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				request_info.request.body_message,
 				response_body_message,
 				response_header_fields,
-				"" // tmp for index
+				"",   // tmp for index
+				false // tmp for autoindex
 			);
 		}
 	} catch (const HttpException &e) {

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -68,7 +68,8 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				server_info_result.allowed_methods,
 				request_info.request.body_message,
 				response_body_message,
-				response_header_fields
+				response_header_fields,
+				"" // tmp for index
 			);
 		}
 	} catch (const HttpException &e) {

--- a/test/unit/http_method/expected/index.txt
+++ b/test/unit/http_method/expected/index.txt
@@ -1,0 +1,1 @@
+This is an index

--- a/test/unit/http_method/test/index.txt
+++ b/test/unit/http_method/test/index.txt
@@ -1,0 +1,1 @@
+This is an index

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -4,8 +4,10 @@
 #include "http_response.hpp"
 #include "utils.hpp"
 #include <cstdlib>
+#include <dirent.h>
 #include <fstream>
 #include <iostream>
+#include <sys/stat.h>
 
 namespace {
 
@@ -17,7 +19,8 @@ struct MethodArgument {
 		const std::string                &request_body_message,
 		std::string                      &response_body_message,
 		http::HeaderFields               &response_header_fields,
-		const std::string                &index_file_path = ""
+		const std::string                &index_file_path = "",
+		const bool                       &autoindex_on    = false
 	)
 		: path(path),
 		  method(method),
@@ -25,7 +28,8 @@ struct MethodArgument {
 		  request_body_message(request_body_message),
 		  response_body_message(response_body_message),
 		  response_header_fields(response_header_fields),
-		  index_file_path(index_file_path) {}
+		  index_file_path(index_file_path),
+		  autoindex_on(autoindex_on) {}
 	const std::string                &path;
 	const std::string                &method;
 	const http::Method::AllowMethods &allow_methods;
@@ -33,6 +37,7 @@ struct MethodArgument {
 	std::string                      &response_body_message;
 	http::HeaderFields               &response_header_fields;
 	const std::string                &index_file_path;
+	const bool                       &autoindex_on;
 };
 
 std::string LoadFileContent(const std::string &file_path) {
@@ -44,6 +49,34 @@ std::string LoadFileContent(const std::string &file_path) {
 	std::ostringstream file_content;
 	file_content << file.rdbuf();
 	return file_content.str();
+}
+
+std::string CreateAutoIndexContent(const std::string &path) {
+	DIR        *dir = opendir(path.c_str());
+	std::string content;
+
+	struct dirent *entry;
+	content += "<html>\n"
+			   "<head><title>Index of /</title></head>\n"
+			   "<body><h1>Index of /</h1><hr><pre>"
+			   "<a href=\"../\">../</a>\n";
+	while ((entry = readdir(dir)) != NULL) {
+		std::string fullPath = std::string(path) + "/" + entry->d_name;
+		struct stat fileStat;
+		if (stat(fullPath.c_str(), &fileStat) == 0) {
+			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
+					   std::string(entry->d_name) + "</a> ";
+			content += utils::ToString(fileStat.st_size) + " bytes ";
+			content += std::ctime(&fileStat.st_mtime);
+		} else {
+			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
+					   std::string(entry->d_name) + "</a> ";
+			content += "Error getting file stats\n";
+		}
+	}
+	content += "</pre><hr></body></html>";
+
+	return content;
 }
 
 int GetTestCaseNum() {
@@ -75,7 +108,8 @@ int MethodHandlerResult(const MethodArgument &srcs, const std::string &expected_
 			srcs.request_body_message,
 			srcs.response_body_message,
 			srcs.response_header_fields,
-			srcs.index_file_path
+			srcs.index_file_path,
+			srcs.autoindex_on
 		);
 		result = HandleResult(srcs.response_body_message, expected_body_message);
 
@@ -106,6 +140,7 @@ int main(void) {
 	// LF:   exist target resourse file
 	std::string expected_file       = LoadFileContent("expected/file.txt");
 	std::string expected_index_file = LoadFileContent("expected/index.txt");
+	std::string expected_autoindex  = CreateAutoIndexContent("test/");
 	// CRLF: use default status code file
 	std::string expected_created    = LoadFileContent("expected/created.txt");
 	std::string expected_no_content = LoadFileContent("expected/no_content.txt");
@@ -163,6 +198,14 @@ int main(void) {
 			"index.txt"
 		),
 		expected_index_file
+	);
+
+	// ディレクトリで'/'があり、autoindexがある場合
+	ret_code |= MethodHandlerResult(
+		MethodArgument(
+			"test/", http::GET, allow_methods, request, response, response_header_fields, "", true
+		),
+		expected_autoindex
 	);
 
 	// POST test

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -62,7 +62,7 @@ std::string CreateAutoIndexContent(const std::string &path) {
 			   "<body><h1>Index of /</h1><hr><pre>"
 			   "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
-		std::string full_path = std::string(path) + "/" + entry->d_name;
+		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
 			content += "<a href=\"" + std::string(entry->d_name) + "\">" +

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -76,6 +76,7 @@ std::string CreateAutoIndexContent(const std::string &path) {
 		}
 	}
 	content += "</pre><hr></body></html>";
+	closedir(dir);
 
 	return content;
 }

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -21,7 +21,7 @@ struct MethodArgument {
 		std::string                      &response_body_message,
 		http::HeaderFields               &response_header_fields,
 		const std::string                &index_file_path = "",
-		const bool                       &autoindex_on    = false
+		bool                              autoindex_on    = false
 	)
 		: path(path),
 		  method(method),
@@ -38,7 +38,7 @@ struct MethodArgument {
 	std::string                      &response_body_message;
 	http::HeaderFields               &response_header_fields;
 	const std::string                &index_file_path;
-	const bool                       &autoindex_on;
+	bool                              autoindex_on;
 };
 
 std::string LoadFileContent(const std::string &file_path) {

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -4,6 +4,7 @@
 #include "http_response.hpp"
 #include "utils.hpp"
 #include <cstdlib>
+#include <ctime>
 #include <dirent.h>
 #include <fstream>
 #include <iostream>

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -30,7 +30,9 @@ struct MethodArgument {
 		  response_body_message(response_body_message),
 		  response_header_fields(response_header_fields),
 		  index_file_path(index_file_path),
-		  autoindex_on(autoindex_on) {}
+		  autoindex_on(autoindex_on) {
+		response_body_message.clear();
+	}
 	const std::string                &path;
 	const std::string                &method;
 	const http::Method::AllowMethods &allow_methods;

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -16,20 +16,23 @@ struct MethodArgument {
 		const http::Method::AllowMethods &allow_methods,
 		const std::string                &request_body_message,
 		std::string                      &response_body_message,
-		http::HeaderFields               &response_header_fields
+		http::HeaderFields               &response_header_fields,
+		const std::string                &index_file_path = ""
 	)
 		: path(path),
 		  method(method),
 		  allow_methods(allow_methods),
 		  request_body_message(request_body_message),
 		  response_body_message(response_body_message),
-		  response_header_fields(response_header_fields) {}
+		  response_header_fields(response_header_fields),
+		  index_file_path(index_file_path) {}
 	const std::string                &path;
 	const std::string                &method;
 	const http::Method::AllowMethods &allow_methods;
 	const std::string                &request_body_message;
 	std::string                      &response_body_message;
 	http::HeaderFields               &response_header_fields;
+	const std::string                &index_file_path;
 };
 
 std::string LoadFileContent(const std::string &file_path) {
@@ -71,7 +74,8 @@ int MethodHandlerResult(const MethodArgument &srcs, const std::string &expected_
 			srcs.allow_methods,
 			srcs.request_body_message,
 			srcs.response_body_message,
-			srcs.response_header_fields
+			srcs.response_header_fields,
+			srcs.index_file_path
 		);
 		result = HandleResult(srcs.response_body_message, expected_body_message);
 
@@ -100,7 +104,8 @@ int main(void) {
 
 	// http_method/expected
 	// LF:   exist target resourse file
-	std::string expected_file = LoadFileContent("expected/file.txt");
+	std::string expected_file       = LoadFileContent("expected/file.txt");
+	std::string expected_index_file = LoadFileContent("expected/index.txt");
 	// CRLF: use default status code file
 	std::string expected_created    = LoadFileContent("expected/created.txt");
 	std::string expected_no_content = LoadFileContent("expected/no_content.txt");
@@ -144,6 +149,20 @@ int main(void) {
 			response_header_fields
 		),
 		expected_forbidden
+	);
+
+	// ディレクトリで'/'があり、indexがある場合
+	ret_code |= MethodHandlerResult(
+		MethodArgument(
+			"test/",
+			http::GET,
+			allow_methods,
+			request,
+			response,
+			response_header_fields,
+			"index.txt"
+		),
+		expected_index_file
 	);
 
 	// POST test

--- a/test/unit/http_method/test_http_method.cpp
+++ b/test/unit/http_method/test_http_method.cpp
@@ -61,13 +61,13 @@ std::string CreateAutoIndexContent(const std::string &path) {
 			   "<body><h1>Index of /</h1><hr><pre>"
 			   "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
-		std::string fullPath = std::string(path) + "/" + entry->d_name;
-		struct stat fileStat;
-		if (stat(fullPath.c_str(), &fileStat) == 0) {
+		std::string full_path = std::string(path) + "/" + entry->d_name;
+		struct stat file_stat;
+		if (stat(full_path.c_str(), &file_stat) == 0) {
 			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
 					   std::string(entry->d_name) + "</a> ";
-			content += utils::ToString(fileStat.st_size) + " bytes ";
-			content += std::ctime(&fileStat.st_mtime);
+			content += utils::ToString(file_stat.st_size) + " bytes ";
+			content += std::ctime(&file_stat.st_mtime);
 		} else {
 			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
 					   std::string(entry->d_name) + "</a> ";


### PR DESCRIPTION
## indexとautoindexに対応する部分を追加しました

- [x] indexがある場合、ディレクトリにアクセスしたらそれを返す
- [x] autoindexがある場合、ディレクトににアクセスしたらディレクトリの中のファイル情報を返す

autoindexなんかはテストでresponseを出力してみるとわかりやすいと思います
ディレクトリの中のファイル名、サイズ、変更日時を表示しています

## TODO

- [ ] autoindexでのエラーハンドリング(SystemExceptionを投げる？)
- [ ] autoindexではファイル一覧で表示される"."と".."はいらないかも？(nginxでは表示なし)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- ディレクトリ内のファイルサイズと最終更新日時を表示する機能を追加しました。
	- ディレクトリリクエストの処理を改善し、インデックスファイルの提供や自動インデックス生成をサポートしました。
	- HTML形式でディレクトリ内容を表示する機能を追加しました。

- **バグ修正**
	- ディレクトリアクセスやファイル統計取得のエラーハンドリングを強化しました。

- **ドキュメント**
	- 基本的なインデックスファイルを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->