### PR TITLE
[epoll] epoll_wait() の MAX_EVENTS を設定 

### DIFF
--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -87,7 +87,7 @@ int Epoll::CreateReadyList() {
 	const int ready = epoll_wait(epoll_fd_, evlist_, MAX_EVENTS, 500);
 	if (ready == SYSTEM_ERROR) {
 		if (errno == EINTR) {
-			return ready;
+			return 0;
 		}
 		throw utils::SystemException(errno);
 	}
@@ -116,11 +116,14 @@ void Epoll::Append(const event::Event &event, const event::Type new_type) {
 	}
 }
 
-event::Event Epoll::GetEvent(std::size_t index) const {
-	if (index >= MAX_EVENTS) {
-		throw std::logic_error("evlist index out of range");
+event::EventList Epoll::GetEventList() {
+	const int ready_list_size = CreateReadyList();
+
+	event::EventList events;
+	for (std::size_t i = 0; i < static_cast<std::size_t>(ready_list_size); ++i) {
+		events.push_back(ConvertToEventDto(evlist_[i]));
 	}
-	return ConvertToEventDto(evlist_[index]);
+	return events;
 }
 
 } // namespace epoll

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -52,7 +52,7 @@ uint32_t ConvertToEventType(uint32_t type) {
 	return ret_type;
 }
 
-event::Event ConvertToEventDto(const epoll::Epoll::EpollEvent &event) {
+event::Event ConvertToEvent(const epoll::Epoll::EpollEvent &event) {
 	event::Event ret_event;
 	ret_event.fd   = event.data.fd;
 	ret_event.type = ConvertToEventType(event.events);
@@ -81,7 +81,7 @@ void Epoll::Delete(int socket_fd) {
 }
 
 // epoll_wait() always monitors EPOLLHUP and EPOLLERR, so no need to explicitly set them in events.
-int Epoll::CreateReadyList() {
+int Epoll::CreateEventReadyList() {
 	errno = 0;
 	// todo: set timeout(ms)
 	const int ready = epoll_wait(epoll_fd_, evlist_, MAX_EVENTS, 500);
@@ -117,11 +117,11 @@ void Epoll::Append(const event::Event &event, const event::Type new_type) {
 }
 
 event::EventList Epoll::GetEventList() {
-	const int ready_list_size = CreateReadyList();
+	const int ready_list_size = CreateEventReadyList();
 
 	event::EventList events;
 	for (std::size_t i = 0; i < static_cast<std::size_t>(ready_list_size); ++i) {
-		events.push_back(ConvertToEventDto(evlist_[i]));
+		events.push_back(ConvertToEvent(evlist_[i]));
 	}
 	return events;
 }

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -67,15 +67,15 @@ Epoll::EpollEventVector Epoll::CreateEventReadyList() {
 
 	errno = 0;
 	// todo: set timeout(ms)
-	const int ready = epoll_wait(epoll_fd_, events.data(), monitored_fd_count_, 500);
-	if (ready == SYSTEM_ERROR) {
+	const int ready_list_size = epoll_wait(epoll_fd_, events.data(), monitored_fd_count_, 500);
+	if (ready_list_size == SYSTEM_ERROR) {
 		if (errno == EINTR) {
 			events.clear();
 			return events;
 		}
 		throw utils::SystemException(errno);
 	}
-	events.resize(ready);
+	events.resize(ready_list_size);
 	return events;
 }
 

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -75,6 +75,7 @@ Epoll::EpollEventVector Epoll::CreateEventReadyList() {
 		}
 		throw utils::SystemException(errno);
 	}
+	events.resize(ready);
 	return events;
 }
 

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -7,7 +7,7 @@
 
 namespace epoll {
 
-Epoll::Epoll() {
+Epoll::Epoll() : monitored_fd_count_(0) {
 	epoll_fd_ = epoll_create1(EPOLL_CLOEXEC);
 	if (epoll_fd_ == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
@@ -69,6 +69,7 @@ void Epoll::Add(int socket_fd, event::Type type) {
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
 	}
+	++monitored_fd_count_;
 }
 
 // remove socket_fd from epoll's interest list
@@ -76,6 +77,7 @@ void Epoll::Delete(int socket_fd) {
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, socket_fd, NULL) == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
 	}
+	--monitored_fd_count_;
 }
 
 // epoll_wait() always monitors EPOLLHUP and EPOLLERR, so no need to explicitly set them in events.

--- a/srcs/epoll/epoll.cpp
+++ b/srcs/epoll/epoll.cpp
@@ -52,7 +52,7 @@ uint32_t ConvertToEventType(uint32_t type) {
 	return ret_type;
 }
 
-event::Event ConvertToEventDto(const struct epoll_event &event) {
+event::Event ConvertToEventDto(const epoll::Epoll::EpollEvent &event) {
 	event::Event ret_event;
 	ret_event.fd   = event.data.fd;
 	ret_event.type = ConvertToEventType(event.events);
@@ -63,9 +63,9 @@ event::Event ConvertToEventDto(const struct epoll_event &event) {
 
 // add new socket_fd to epoll's interest list
 void Epoll::Add(int socket_fd, event::Type type) {
-	struct epoll_event ev = {};
-	ev.events             = ConvertToEpollEventType(type);
-	ev.data.fd            = socket_fd;
+	EpollEvent ev = {};
+	ev.events     = ConvertToEpollEventType(type);
+	ev.data.fd    = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
 	}
@@ -96,9 +96,9 @@ int Epoll::CreateReadyList() {
 
 // replace old_type with new_type
 void Epoll::Replace(int socket_fd, const event::Type new_type) {
-	struct epoll_event ev = {};
-	ev.events             = ConvertToEpollEventType(new_type);
-	ev.data.fd            = socket_fd;
+	EpollEvent ev = {};
+	ev.events     = ConvertToEpollEventType(new_type);
+	ev.data.fd    = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
 	}
@@ -108,9 +108,9 @@ void Epoll::Replace(int socket_fd, const event::Type new_type) {
 void Epoll::Append(const event::Event &event, const event::Type new_type) {
 	int socket_fd = event.fd;
 
-	struct epoll_event ev = {};
-	ev.events             = ConvertToEpollEventType(event.type) | ConvertToEpollEventType(new_type);
-	ev.data.fd            = socket_fd;
+	EpollEvent ev = {};
+	ev.events     = ConvertToEpollEventType(event.type) | ConvertToEpollEventType(new_type);
+	ev.data.fd    = socket_fd;
 	if (epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, socket_fd, &ev) == SYSTEM_ERROR) {
 		throw utils::SystemException(errno);
 	}

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -14,11 +14,11 @@ class Epoll {
 	Epoll();
 	~Epoll();
 
+	event::EventList GetEventList();
 	void             Add(int socket_fd, event::Type type);
 	void             Delete(int socket_fd);
 	void             Replace(int socket_fd, event::Type new_type);
 	void             Append(const event::Event &event, event::Type new_type);
-	event::EventList GetEventList();
 
   private:
 	// prohibit copy

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -25,7 +25,7 @@ class Epoll {
 	Epoll(const Epoll &other);
 	Epoll &operator=(const Epoll &other);
 	// function
-	int CreateReadyList();
+	int CreateEventReadyList();
 	// const
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int MAX_EVENTS   = 10; // todo: remove

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -13,24 +13,25 @@ class Epoll {
 
 	Epoll();
 	~Epoll();
-	void Add(int socket_fd, event::Type type);
-	void Delete(int socket_fd);
-	void Replace(int socket_fd, event::Type new_type);
-	void Append(const event::Event &event, event::Type new_type);
-	int  CreateReadyList();
-	// getter
-	event::Event GetEvent(std::size_t index) const;
+
+	void             Add(int socket_fd, event::Type type);
+	void             Delete(int socket_fd);
+	void             Replace(int socket_fd, event::Type new_type);
+	void             Append(const event::Event &event, event::Type new_type);
+	event::EventList GetEventList();
 
   private:
 	// prohibit copy
 	Epoll(const Epoll &other);
 	Epoll &operator=(const Epoll &other);
+	// function
+	int CreateReadyList();
 	// const
 	static const int          SYSTEM_ERROR = -1;
-	static const unsigned int MAX_EVENTS   = 10;
+	static const unsigned int MAX_EVENTS   = 10; // todo: remove
 	// variables
 	int          epoll_fd_;
-	EpollEvent   evlist_[MAX_EVENTS];
+	EpollEvent   evlist_[MAX_EVENTS]; // todo: remove
 	unsigned int monitored_fd_count_;
 };
 

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -29,6 +29,7 @@ class Epoll {
 	// variables
 	int                epoll_fd_;
 	struct epoll_event evlist_[MAX_EVENTS];
+	unsigned int       monitored_fd_count_;
 };
 
 } // namespace epoll

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -9,6 +9,8 @@ namespace epoll {
 
 class Epoll {
   public:
+	typedef struct epoll_event EpollEvent;
+
 	Epoll();
 	~Epoll();
 	void Add(int socket_fd, event::Type type);
@@ -27,9 +29,9 @@ class Epoll {
 	static const int          SYSTEM_ERROR = -1;
 	static const unsigned int MAX_EVENTS   = 10;
 	// variables
-	int                epoll_fd_;
-	struct epoll_event evlist_[MAX_EVENTS];
-	unsigned int       monitored_fd_count_;
+	int          epoll_fd_;
+	EpollEvent   evlist_[MAX_EVENTS];
+	unsigned int monitored_fd_count_;
 };
 
 } // namespace epoll

--- a/srcs/epoll/epoll.hpp
+++ b/srcs/epoll/epoll.hpp
@@ -4,12 +4,14 @@
 #include "event.hpp"
 #include <cstddef>     // size_t
 #include <sys/epoll.h> // epoll
+#include <vector>
 
 namespace epoll {
 
 class Epoll {
   public:
-	typedef struct epoll_event EpollEvent;
+	typedef struct epoll_event      EpollEvent;
+	typedef std::vector<EpollEvent> EpollEventVector;
 
 	Epoll();
 	~Epoll();
@@ -25,13 +27,11 @@ class Epoll {
 	Epoll(const Epoll &other);
 	Epoll &operator=(const Epoll &other);
 	// function
-	int CreateEventReadyList();
+	EpollEventVector CreateEventReadyList();
 	// const
-	static const int          SYSTEM_ERROR = -1;
-	static const unsigned int MAX_EVENTS   = 10; // todo: remove
+	static const int SYSTEM_ERROR = -1;
 	// variables
 	int          epoll_fd_;
-	EpollEvent   evlist_[MAX_EVENTS]; // todo: remove
 	unsigned int monitored_fd_count_;
 };
 

--- a/srcs/event/event.hpp
+++ b/srcs/event/event.hpp
@@ -1,6 +1,7 @@
 #ifndef EVENT_EVENT_HPP_
 #define EVENT_EVENT_HPP_
 
+#include <list>
 #include <stdint.h> // uint32_t
 
 namespace event {
@@ -17,6 +18,9 @@ struct Event {
 	int      fd;
 	uint32_t type;
 };
+
+typedef std::list<Event>          EventList;
+typedef EventList::const_iterator ItEventList;
 
 } // namespace event
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -133,12 +133,10 @@ void Server::Run() {
 	utils::Debug("server", "run server");
 
 	while (true) {
-		const int ready = event_monitor_.CreateReadyList();
-		if (ready == SYSTEM_ERROR) {
-			continue;
-		}
-		for (std::size_t i = 0; i < static_cast<std::size_t>(ready); ++i) {
-			HandleEvent(event_monitor_.GetEvent(i));
+		const event::EventList events = event_monitor_.GetEventList();
+		for (event::ItEventList it = events.begin(); it != events.end(); ++it) {
+			const event::Event &event = *it;
+			HandleEvent(event);
 		}
 		HandleTimeoutMessages();
 	}


### PR DESCRIPTION
`epoll_wiat()` の引数について
- `epoll_wait()` の第 3 引数 `maxevents` を動的に設定
- event の `ready_list` をコンテナ (list) に変換して返す ( Issue #59 )

これにより、`maxevents` が最小限で済み、
Server 側から `ready_list` という概念をなくし、単に event が入った list を受け取る、という状態に改善されたと思います

挙動に変更なしです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - イベント管理の機能を強化するために、`Epoll` クラスに新しいメソッドが追加されました。
  - 複数のイベントを効率的に管理するための新しいタイプエイリアスが導入されました。

- **バグ修正**
  - エラーハンドリングを改善し、イベント管理のプロセスを強化しました。

- **リファクタリング**
  - イベント処理ロジックを簡素化し、より効率的なイベントハンドリングを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->