### PR TITLE
[add] cgi_manager 追加

### DIFF
--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -198,6 +198,10 @@ char *const *Cgi::SetCgiEnv(const MetaMap &meta_variables) {
 	return cgi_env;
 }
 
+Cgi::CgiResult Cgi::Run() {
+	return CgiResult();
+}
+
 int Cgi::GetReadFd() const {
 	return read_fd_;
 }

--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -218,4 +218,8 @@ bool Cgi::IsWriteRequired() const {
 	return write_fd_ != -1;
 }
 
+void Cgi::AddReadBuf(const std::string &read_buf) {
+	response_body_message_ += read_buf;
+}
+
 } // namespace cgi

--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -83,7 +83,8 @@ Cgi::Cgi(const CgiRequest &request)
 	  exit_status_(0),
 	  request_body_message_(request.body_message),
 	  read_fd_(-1),
-	  write_fd_(-1) {}
+	  write_fd_(-1),
+	  is_response_complete_(true) {}
 
 Cgi::~Cgi() {
 	Free();
@@ -220,6 +221,10 @@ bool Cgi::IsWriteRequired() const {
 
 void Cgi::AddReadBuf(const std::string &read_buf) {
 	response_body_message_ += read_buf;
+}
+
+bool Cgi::IsResponseComplete() const {
+	return is_response_complete_;
 }
 
 } // namespace cgi

--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -235,4 +235,8 @@ const std::string &Cgi::GetResponse() const {
 	return response_body_message_;
 }
 
+void Cgi::ReplaceNewRequest(const std::string &new_request_str) {
+	request_body_message_ = new_request_str;
+}
+
 } // namespace cgi

--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -227,6 +227,10 @@ bool Cgi::IsResponseComplete() const {
 	return is_response_complete_;
 }
 
+const std::string &Cgi::GetRequest() const {
+	return request_body_message_;
+}
+
 const std::string &Cgi::GetResponse() const {
 	return response_body_message_;
 }

--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -227,4 +227,8 @@ bool Cgi::IsResponseComplete() const {
 	return is_response_complete_;
 }
 
