### PR TITLE
[server] server.Run() より前に終了して良いようなエラー処理、異常時にも server が die しない処理

### DIFF
--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -77,11 +77,11 @@ void Epoll::Delete(int socket_fd) {
 	}
 }
 
+// epoll_wait() always monitors EPOLLHUP and EPOLLERR, so no need to explicitly set them in events.
 int Epoll::CreateReadyList() {
 	errno = 0;
 	// todo: set timeout(ms)
 	const int ready = epoll_wait(epoll_fd_, evlist_, MAX_EVENTS, 500);
-
 	if (ready == SYSTEM_ERROR) {
 		if (errno == EINTR) {
 			return ready;

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -42,7 +42,12 @@ uint32_t ConvertToEventType(uint32_t type) {
 	if (type & EPOLLOUT) {
 		ret_type |= event::EVENT_WRITE;
 	}
-	// todo: tmp
+	if (type & EPOLLERR) {
+		ret_type |= event::EVENT_ERROR;
+	}
+	if (type & EPOLLHUP) {
+		ret_type |= event::EVENT_HANGUP;
+	}
 	return ret_type;
 }
 

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -66,14 +66,15 @@ void Epoll::Add(int socket_fd, event::Type type) {
 	ev.events             = ConvertToEpollEventType(type);
 	ev.data.fd            = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, socket_fd, &ev) == SYSTEM_ERROR) {
-		throw std::runtime_error("epoll_ctl failed");
+		throw std::runtime_error("epoll_ctl add failed");
 	}
 }
 
 // remove socket_fd from epoll's interest list
 void Epoll::Delete(int socket_fd) {
-	// todo: error?
-	epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, socket_fd, NULL);
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, socket_fd, NULL) == SYSTEM_ERROR) {
+		throw std::runtime_error("epoll_ctl delete failed");
+	}
 }
 
 int Epoll::CreateReadyList() {
@@ -96,7 +97,7 @@ void Epoll::Replace(int socket_fd, const event::Type new_type) {
 	ev.events             = ConvertToEpollEventType(new_type);
 	ev.data.fd            = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
-		throw std::runtime_error("epoll_ctl failed");
+		throw std::runtime_error("epoll_ctl replace failed");
 	}
 }
 
