### PR TITLE
[update] autoindexの表示をアップデート

### DIFF
--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -254,11 +254,12 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
-			std::string entry_name =
-				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
+			bool        is_dir     = S_ISDIR(file_stat.st_mode);
+			std::string entry_name = std::string(entry->d_name) + (is_dir ? "/" : "");
 			// エントリ名の幅を固定
 			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
-			response_body_message += std::string(50 - entry_name.length(), ' ') + " ";
+			size_t padding = (entry_name.length() < 50) ? 50 - entry_name.length() : 0;
+			response_body_message += std::string(padding, ' ') + " ";
 
 			// ctimeの部分を固定幅にする
 			char time_buf[20];
@@ -268,9 +269,9 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 			response_body_message += std::string(time_buf) + " ";
 
 			// bytesの部分を固定幅にする
-			std::string size_str =
-				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
-			response_body_message += std::string(20 - size_str.length(), ' ') + size_str + "\n";
+			std::string size_str = is_dir ? "-" : utils::ToString(file_stat.st_size) + " bytes";
+			padding              = (size_str.length() < 20) ? 20 - size_str.length() : 0;
+			response_body_message += std::string(padding, ' ') + size_str + "\n";
 		} else {
 			result.Set(false);
 		}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -258,7 +258,8 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 			std::string entry_name =
 				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
 			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
-			response_body_message += utils::ToString(file_stat.st_size) + " bytes ";
+			response_body_message +=
+				entry->d_type == DT_DIR ? " - " : utils::ToString(file_stat.st_size) + " bytes ";
 			response_body_message += std::ctime(&file_stat.st_mtime);
 		} else {
 			// response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -226,7 +226,6 @@ bool Method::IsAllowedMethod(
 	}
 }
 
-// ./と../はいらないかも？
 utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 	utils::Result<std::string> result;
 	DIR                       *dir = opendir(path.c_str());
@@ -273,9 +272,6 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
 			response_body_message += std::string(20 - size_str.length(), ' ') + size_str + "\n";
 		} else {
-			// response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
-			// 						 std::string(entry->d_name) + "</a> ";
-			// response_body_message += "Error getting file stats\n"; // tmp
 			result.Set(false);
 		}
 	}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -249,6 +249,9 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 
 	errno = 0;
 	while ((entry = readdir(dir)) != NULL) {
+		if (entry->d_name[0] == '.') {
+			continue;
+		}
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -263,7 +263,7 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 		result.Set(false);
 	}
 
-	response_body_message += "</pre><hr></body></html>";
+	response_body_message += "</pre><hr></body>\n</html>";
 	closedir(dir);
 
 	result.SetValue(response_body_message);

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -239,8 +239,12 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 
 	struct dirent *entry;
 	response_body_message += "<html>\n"
-							 "<head><title>Index of /</title></head>\n"
-							 "<body><h1>Index of /</h1><hr><pre>"
+							 "<head><title>Index of " +
+							 path +
+							 "</title></head>\n"
+							 "<body><h1>Index of " +
+							 path +
+							 "</h1><hr><pre>"
 							 "<a href=\"../\">../</a>\n";
 
 	errno = 0;

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -257,7 +257,7 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 			bool        is_dir     = S_ISDIR(file_stat.st_mode);
 			std::string entry_name = std::string(entry->d_name) + (is_dir ? "/" : "");
 			// エントリ名の幅を固定
