### PR TITLE
[listen] listen() の第 2 引数を適切な数値にする

### DIFF
--- a/srcs/server/connection.cpp
+++ b/srcs/server/connection.cpp
@@ -138,9 +138,8 @@ int Connection::Connect(const HostPortPair &host_port) {
 	}
 	const int server_fd = bind_result.GetValue();
 
-	// todo / listen() : set an appropriate backlog value
 	// listen
-	if (listen(server_fd, 3) == SYSTEM_ERROR) {
+	if (listen(server_fd, LISTEN_BACKLOG) == SYSTEM_ERROR) {
 		close(server_fd);
 		throw std::runtime_error("listen failed");
 	}

--- a/srcs/server/connection.hpp
+++ b/srcs/server/connection.hpp
@@ -18,6 +18,7 @@ class Connection {
 	typedef std::set<int>                        FdSet;
 	typedef std::list<std::string>               IpList;
 	typedef utils::Result<int>                   BindResult;
+	typedef utils::Result<void>                  ListenResult;
 	typedef std::pair<std::string, unsigned int> IpPortPair;
 	typedef std::pair<std::string, unsigned int> HostPortPair;
 
@@ -36,6 +37,7 @@ class Connection {
 	// functions
 	AddrInfo         *GetAddrInfoList(const HostPortPair &host_port) const;
 	BindResult        TryBind(AddrInfo *addrinfo) const;
+	ListenResult      Listen(int server_fd);
 	static IpPortPair GetListenIpPort(int client_fd);
 	// const
 	static const int SYSTEM_ERROR   = -1;

--- a/srcs/server/connection.hpp
+++ b/srcs/server/connection.hpp
@@ -38,7 +38,8 @@ class Connection {
 	BindResult        TryBind(AddrInfo *addrinfo) const;
 	static IpPortPair GetListenIpPort(int client_fd);
 	// const
-	static const int SYSTEM_ERROR = -1;
+	static const int SYSTEM_ERROR   = -1;
+	static const int LISTEN_BACKLOG = 512;
 	// variable
 	FdSet listen_server_fds_;
 };

--- a/test/common/client/Makefile
+++ b/test/common/client/Makefile
@@ -1,6 +1,6 @@
 NAME		:=	client
 
-UTILS_DIR	:=	../../srcs/utils
+UTILS_DIR	:=	../../../srcs/utils
 SRCS		:=	client.cpp \
 				main.cpp \
 				$(UTILS_DIR)/color.cpp


### PR DESCRIPTION
`listen()` 第2引数 `backlog`
カーネルに接続待ちのキューがあって、そこに保持できる数の max を指定するパラメータ

OS 自体にも設定してあり、linux の default は以下の場所で確認・変更できる
```sh
% cat /proc/sys/net/core/somaxconn
4096
```
server としては数百くらいの同時リクエストを想定して、2 の累乗を指定することが一般的らしいので `512` にしてみました
挙動に変更なしです

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - サーバー接続を受け入れるための新しいリスニング機能を追加しました。
  - リスニング操作の結果を管理するための新しいタイプエイリアス `ListenResult` を導入しました。
  - リスニングキューの最大長を定義する定数 `LISTEN_BACKLOG` を追加しました。
- **変更**
  - ビルドシステムのためのユーティリティディレクトリのパスを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->