@@ -108,7 +109,7 @@ void Epoll::Append(const event::Event &event, const event::Type new_type) {
 	ev.events             = ConvertToEpollEventType(event.type) | ConvertToEpollEventType(new_type);
 	ev.data.fd            = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
-		throw std::runtime_error("epoll_ctl failed");
+		throw std::runtime_error("epoll_ctl append failed");
 	}
 }
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -37,7 +37,6 @@ void RunServer() {
 	while (true) {
 		try {
 			server::Server server(config::ConfigInstance->servers_);
-			config::ConfigInstance->Destroy();
 			server.Init();
 			server.Run();
 		} catch (const server::StartUpException &e) {
@@ -70,6 +69,7 @@ int main(int argc, char **argv) {
 	try {
 		config::ConfigInstance->Create(path_config);
 		RunServer();
+		config::ConfigInstance->Destroy();
 	} catch (const std::exception &e) {
 		PrintError(e.what());
 		return EXIT_FAILURE;

--- a/srcs/server/context_manager/sock_context/client_info.cpp
+++ b/srcs/server/context_manager/sock_context/client_info.cpp
@@ -2,7 +2,7 @@
 
 namespace server {
 
-ClientInfo::ClientInfo() : fd_(0), listen_port_(0) {}
+ClientInfo::ClientInfo() : fd_(-1), listen_port_(0) {}
 
 ClientInfo::ClientInfo(int fd, const std::string &listen_ip, unsigned int listen_port)
 	: fd_(fd), listen_ip_(listen_ip), listen_port_(listen_port) {}

--- a/srcs/server/context_manager/sock_context/server_info.cpp
+++ b/srcs/server/context_manager/sock_context/server_info.cpp
@@ -3,9 +3,9 @@
 
 namespace server {
 
-ServerInfo::ServerInfo() : fd_(0), host_port_(std::make_pair(IPV4_ADDR_ANY, 0)) {}
+ServerInfo::ServerInfo() : fd_(-1), host_port_(std::make_pair(IPV4_ADDR_ANY, 0)) {}
 
-ServerInfo::ServerInfo(const HostPortPair &host_port) : fd_(0), host_port_(host_port) {}
+ServerInfo::ServerInfo(const HostPortPair &host_port) : fd_(-1), host_port_(host_port) {}
 
 ServerInfo::~ServerInfo() {}
 

--- a/srcs/server/context_manager/sock_context/sock_context.cpp
+++ b/srcs/server/context_manager/sock_context/sock_context.cpp
@@ -1,13 +1,29 @@
 #include "sock_context.hpp"
 #include "client_info.hpp"
 #include "server_info.hpp"
+#include "unistd.h"  // close
 #include <stdexcept> // logic_error
-
 namespace server {
 
 SockContext::SockContext() {}
 
-SockContext::~SockContext() {}
+// todo: tmp
+SockContext::~SockContext() {
+	typedef ServerInfoMap::iterator ItServer;
+	for (ItServer it = server_context_.begin(); it != server_context_.end(); ++it) {
+		const int server_fd = it->second.GetFd();
+		if (server_fd != SYSTEM_ERROR) {
+			close(server_fd);
+		}
+	}
+	typedef ClientInfoMap::iterator ItClient;
+	for (ItClient it = client_context_.begin(); it != client_context_.end(); ++it) {
+		const int client_fd = it->first;
+		if (client_fd != SYSTEM_ERROR) {
+			close(client_fd);
+		}
+	}
+}
 
 SockContext::SockContext(const SockContext &other) {
 	*this = other;

--- a/srcs/server/exception/start_up_exception.cpp
+++ b/srcs/server/exception/start_up_exception.cpp
@@ -1,0 +1,7 @@
+#include "start_up_exception.hpp"
+
+namespace server {
+
+StartUpException::StartUpException(const std::string &message) : std::runtime_error(message) {}
+
+} // namespace server

--- a/srcs/server/exception/start_up_exception.hpp
+++ b/srcs/server/exception/start_up_exception.hpp
@@ -1,0 +1,16 @@
+#ifndef SERVER_EXCEPTION_START_UP_EXCEPTION_HPP_
+#define SERVER_EXCEPTION_START_UP_EXCEPTION_HPP_
+
+#include <stdexcept>
+#include <string>
+
+namespace server {
+
+class StartUpException : public std::runtime_error {
+  public:
+	explicit StartUpException(const std::string &message);
+};
+
+} // namespace server
+
+#endif /* SERVER_EXCEPTION_START_UP_EXCEPTION_HPP_ */

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -167,6 +167,10 @@ void Server::HandleNewConnection(int server_fd) {
 }
 
 void Server::HandleExistingConnection(const event::Event &event) {
+	if (event.type & event::EVENT_ERROR || event.type & event::EVENT_HANGUP) {
+		Disconnect(event.fd);
+		return;
+	}
 	if (event.type & event::EVENT_READ) {
 		ReadRequest(event.fd);
 		RunHttp(event);
@@ -174,7 +178,6 @@ void Server::HandleExistingConnection(const event::Event &event) {
 	if (event.type & event::EVENT_WRITE) {
 		SendResponse(event.fd);
 	}
-	// todo: handle other EventType
 }
 
 http::ClientInfos Server::GetClientInfos(int client_fd) const {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -292,10 +292,11 @@ void Server::KeepConnection(int client_fd) {
 	utils::Debug("server", "Connection: keep-alive client", client_fd);
 }
 
-// todo: 強制Disconnectする場合はHttpにclient_fdを知らせてdata削除する必要あり
-//       internal server error用responseを貰って実際は送らないという手もあり
 // delete from context, event, message
 void Server::Disconnect(int client_fd) {
+	// todo: client_save_dataがない場合に呼ばれても大丈夫な作りになってるか確認
+	// HttpResult is not used.
+	mock_http_.GetErrorResponse(GetClientInfos(client_fd), http::INTERNAL_ERROR);
 	context_.DeleteClientInfo(client_fd);
 	event_monitor_.Delete(client_fd);
 	message_manager_.DeleteMessage(client_fd);

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -4,6 +4,7 @@
 #include "event.hpp"
 #include "read.hpp"
 #include "send.hpp"
+#include "start_up_exception.hpp"
 #include "utils.hpp"
 #include "virtual_server.hpp"
 #include <errno.h>
@@ -117,7 +118,11 @@ void Server::AddVirtualServers(const ConfigServers &config_servers) {
 }
 
 Server::Server(const ConfigServers &config_servers) {
-	AddVirtualServers(config_servers);
+	try {
+		AddVirtualServers(config_servers);
+	} catch (const std::exception &e) {
+		throw StartUpException("Construct Server failed");
+	}
 }
 
 Server::~Server() {}
@@ -388,7 +393,11 @@ void Server::Init() {
 	const VirtualServerList &virtual_server_list = context_.GetAllVirtualServer();
 
 	AddServerInfoToContext(virtual_server_list);
-	ListenAllHostPorts(virtual_server_list);
+	try {
+		ListenAllHostPorts(virtual_server_list);
+	} catch (const std::exception &e) {
+		throw StartUpException("Init Server failed");
+	}
 }
 
 void Server::SetNonBlockingMode(int sock_fd) {


### PR DESCRIPTION
## したこと
- Server の `constructor`, `Init()` までのエラーは webserv が起動せず終了して良いので、専用の例外 `StartUpException` を作成し、try-catch
- 逆に Server の `Run()` 以降、滅多に起こらないが致命的エラーが起きた場合用に、Server 再起動のループを作り、server が終了だけはしないように


`server.Run()` 以降でも、`Internal server error` を返せる場合はなるべく返す、という処理は別 PR ( #443 ) でしてます


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サーバーのライフサイクル管理を行う新しい関数 `RunServer` を追加しました。
  - 特定のエラーを処理するための `StartUpException` クラスを導入しました。

- **バグ修正**
  - エラーメッセージを改善し、サーバーの初期化時のエラー処理を強化しました。
  - クライアントおよびサーバーのコンテキストに関連するファイルディスクリプタを適切にクリーンアップする機能を追加しました。

- **改善**
  - イベントハンドリングの堅牢性を向上させ、エラーおよびハングアップイベントを適切に処理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 