-			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
+			response_body_message += "<a href=\"" + path + entry_name + "\">" + entry_name + "</a>";
 			size_t padding = (entry_name.length() < 50) ? 50 - entry_name.length() : 0;
 			response_body_message += std::string(padding, ' ') + " ";
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -255,8 +255,9 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
-			response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
-									 std::string(entry->d_name) + "</a> ";
+			std::string entry_name =
+				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
+			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
 			response_body_message += utils::ToString(file_stat.st_size) + " bytes ";
 			response_body_message += std::ctime(&file_stat.st_mtime);
 		} else {

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -257,10 +257,21 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 		if (stat(full_path.c_str(), &file_stat) == 0) {
 			std::string entry_name =
 				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
-			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
-			response_body_message +=
-				entry->d_type == DT_DIR ? " - " : utils::ToString(file_stat.st_size) + " bytes ";
-			response_body_message += std::ctime(&file_stat.st_mtime);
+			// エントリ名の幅を固定
+			response_body_message += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
+			response_body_message += std::string(50 - entry_name.length(), ' ') + " ";
+
+			// ctimeの部分を固定幅にする
+			char time_buf[20];
+			std::strftime(
+				time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", std::localtime(&file_stat.st_mtime)
+			);
+			response_body_message += std::string(time_buf) + " ";
+
+			// bytesの部分を固定幅にする
+			std::string size_str =
+				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
+			response_body_message += std::string(20 - size_str.length(), ' ') + size_str + "\n";
 		} else {
 			// response_body_message += "<a href=\"" + std::string(entry->d_name) + "\">" +
 			// 						 std::string(entry->d_name) + "</a> ";

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -74,8 +74,9 @@ std::string CreateAutoIndexContent(const std::string &path) {
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
-			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
-					   std::string(entry->d_name) + "</a> ";
+			std::string entry_name =
+				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
+			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
 			content += utils::ToString(file_stat.st_size) + " bytes ";
 			content += std::ctime(&file_stat.st_mtime);
 		} else {

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -60,8 +60,12 @@ std::string CreateAutoIndexContent(const std::string &path) {
 
 	struct dirent *entry;
 	content += "<html>\n"
-			   "<head><title>Index of /</title></head>\n"
-			   "<body><h1>Index of /</h1><hr><pre>"
+			   "<head><title>Index of " +
+			   path +
+			   "</title></head>\n"
+			   "<body><h1>Index of " +
+			   path +
+			   "</h1><hr><pre>"
 			   "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
 		std::string full_path = path + "/" + entry->d_name;

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -87,9 +87,7 @@ std::string CreateAutoIndexContent(const std::string &path) {
 				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
 			content += std::string(20 - size_str.length(), ' ') + size_str + "\n";
 		} else {
-			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
-					   std::string(entry->d_name) + "</a> ";
-			content += "Error getting file stats\n";
+			return "";
 		}
 	}
 	content += "</pre><hr></body>\n</html>";

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -76,7 +76,7 @@ std::string CreateAutoIndexContent(const std::string &path) {
 		if (stat(full_path.c_str(), &file_stat) == 0) {
 			bool        is_dir     = S_ISDIR(file_stat.st_mode);
 			std::string entry_name = std::string(entry->d_name) + (is_dir ? "/" : "");
-			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
+			content += "<a href=\"" + path + entry_name + "\">" + entry_name + "</a>";
 			size_t padding = (entry_name.length() < 50) ? 50 - entry_name.length() : 0;
 			content += std::string(padding, ' ') + " ";
 			char time_buf[20];

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -77,7 +77,7 @@ std::string CreateAutoIndexContent(const std::string &path) {
 			content += "Error getting file stats\n";
 		}
 	}
-	content += "</pre><hr></body></html>";
+	content += "</pre><hr></body>\n</html>";
 	closedir(dir);
 
 	return content;

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -76,10 +76,16 @@ std::string CreateAutoIndexContent(const std::string &path) {
 		if (stat(full_path.c_str(), &file_stat) == 0) {
 			std::string entry_name =
 				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
-			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
-			content +=
-				entry->d_type == DT_DIR ? " - " : utils::ToString(file_stat.st_size) + " bytes ";
-			content += std::ctime(&file_stat.st_mtime);
+			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
+			content += std::string(50 - entry_name.length(), ' ') + " ";
+			char time_buf[20];
+			std::strftime(
+				time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", std::localtime(&file_stat.st_mtime)
+			);
+			content += std::string(time_buf) + " ";
+			std::string size_str =
+				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
+			content += std::string(20 - size_str.length(), ' ') + size_str + "\n";
 		} else {
 			content += "<a href=\"" + std::string(entry->d_name) + "\">" +
 					   std::string(entry->d_name) + "</a> ";

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -77,7 +77,8 @@ std::string CreateAutoIndexContent(const std::string &path) {
 			std::string entry_name =
 				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
 			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a> ";
-			content += utils::ToString(file_stat.st_size) + " bytes ";
+			content +=
+				entry->d_type == DT_DIR ? " - " : utils::ToString(file_stat.st_size) + " bytes ";
 			content += std::ctime(&file_stat.st_mtime);
 		} else {
 			content += "<a href=\"" + std::string(entry->d_name) + "\">" +

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -74,18 +74,19 @@ std::string CreateAutoIndexContent(const std::string &path) {
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {
-			std::string entry_name =
-				std::string(entry->d_name) + (entry->d_type == DT_DIR ? "/" : "");
+			bool        is_dir     = S_ISDIR(file_stat.st_mode);
+			std::string entry_name = std::string(entry->d_name) + (is_dir ? "/" : "");
 			content += "<a href=\"" + entry_name + "\">" + entry_name + "</a>";
-			content += std::string(50 - entry_name.length(), ' ') + " ";
+			size_t padding = (entry_name.length() < 50) ? 50 - entry_name.length() : 0;
+			content += std::string(padding, ' ') + " ";
 			char time_buf[20];
 			std::strftime(
 				time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", std::localtime(&file_stat.st_mtime)
 			);
 			content += std::string(time_buf) + " ";
-			std::string size_str =
-				entry->d_type == DT_DIR ? "-" : utils::ToString(file_stat.st_size) + " bytes";
-			content += std::string(20 - size_str.length(), ' ') + size_str + "\n";
+			std::string size_str = is_dir ? "-" : utils::ToString(file_stat.st_size) + " bytes";
+			padding              = (size_str.length() < 20) ? 20 - size_str.length() : 0;
+			content += std::string(padding, ' ') + size_str + "\n";
 		} else {
 			return "";
 		}

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -68,6 +68,9 @@ std::string CreateAutoIndexContent(const std::string &path) {
 			   "</h1><hr><pre>"
 			   "<a href=\"../\">../</a>\n";
 	while ((entry = readdir(dir)) != NULL) {
+		if (entry->d_name[0] == '.') {
+			continue;
+		}
 		std::string full_path = path + "/" + entry->d_name;
 		struct stat file_stat;
 		if (stat(full_path.c_str(), &file_stat) == 0) {


### PR DESCRIPTION
## AutoIndexの表示をアップデートしました

- [x] 隠しファイルの表示を無しに
- [x] タイトルに何のディレクトリのautoindexか表示(本当はパス解決する前の情報を表示するが今回はそのまま)
- [x] エントリがディレクトリの場合には/をつけた
- [x] ディレクトリのバイト数は非表示に
- [x] パディングをつけて、出力の列が揃うように

これでかなりnginxの出力に近づいたかと思います。
本当はパス解決する前の情報を表示するが今回はそのまま、というのは例えば/にアクセスした場合、サーバー内部でhtml/に置き換えられるのですが、この場合にIndex of /ではなくIndex of html/と表示されてしまうことです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - ディレクトリリストのHTMLレスポンスが改善され、特定のパスを動的に反映するようになりました。
  - 隠しファイルをスキップし、ディレクトリ名にはスラッシュを追加して表示するようになりました。
  - ファイルサイズと最終更新日時が整然とした形式で表示され、可読性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->