### PR TITLE
IsSupportedMethod関数作成

### DIFF
--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -14,8 +14,7 @@ const std::string GET                       = "GET";
 const std::string DELETE                    = "DELETE";
 const std::string POST                      = "POST";
 const std::string DEFAULT_METHODS[]         = {GET, DELETE, POST};
-const std::size_t DEFAULT_METHODS_SIZE =
-	sizeof(DEFAULT_METHODS) / sizeof(DEFAULT_METHODS[0]);
+const std::size_t DEFAULT_METHODS_SIZE      = sizeof(DEFAULT_METHODS) / sizeof(DEFAULT_METHODS[0]);
 const std::string DEFAULT_ALLOWED_METHODS[] = {GET};
 const std::size_t DEFAULT_ALLOWED_METHODS_SIZE =
 	sizeof(DEFAULT_ALLOWED_METHODS) / sizeof(DEFAULT_ALLOWED_METHODS[0]);

--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -13,6 +13,9 @@ const std::string SERVER_VERSION      = "webserv/1.1";
 const std::string GET                       = "GET";
 const std::string DELETE                    = "DELETE";
 const std::string POST                      = "POST";
+const std::string DEFAULT_METHODS[]         = {GET, DELETE, POST};
+const std::size_t DEFAULT_METHODS_SIZE =
+	sizeof(DEFAULT_METHODS) / sizeof(DEFAULT_METHODS[0]);
 const std::string DEFAULT_ALLOWED_METHODS[] = {GET};
 const std::size_t DEFAULT_ALLOWED_METHODS_SIZE =
 	sizeof(DEFAULT_ALLOWED_METHODS) / sizeof(DEFAULT_ALLOWED_METHODS[0]);

--- a/srcs/http/http_message.hpp
+++ b/srcs/http/http_message.hpp
@@ -16,6 +16,8 @@ extern const std::string SERVER_VERSION;
 extern const std::string GET;
 extern const std::string DELETE;
 extern const std::string POST;
