### PR TITLE
[fix] chunked request handlerの修正

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -53,8 +53,8 @@ bool IsBodyMessageReadingRequired(const HeaderFields &header_fields) {
 utils::Result<int> HexToDec(const std::string &hex_str) {
 	std::istringstream iss(hex_str);
 	int                decimal_value;
-	if (!(iss >> std::hex >> decimal_value)) {
-		return utils::Result<int>(false, 0);
+	if (!(iss >> std::hex >> decimal_value) || decimal_value < 0) {
+		return utils::Result<int>(false, -1);
 	}
 	return utils::Result<int>(decimal_value);
 }

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -141,19 +141,17 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			StatusCode(BAD_REQUEST)
 		);
 	}
-	unsigned int chunk_size = 0;
-	do {
-		std::string::size_type end_of_chunk_size_pos = data.current_buf.find(CRLF);
-		std::string            chunk_size_str = data.current_buf.substr(0, end_of_chunk_size_pos);
-		data.current_buf.erase(0, chunk_size_str.size() + CRLF.size());
-		chunk_size = HexToDec(chunk_size_str).GetValue();
-		if (HexToDec(chunk_size_str).IsOk() == false && chunk_size_str != "\0") {
-			throw HttpException(
-				"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
-			);
-		} else if (chunk_size_str == "\0") {
-			return; // is_body_message = false
-		}
+
+	std::string::size_type end_of_chunk_size_pos = data.current_buf.find(CRLF);
+	std::string            chunk_size_str = data.current_buf.substr(0, end_of_chunk_size_pos);
+	data.current_buf.erase(0, chunk_size_str.size() + CRLF.size());
+	unsigned int chunk_size = HexToDec(chunk_size_str).GetValue();
+	if (HexToDec(chunk_size_str).IsOk() == false) {
+		throw HttpException(
+			"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
+		);
+	}
+	while (chunk_size > 0) {
 		std::string::size_type end_of_chunk_data_pos = data.current_buf.find(CRLF);
 		std::string            chunk_data = data.current_buf.substr(0, end_of_chunk_data_pos);
 		data.current_buf.erase(0, chunk_data.size() + CRLF.size());
@@ -163,7 +161,23 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			);
 		}
 		data.request_result.request.body_message += chunk_data;
-	} while (chunk_size > 0);
+		end_of_chunk_size_pos = data.current_buf.find(CRLF);
+		chunk_size_str        = data.current_buf.substr(0, end_of_chunk_size_pos);
+		data.current_buf.erase(0, chunk_size_str.size() + CRLF.size());
+		chunk_size = HexToDec(chunk_size_str).GetValue();
+		if (HexToDec(chunk_size_str).IsOk() == false) {
+			throw HttpException(
+				"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
+			);
+		}
+	}
+	if (data.current_buf != "\r\n") { // 終端に0\r\n\r\nの\r\nがあるはず
+		throw HttpException(
+			"Error: Missing or incorrect chunked transfer encoding terminator",
+			StatusCode(BAD_REQUEST)
+		);
+	}
+
 	data.is_request_format.is_body_message = true;
 }
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -152,8 +152,7 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 				"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
 			);
 		} else if (chunk_size_str == "\0") {
-			data.is_request_format.is_body_message = false;
-			return;
+			return; // is_body_message = false
 		}
 		std::string::size_type end_of_chunk_data_pos = data.current_buf.find(CRLF);
 		std::string            chunk_data = data.current_buf.substr(0, end_of_chunk_data_pos);

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -171,7 +171,7 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			);
 		}
 	}