+const std::string &Cgi::GetResponse() const {
+	return response_body_message_;
+}
+
 } // namespace cgi

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -34,6 +34,8 @@ class Cgi {
 	void AddReadBuf(const std::string &read_buf);
 	// responseが完成したかどうかを取得
 	bool IsResponseComplete() const;
+	// requestのgetter
+	const std::string &GetRequest() const;
 	// responseのgetter(返り値がstruct CgiResponseになる？)
 	const std::string &GetResponse() const;
 	// >>> todo

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -38,6 +38,8 @@ class Cgi {
 	const std::string &GetRequest() const;
 	// responseのgetter(返り値がstruct CgiResponseになる？)
 	const std::string &GetResponse() const;
+	// write()が全部できなかった場合に送れなかった分だけ渡されるので差し替える
+	void ReplaceNewRequest(const std::string &new_request_str);
 	// >>> todo
 
   private:

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -32,6 +32,8 @@ class Cgi {
 	bool IsWriteRequired() const;
 	// read()した結果をresponseに追加していく
 	void AddReadBuf(const std::string &read_buf);
+	// responseが完成したかどうかを取得
+	bool IsResponseComplete() const;
 	// >>> todo
 
   private:
@@ -61,6 +63,8 @@ class Cgi {
 	// constructorの初期化も適当に-1にしてある
 	int read_fd_;
 	int write_fd_;
+	// constructorの初期化をtrueにしてるけど本当はfalse。どこかでチェックしてフラグ変更する
+	bool is_response_complete_;
 	// >>> todo
 };
 

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -34,6 +34,8 @@ class Cgi {
 	void AddReadBuf(const std::string &read_buf);
 	// responseが完成したかどうかを取得
 	bool IsResponseComplete() const;
+	// responseのgetter(返り値がstruct CgiResponseになる？)
+	const std::string &GetResponse() const;
 	// >>> todo
 
   private:

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -19,6 +19,15 @@ class Cgi {
 	~Cgi();
 	http::StatusCode Run(std::string &response_body_message);
 
+	// <<< todo (関数名・変数名とか含め変えてしまって全然大丈夫です)
+	// pipe_fdのgetter
+	int GetReadFd() const;
+	int GetWriteFd() const;
+	// read/writeのpipe_fdが存在するかどうか
+	bool IsReadRequired() const;
+	bool IsWriteRequired() const;
+	// >>> todo
+
   private:
 	// prohibit copy constructor and assignment operator
 	Cgi(const Cgi &cgi);
@@ -41,6 +50,12 @@ class Cgi {
 
 	static const int READ  = 0;
 	static const int WRITE = 1;
+
+	// <<< todo
+	// constructorの初期化も適当に-1にしてある
+	int read_fd_;
+	int write_fd_;
+	// >>> todo
 };
 
 } // namespace cgi

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -2,6 +2,7 @@
 #define CGI_HPP_
 
 #include "cgi_request.hpp"
+#include "utils.hpp"
 #include <map>
 #include <string>
 
@@ -20,6 +21,9 @@ class Cgi {
 	http::StatusCode Run(std::string &response_body_message);
 
 	// <<< todo (関数名・変数名とか含め変えてしまって全然大丈夫です)
+	typedef utils::Result<void> CgiResult;
+	// pipe(),fork(),close()してpipe_fdをメンバにセット
+	CgiResult Run();
 	// pipe_fdのgetter
 	int GetReadFd() const;
 	int GetWriteFd() const;

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -30,6 +30,8 @@ class Cgi {
 	// read/writeのpipe_fdが存在するかどうか
 	bool IsReadRequired() const;
 	bool IsWriteRequired() const;
+	// read()した結果をresponseに追加していく
+	void AddReadBuf(const std::string &read_buf);
 	// >>> todo
 
   private:

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -103,6 +103,11 @@ const std::string &CgiManager::GetResponse(int client_fd) const {
 	return cgi->GetResponse();
 }
 
+void CgiManager::ReplaceNewRequest(int client_fd, const std::string &new_request_str) {
+	Cgi *cgi = cgi_addr_map_.at(client_fd);
+	cgi->ReplaceNewRequest(new_request_str);
+}
+
 CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
 	// todo: add logic_error?
 	return cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -18,4 +18,16 @@ void CgiManager::AddNewCgi(int client_fd, const cgi::CgiRequest &request) {
 	cgi_addr_map_[client_fd] = cgi;
 }
 
+void CgiManager::DeleteCgi(int client_fd) {
+	const Cgi *cgi = GetCgi(client_fd);
+
+	delete cgi;
+	cgi_addr_map_.erase(client_fd);
+}
+
+CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
+	// todo: add logic_error?
+	return cgi_addr_map_.at(client_fd);
+}
+
 } // namespace server

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -10,4 +10,12 @@ CgiManager::~CgiManager() {
 	}
 }
 
+// todo: 1complete_request(1CGI)につき2回以上この関数が呼ばれないかhttpの実装を確認
+void CgiManager::AddNewCgi(int client_fd, const cgi::CgiRequest &request) {
+	// todo: new error handling
+	Cgi *cgi = new Cgi(request);
+	// todo: add logic_error?
+	cgi_addr_map_[client_fd] = cgi;
+}
+
 } // namespace server

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -25,6 +25,30 @@ void CgiManager::DeleteCgi(int client_fd) {
 	cgi_addr_map_.erase(client_fd);
 }
 
+CgiManager::GetFdResult CgiManager::GetReadFd(int client_fd) const {
+	GetFdResult result;
+
+	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	if (!cgi->IsReadRequired()) {
+		result.Set(false);
+		return result;
+	}
+	result.SetValue(cgi->GetReadFd());
+	return result;
+}
+
+CgiManager::GetFdResult CgiManager::GetWriteFd(int client_fd) const {
+	GetFdResult result;
+
+	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	if (!cgi->IsWriteRequired()) {
+		result.Set(false);
+		return result;
+	}
+	result.SetValue(cgi->GetWriteFd());
+	return result;
+}
+
 CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
 	// todo: add logic_error?
 	return cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -108,7 +108,12 @@ void CgiManager::ReplaceNewRequest(int client_fd, const std::string &new_request
 	cgi->ReplaceNewRequest(new_request_str);
 }
 
-CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
+CgiManager::Cgi *CgiManager::GetCgi(int client_fd) {
+	// todo: add logic_error?
+	return cgi_addr_map_.at(client_fd);
+}
+
+const CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
 	// todo: add logic_error?
 	return cgi_addr_map_.at(client_fd);
 }

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -87,6 +87,11 @@ CgiManager::GetFdResult CgiManager::GetWriteFd(int client_fd) const {
 	return result;
 }
 
+int CgiManager::GetClientFd(int pipe_fd) const {
+	// todo: add logic_error?
+	return client_fd_map_.at(pipe_fd);
+}
+
 // todo: 返り値がcgi::CgiResponseになりそう
 const std::string &CgiManager::GetResponse(int client_fd) const {
 	const Cgi *cgi = cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -87,6 +87,12 @@ CgiManager::GetFdResult CgiManager::GetWriteFd(int client_fd) const {
 	return result;
 }
 
+// todo: 返り値がcgi::CgiResponseになりそう
+const std::string &CgiManager::GetResponse(int client_fd) const {
+	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	return cgi->GetResponse();
+}
+
 CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
 	// todo: add logic_error?
 	return cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -53,6 +53,11 @@ void CgiManager::DeleteCgi(int client_fd) {
 	cgi_addr_map_.erase(client_fd);
 }
 
+bool CgiManager::IsResponseComplete(int client_fd) const {
+	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	return cgi->IsResponseComplete();
+}
+
 void CgiManager::AddReadBuf(int client_fd, const std::string &read_buf) {
 	Cgi *cgi = cgi_addr_map_.at(client_fd);
 	cgi->AddReadBuf(read_buf);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -92,6 +92,11 @@ int CgiManager::GetClientFd(int pipe_fd) const {
 	return client_fd_map_.at(pipe_fd);
 }
 
+const std::string &CgiManager::GetRequest(int client_fd) const {
+	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	return cgi->GetRequest();
+}
+
 // todo: 返り値がcgi::CgiResponseになりそう
 const std::string &CgiManager::GetResponse(int client_fd) const {
 	const Cgi *cgi = cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -1,0 +1,13 @@
+#include "cgi_manager.hpp"
+
+namespace server {
+
+CgiManager::CgiManager() {}
+
+CgiManager::~CgiManager() {
+	for (ItrCgiAddrMap it = cgi_addr_map_.begin(); it != cgi_addr_map_.end(); ++it) {
+		delete it->second;
+	}
+}
+
+} // namespace server

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -53,6 +53,11 @@ void CgiManager::DeleteCgi(int client_fd) {
 	cgi_addr_map_.erase(client_fd);
 }
 
+void CgiManager::AddReadBuf(int client_fd, const std::string &read_buf) {
+	Cgi *cgi = cgi_addr_map_.at(client_fd);
+	cgi->AddReadBuf(read_buf);
+}
+
 CgiManager::GetFdResult CgiManager::GetReadFd(int client_fd) const {
 	GetFdResult result;
 

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -28,6 +28,7 @@ class CgiManager {
 	GetFdResult        GetReadFd(int client_fd) const;
 	GetFdResult        GetWriteFd(int client_fd) const;
 	int                GetClientFd(int pipe_fd) const;
+	const std::string &GetRequest(int client_fd) const;
 	const std::string &GetResponse(int client_fd) const;
 
   private:

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -20,13 +20,14 @@ class CgiManager {
 	~CgiManager();
 
 	// functions
-	void           AddNewCgi(int client_fd, const cgi::CgiRequest &request);
-	Cgi::CgiResult RunCgi(int client_fd);
-	void           DeleteCgi(int client_fd);
-	bool           IsResponseComplete(int client_fd) const;
-	void           AddReadBuf(int client_fd, const std::string &read_buf);
-	GetFdResult    GetReadFd(int client_fd) const;
-	GetFdResult    GetWriteFd(int client_fd) const;
+	void               AddNewCgi(int client_fd, const cgi::CgiRequest &request);
+	Cgi::CgiResult     RunCgi(int client_fd);
+	void               DeleteCgi(int client_fd);
+	bool               IsResponseComplete(int client_fd) const;
+	void               AddReadBuf(int client_fd, const std::string &read_buf);
+	GetFdResult        GetReadFd(int client_fd) const;
+	GetFdResult        GetWriteFd(int client_fd) const;
+	const std::string &GetResponse(int client_fd) const;
 
   private:
 	// Prohibit copy

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -2,6 +2,7 @@
 #define SERVER_CGI_MANAGER_HPP_
 
 #include "cgi.hpp"
+#include "utils.hpp"
 #include <map>
 
 namespace server {
@@ -13,13 +14,16 @@ class CgiManager {
 	typedef std::map<int, cgi::Cgi *>  CgiAddrMap;
 	typedef CgiAddrMap::const_iterator ItrCgiAddrMap;
 	typedef std::map<int, int>         FdMap;
+	typedef utils::Result<int>         GetFdResult;
 
 	CgiManager();
 	~CgiManager();
 
 	// functions
-	void AddNewCgi(int client_fd, const cgi::CgiRequest &request);
-	void DeleteCgi(int client_fd);
+	void        AddNewCgi(int client_fd, const cgi::CgiRequest &request);
+	void        DeleteCgi(int client_fd);
+	GetFdResult GetReadFd(int client_fd) const;
+	GetFdResult GetWriteFd(int client_fd) const;
 
   private:
 	// Prohibit copy

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -17,6 +17,9 @@ class CgiManager {
 	CgiManager();
 	~CgiManager();
 
+	// functions
+	void AddNewCgi(int client_fd, const cgi::CgiRequest &request);
+
   private:
 	// Prohibit copy
 	CgiManager(const CgiManager &other);

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -30,6 +30,7 @@ class CgiManager {
 	int                GetClientFd(int pipe_fd) const;
 	const std::string &GetRequest(int client_fd) const;
 	const std::string &GetResponse(int client_fd) const;
+	void               ReplaceNewRequest(int client_fd, const std::string &new_request_str);
 
   private:
 	// Prohibit copy

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -19,11 +19,15 @@ class CgiManager {
 
 	// functions
 	void AddNewCgi(int client_fd, const cgi::CgiRequest &request);
+	void DeleteCgi(int client_fd);
 
   private:
 	// Prohibit copy
 	CgiManager(const CgiManager &other);
 	CgiManager &operator=(const CgiManager &other);
+
+	// functions
+	Cgi *GetCgi(int client_fd) const;
 
 	// variables
 	// client_fd毎にCgiをnewして保持

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -38,7 +38,8 @@ class CgiManager {
 	CgiManager &operator=(const CgiManager &other);
 
 	// functions
-	Cgi *GetCgi(int client_fd) const;
+	Cgi       *GetCgi(int client_fd);
+	const Cgi *GetCgi(int client_fd) const;
 
 	// variables
 	// client_fd毎にCgiをnewして保持

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -1,0 +1,34 @@
+#ifndef SERVER_CGI_MANAGER_HPP_
+#define SERVER_CGI_MANAGER_HPP_
+
+#include "cgi.hpp"
+#include <map>
+
+namespace server {
+
+// "client_fd - cgi_instance", "pipe_fd - client_fd" を紐づけて全cgi_instanceを保持・取得
+class CgiManager {
+  public:
+	typedef cgi::Cgi                   Cgi;
+	typedef std::map<int, cgi::Cgi *>  CgiAddrMap;
+	typedef CgiAddrMap::const_iterator ItrCgiAddrMap;
+	typedef std::map<int, int>         FdMap;
+
+	CgiManager();
+	~CgiManager();
+
+  private:
+	// Prohibit copy
+	CgiManager(const CgiManager &other);
+	CgiManager &operator=(const CgiManager &other);
+
+	// variables
+	// client_fd毎にCgiをnewして保持
+	CgiAddrMap cgi_addr_map_;
+	// pipe_fdとclient_fdを紐づけ
+	FdMap client_fd_map_;
+};
+
+} // namespace server
+
+#endif /* SERVER_CGI_MANAGER_HPP_ */

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -27,6 +27,7 @@ class CgiManager {
 	void               AddReadBuf(int client_fd, const std::string &read_buf);
 	GetFdResult        GetReadFd(int client_fd) const;
 	GetFdResult        GetWriteFd(int client_fd) const;
+	int                GetClientFd(int pipe_fd) const;
 	const std::string &GetResponse(int client_fd) const;
 
   private:

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -20,10 +20,11 @@ class CgiManager {
 	~CgiManager();
 
 	// functions
-	void        AddNewCgi(int client_fd, const cgi::CgiRequest &request);
-	void        DeleteCgi(int client_fd);
-	GetFdResult GetReadFd(int client_fd) const;
-	GetFdResult GetWriteFd(int client_fd) const;
+	void           AddNewCgi(int client_fd, const cgi::CgiRequest &request);
+	Cgi::CgiResult RunCgi(int client_fd);
+	void           DeleteCgi(int client_fd);
+	GetFdResult    GetReadFd(int client_fd) const;
+	GetFdResult    GetWriteFd(int client_fd) const;
 
   private:
 	// Prohibit copy

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -23,6 +23,7 @@ class CgiManager {
 	void           AddNewCgi(int client_fd, const cgi::CgiRequest &request);
 	Cgi::CgiResult RunCgi(int client_fd);
 	void           DeleteCgi(int client_fd);
+	bool           IsResponseComplete(int client_fd) const;
 	void           AddReadBuf(int client_fd, const std::string &read_buf);
 	GetFdResult    GetReadFd(int client_fd) const;
 	GetFdResult    GetWriteFd(int client_fd) const;

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -23,6 +23,7 @@ class CgiManager {
 	void           AddNewCgi(int client_fd, const cgi::CgiRequest &request);
 	Cgi::CgiResult RunCgi(int client_fd);
 	void           DeleteCgi(int client_fd);
+	void           AddReadBuf(int client_fd, const std::string &read_buf);
 	GetFdResult    GetReadFd(int client_fd) const;
 	GetFdResult    GetWriteFd(int client_fd) const;
 


### PR DESCRIPTION
順番
1. CgiManager class 追加  (<- この PR )
2. CgiManager の unit test 追加 (PR #474 )
3. Server に CgiManager を組み込む
4. Server と Http 統合
5. cgi 確認用 integration で試す？

---
### したこと
PR #457 から `CgiManager class` だけ整理してもってきました

機能
- `client_fd` 毎に `Cgi class` をインスタンス化して保持・取得 (new してる)
- 削除する時は delete
- `pipe_fd` から `client_fd` を取得できるように紐づけて保持
- `client_fd` を指定して `Cgi class` の関数を呼ぶ
  - `request` / `response` を渡す・取得
  - `pipe_fd` の取得

多くなってしまったので unit test は PR #474 に分けました。実行確認はそっちでお願いします

`Cgi class` は動けば良い程度にしか変更してないので、`todo` で挟んだ部分の実装をお願いします🙏

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - CGIリクエストを管理する新しい`CgiManager`クラスを追加。
  - 新しいメソッドを通じて、CGIインスタンスの追加、実行、削除、リクエストとレスポンスの取得が可能に。

- **改善**
  - CGIインスタンスのライフサイクル管理機能を強化。
  - ファイルディスクリプタの読み書き管理を効率化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->