+extern const std::string DEFAULT_METHODS[];
+extern const std::size_t DEFAULT_METHODS_SIZE;
 extern const std::string DEFAULT_ALLOWED_METHODS[];
 extern const std::size_t DEFAULT_ALLOWED_METHODS_SIZE;
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -216,16 +216,13 @@ Stat Method::TryStat(const std::string &path) {
 }
 
 bool Method::IsSupportedMethod(const std::string &method) {
-	return std::find(
-				DEFAULT_METHODS,
-				DEFAULT_METHODS + DEFAULT_METHODS_SIZE,
-				method
-			) != DEFAULT_METHODS + DEFAULT_METHODS_SIZE;
+	return std::find(DEFAULT_METHODS, DEFAULT_METHODS + DEFAULT_METHODS_SIZE, method) !=
+		   DEFAULT_METHODS + DEFAULT_METHODS_SIZE;
 }
 
 bool Method::IsAllowedMethod(
-		const std::string &method, const std::list<std::string> &allow_methods
-	) {
+	const std::string &method, const std::list<std::string> &allow_methods
+) {
 	if (allow_methods.empty()) {
 		return std::find(
 				   DEFAULT_ALLOWED_METHODS,

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -53,8 +53,11 @@ StatusCode Method::Handler(
 	bool                autoindex_on
 ) {
 	StatusCode status_code(OK);
-	if (!IsAllowedMethod(method, allow_methods)) {
+	if (!IsSupportedMethod(method)) {
 		throw HttpException("Error: Not Implemented", StatusCode(NOT_IMPLEMENTED));
+	}
+	if (!IsAllowedMethod(method, allow_methods)) {
+		throw HttpException("Error: Method Not Allowed", StatusCode(METHOD_NOT_ALLOWED));
 	}
 	if (method == GET) {
 		status_code = GetHandler(
@@ -212,9 +215,17 @@ Stat Method::TryStat(const std::string &path) {
 	return info;
 }
 
+bool Method::IsSupportedMethod(const std::string &method) {
+	return std::find(
+				DEFAULT_METHODS,
+				DEFAULT_METHODS + DEFAULT_METHODS_SIZE,
+				method
+			) != DEFAULT_METHODS + DEFAULT_METHODS_SIZE;
+}
+
 bool Method::IsAllowedMethod(
-	const std::string &method, const std::list<std::string> &allow_methods
-) {
+		const std::string &method, const std::list<std::string> &allow_methods
+	) {
 	if (allow_methods.empty()) {
 		return std::find(
 				   DEFAULT_ALLOWED_METHODS,

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -30,9 +30,8 @@ class Method {
 					 bool                autoindex_on
 				 );
 	static bool IsSupportedMethod(const std::string &method);
-	static bool IsAllowedMethod(
-		const std::string &method, const std::list<std::string> &allow_methods
-	);
+	static bool
+	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
 
   private:
 	static StatusCode GetHandler(

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -29,8 +29,10 @@ class Method {
 					 const std::string  &index_file_path,
 					 bool                autoindex_on
 				 );
-	static bool
-	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
+	static bool IsSupportedMethod(const std::string &method);
+	static bool IsAllowedMethod(
+		const std::string &method, const std::list<std::string> &allow_methods
+	);
 
   private:
 	static StatusCode GetHandler(

--- a/srcs/http/status_code.cpp
+++ b/srcs/http/status_code.cpp
@@ -12,6 +12,7 @@ StatusCode::ReasonPhrase StatusCode::InitReasonPhrase() {
 	init_reason_phrase[BAD_REQUEST]           = "Bad Request";
 	init_reason_phrase[FORBIDDEN]             = "Forbidden";
 	init_reason_phrase[NOT_FOUND]             = "Not Found";
+	init_reason_phrase[METHOD_NOT_ALLOWED]    = "Method Not Allowed";
 	init_reason_phrase[PAYLOAD_TOO_LARGE]     = "Payload Too Large";
 	init_reason_phrase[INTERNAL_SERVER_ERROR] = "Internal Server Error";
 	init_reason_phrase[NOT_IMPLEMENTED]       = "Not Implemented";

--- a/srcs/http/status_code.hpp
+++ b/srcs/http/status_code.hpp
@@ -14,6 +14,7 @@ enum EStatusCode {
 	BAD_REQUEST           = 400,
 	FORBIDDEN             = 403,
 	NOT_FOUND             = 404,
+	METHOD_NOT_ALLOWED    = 405,
 	PAYLOAD_TOO_LARGE     = 413,
 	INTERNAL_SERVER_ERROR = 500,
 	NOT_IMPLEMENTED       = 501

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -54,7 +54,6 @@ int  main(void) {
     // todo: HttpResponse::CreateBadRequestResponse
     // ret_code |= test::TestGetBadRequest1OnlyCrlf(server_infos);
     ret_code |= test::TestGetNotFound1NotExistFile(server_infos);
-    // todo: 405 Method Not Implemented
     ret_code |= test::TestGetMethodNotAllowed(server_infos);
     // todo: HttpResponse::CreateTimeoutResponse
     // ret_code |= test::TestGetTimeout1NoCrlf(server_infos);

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -55,7 +55,7 @@ int  main(void) {
     // ret_code |= test::TestGetBadRequest1OnlyCrlf(server_infos);
     ret_code |= test::TestGetNotFound1NotExistFile(server_infos);
     // todo: 405 Method Not Implemented
-    // ret_code |= test::TestGetMethodNotAllowed(server_infos);
+    ret_code |= test::TestGetMethodNotAllowed(server_infos);
     // todo: HttpResponse::CreateTimeoutResponse
     // ret_code |= test::TestGetTimeout1NoCrlf(server_infos);
     ret_code |= test::TestGetNotImplemented1NotExistMethod(server_infos);

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -177,9 +177,9 @@ int main(void) {
 	std::string response2 = http::HttpResponse::Run(client_info, server_info, request_info);
 
 	std::string expected2_status_line =
-		LoadFileContent("../../expected_response/default_status_line/501_not_implemented.txt");
+		LoadFileContent("../../expected_response/default_status_line/405_method_not_allowed.txt");
 	std::string expected2_body_message =
-		LoadFileContent("../../expected_response/default_body_message/501_not_implemented.txt");
+		LoadFileContent("../../expected_response/default_body_message/405_method_not_allowed.txt");
 	std::string expected2_header_fields = SetDefaultHeaderFields(
 		http::KEEP_ALIVE, utils::ToString(expected2_body_message.length()), "test/html"
 	);


### PR DESCRIPTION
# 変更点
* `IsSupportedMethod`作成 / 501に対応するため
  * GET, DELETE, POST以外の大文字のメソッドは501
* TestGetMethodNotAllowedのテスト通した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 特定のエンドポイント `/get_not_allowed` に対して HTTP DELETE メソッドのみを許可する設定を追加しました。
  - HTTP 接続の持続性を管理する新しいメソッドを追加しました。
  - HTTP ステータスコード 405（メソッドが許可されていない）の新しい応答を追加しました。

- **バグ修正**
  - HTTP ステータスコード 400（不正なリクエスト）および 408（リクエストタイムアウト）に関する新しい応答を追加しました。

- **テスト**
  - さまざまな 4xx および 5xx ステータスコードに対する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->