-	if (data.current_buf != "\r\n") { // 終端に0\r\n\r\nの\r\nがあるはず
+	if (data.current_buf != CRLF) { // 終端に0\r\n\r\nの\r\nがあるはず
 		throw HttpException(
 			"Error: Missing or incorrect chunked transfer encoding terminator",
 			StatusCode(BAD_REQUEST)

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -403,6 +403,16 @@ int main(void) {
 	test9_body_message.is_request_format.is_body_message   = false;
 	test9_body_message.request_result.request.body_message = "Wikipedia";
 
+	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
+	http::HttpRequestParsedData test10_body_message;
+	test10_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test10_body_message.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test10_body_message.is_request_format.is_request_line   = true;
+	test10_body_message.is_request_format.is_header_fields  = true;
+	test10_body_message.is_request_format.is_body_message   = false;
+	test10_body_message.request_result.request.body_message = "Wikipedia";
+
 	static const TestCase test_case_http_request_body_message_format[] = {
 		TestCase(
 			"GET / HTTP/1.1\r\nHost: a\r\n\r\nContent-Length:  3\r\n\r\nabc", test1_body_message
@@ -445,6 +455,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n-122\r\npedia\r\n",
 			test9_body_message
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
+			test10_body_message
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -393,7 +393,7 @@ int main(void) {
 	test8_body_message.is_request_format.is_body_message   = false;
 	test8_body_message.request_result.request.body_message = "Wikipedia";
 
-	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
+	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
 	http::HttpRequestParsedData test9_body_message;
 	test9_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
 	test9_body_message.request_result.request.request_line =

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -383,7 +383,7 @@ int main(void) {
 	test7_body_message.is_request_format.is_body_message   = false;
 	test7_body_message.request_result.request.body_message = "Wikipedia";
 
-	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合
+	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
 	http::HttpRequestParsedData test8_body_message;
 	test8_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
 	test8_body_message.request_result.request.request_line =
@@ -392,6 +392,16 @@ int main(void) {
 	test8_body_message.is_request_format.is_header_fields  = true;
 	test8_body_message.is_request_format.is_body_message   = false;
 	test8_body_message.request_result.request.body_message = "Wikipedia";
+
+	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
+	http::HttpRequestParsedData test9_body_message;
+	test9_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test9_body_message.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test9_body_message.is_request_format.is_request_line   = true;
+	test9_body_message.is_request_format.is_header_fields  = true;
+	test9_body_message.is_request_format.is_body_message   = false;
+	test9_body_message.request_result.request.body_message = "Wikipedia";
 
 	static const TestCase test_case_http_request_body_message_format[] = {
 		TestCase(
@@ -430,6 +440,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\nss\r\npedia\r\n",
 			test8_body_message
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n-122\r\npedia\r\n",
+			test9_body_message
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -375,7 +375,7 @@ int main(void) {
 
 	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
 	http::HttpRequestParsedData test7_body_message;
-	test7_body_message.request_result.status_code = http::StatusCode(http::OK);
+	test7_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
 	test7_body_message.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
 	test7_body_message.is_request_format.is_request_line   = true;


### PR DESCRIPTION
## chunked request handlerを修正しました

- [x] HexToDec のマイナスを弾きました
- [x] body の終わりが、0\r\n\r\n ではなく 0 や 0\r\n だけでも OK になるエラーを修正しました
- [x] 複数リクエストがまたがってチャンクが送られる場合がエラーとしました
- [x] 関数全体のアルゴリズムを改善しました(do while自分でもこんがらがったのでやめました😅)

**参考**
```
A process for decoding the chunked transfer coding can be represented in pseudo-code as:

  length := 0
  read chunk-size, chunk-ext (if any), and CRLF
  while (chunk-size > 0) {
     read chunk-data and CRLF
     append chunk-data to content
     length := length + chunk-size
     read chunk-size, chunk-ext (if any), and CRLF
  }
  read trailer field
  while (trailer field is not empty) {
     if (trailer fields are stored/forwarded separately) {
         append trailer field to existing trailer fields
     }
     else if (trailer field is understood and defined as mergeable) {
         merge trailer field with existing header fields
     }
     else {
         discard trailer field
     }
     read trailer field
  }
  Content-Length := length
  Remove "chunked" from Transfer-Encoding
```

## Further
- [ ] ヘッダーを書き換える部分の追加


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- チャンク転送エンコーディングの処理を改善し、無効なチャンクサイズや不正な終了シーケンスに対するエラーハンドリングを強化しました。

- **バグ修正**
	- 不正なチャンクサイズや終了シーケンスに対して、適切なエラーレスポンスを返すようにテストケースを更新しました。

- **テスト**
	- 新しいテストケースを追加し、チャンク転送エンコーディングに関連するエッジケースを網羅しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->