### PR TITLE
[fix] connection / getaddrinfo() の freeaddrinfo() ミスで leak してるの修正

### DIFF
--- a/srcs/server/connection.cpp
+++ b/srcs/server/connection.cpp
@@ -76,6 +76,7 @@ Connection::IpList Connection::ResolveHostName(const std::string &hostname) {
 		);
 	}
 
+	AddrInfo *head_result = result;
 	// Temporary std::set for checking duplicate IPs.
 	std::set<std::string> ip_set;
 	for (; result != NULL; result = result->ai_next) {
@@ -83,7 +84,7 @@ Connection::IpList Connection::ResolveHostName(const std::string &hostname) {
 		const std::string   ip    = ConvertToIpv4Str(sa_in->sin_addr);
 		ip_set.insert(ip);
 	}
-	freeaddrinfo(result);
+	freeaddrinfo(head_result);
 	return IpList(ip_set.begin(), ip_set.end());
 }
 


### PR DESCRIPTION
いつからか `make val` で `definitely lost` があったようで、調査したら `freeaddrinfo()` に先頭ポインタを渡せていないという初歩的な失敗をしていました…

`make val` で webserv 起動して終了した時に、`definitely lost` がなくなりました
(`still reachable` の方は server 的に 0 にできるものなのかちょっと分かっていません)

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- メモリ管理の改善により、アドレス情報の解決時に発生する可能性のあるメモリアクセス違反を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->