### PR TITLE
[update] uriのルートをrootディレクトリに

### DIFF
--- a/sandbox/sawa/default.conf
+++ b/sandbox/sawa/default.conf
@@ -44,7 +44,7 @@ server {
 
 	# return
 	location / {
-		alias /html;
+		alias /html/;
 		return 301 index.html;
 	}
 }

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -11,8 +11,8 @@ namespace http {
 namespace {
 
 std::string GetCwd() {
-	const char            *filePath = __FILE__;
-	std::string            path(filePath);
+	const char            *file_path = __FILE__;
+	std::string            path(file_path);
 	std::string::size_type pos       = path.find_last_of("/\\");
 	std::string            directory = (pos != std::string::npos) ? path.substr(0, pos) : "";
 	return directory;

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -8,6 +8,17 @@
 #include <iostream>
 
 namespace http {
+namespace {
+
+std::string GetCwd() {
+	const char            *filePath = __FILE__;
+	std::string            path(filePath);
+	std::string::size_type pos       = path.find_last_of("/\\");
+	std::string            directory = (pos != std::string::npos) ? path.substr(0, pos) : "";
+	return directory;
+}
+
+} // namespace
 
 CheckServerInfoResult HttpServerInfoCheck::Check(
 	const server::VirtualServerAddrList &server_infos, const HttpRequestFormat &request
@@ -70,6 +81,8 @@ void HttpServerInfoCheck::CheckLocationList(
 	CheckAllowedMethods(result, match_location);
 	CheckCgiExtension(result, match_location);
 	CheckUploadDirectory(result, match_location);
+	const std::string ROOT_PATH = GetCwd() + "/../../../../root";
+	result.path                 = ROOT_PATH + result.path;
 	return;
 }
 

--- a/test/common/request/get/4xx/405_01_not_allowed.txt
+++ b/test/common/request/get/4xx/405_01_not_allowed.txt
@@ -1,4 +1,4 @@
-GET /get_not_allowed HTTP/1.1
+GET /get_not_allowed/ HTTP/1.1
 Host: localhost
 Connection: close
 

--- a/test/webserv/unit/http/Makefile
+++ b/test/webserv/unit/http/Makefile
@@ -60,8 +60,7 @@ SRCS	+=	test_http.cpp \
 
 # 4. Add unit test directory for INCLUDE
 SRCS_DIR += $(TEST_CASE_DIR) \
-			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)/$(TEST_CASE_FOR_2XX) \
-			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)/$(TEST_CASE_FOR_4XX)
+			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)
 
 #--------------------------------------------
 OBJ_DIR		:=	objs

--- a/test/webserv/unit/http/build_virtual_server_addr_list.cpp
+++ b/test/webserv/unit/http/build_virtual_server_addr_list.cpp
@@ -59,7 +59,7 @@ server::VirtualServer *BuildVirtualServer1() {
 	allowed_methods_root.push_back(http::GET);
 	allowed_methods_root.push_back(http::POST);
 	server::Location loc_root = BuildLocation(
-		"/", "/html", "index.html", false, allowed_methods_root, std::make_pair(0, "")
+		"/", "/html/", "index.html", false, allowed_methods_root, std::make_pair(0, "")
 	);
 	locationlist.push_back(loc_root);
 
@@ -69,7 +69,7 @@ server::VirtualServer *BuildVirtualServer1() {
 	allowed_methods_save.push_back(http::POST);
 	allowed_methods_save.push_back(http::DELETE);
 	server::Location loc_save = BuildLocation(
-		"/upload", "", "", true, allowed_methods_save, std::make_pair(0, ""), "", "/upload"
+		"/upload/", "", "", true, allowed_methods_save, std::make_pair(0, ""), "", "/upload"
 	);
 	locationlist.push_back(loc_save);
 
@@ -78,7 +78,7 @@ server::VirtualServer *BuildVirtualServer1() {
 	allowed_methods_cgi.push_back(http::GET);
 	allowed_methods_cgi.push_back(http::POST);
 	server::Location loc_cgi = BuildLocation(
-		"/cgi-bin", "", "", false, allowed_methods_cgi, std::make_pair(0, ""), ".pl", ""
+		"/cgi-bin/", "", "", false, allowed_methods_cgi, std::make_pair(0, ""), ".pl", ""
 	);
 	locationlist.push_back(loc_cgi);
 
@@ -86,7 +86,7 @@ server::VirtualServer *BuildVirtualServer1() {
 	std::list<std::string> get_not_allowed;
 	get_not_allowed.push_back(http::DELETE);
 	server::Location loc_get_not_allowed = BuildLocation(
-		"/get_not_allowed", "", "", false, get_not_allowed, std::make_pair(0, ""), ".pl", ""
+		"/get_not_allowed/", "", "", false, get_not_allowed, std::make_pair(0, ""), ".pl", ""
 	);
 	locationlist.push_back(loc_get_not_allowed);
 

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -50,7 +50,7 @@ int  main(void) {
 
     server::VirtualServerAddrList server_infos = BuildVirtualServerAddrList();
     // todo: alias ../../../../root/html/ -> /html in build_virtual_server.cpp
-    // ret_code |= test::TestGetOk1ConnectionClose(server_infos);
+    ret_code |= test::TestGetOk1ConnectionClose(server_infos);
     // todo: HttpResponse::CreateBadRequestResponse
     // ret_code |= test::TestGetBadRequest1OnlyCrlf(server_infos);
     ret_code |= test::TestGetNotFound1NotExistFile(server_infos);

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -66,7 +66,7 @@ server::VirtualServer *BuildVirtualServer1() {
 	// LocationList
 	server::VirtualServer::LocationList locationlist;
 	// リソースの取得位置によって(srcs/http/response/http_method.cpp)によって出力結果が決まる
-	std::string                         alias = "../../../../root/html/index.html";
+	std::string                         alias = "/html/";
 	server::Location::AllowedMethodList allowed_methods;
 	allowed_methods.push_back("GET");
 	allowed_methods.push_back("POST");

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -163,6 +163,19 @@ InputIt Next(InputIt it, typename std::iterator_traits<InputIt>::difference_type
 
 // ================================================= //
 
+#define ROOT_DIR "root"
+
+// root 以降を抜き出す
+std::string ExtractHttpServerInfoCheckPath(const std::string &fullPath) {
+	const std::string target = ROOT_DIR;
+	size_t            pos    = fullPath.find(target);
+	if (pos != std::string::npos) {
+		return fullPath.substr(pos + target.length());
+	} else {
+		return "";
+	}
+}
+
 /* 以下のテストではメソッドは特に関係ない */
 int Test1() {
 	// request
@@ -177,7 +190,7 @@ int Test1() {
 	server::Location              location = vs->GetLocationList().front(); // location1
 
 	try {
-		COMPARE(result.path, location.request_uri);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri);
 		COMPARE(result.index, location.index);
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
@@ -240,7 +253,7 @@ int Test3() {
 	server::Location              location = vs->GetLocationList().front(); // location1(alias)
 
 	try {
-		COMPARE(result.path, location.alias + "test.html");
+		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.alias + "test.html");
 		COMPARE(result.index, location.index);
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
@@ -273,7 +286,7 @@ int Test4() {
 		*(Next(vs->GetLocationList().begin(), 1)); // location2(cgi, upload_directory)
 
 	try {
-		COMPARE(result.path, location.request_uri);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri);
 		COMPARE(result.index, location.index);
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -166,11 +166,11 @@ InputIt Next(InputIt it, typename std::iterator_traits<InputIt>::difference_type
 #define ROOT_DIR "root"
 
 // root 以降を抜き出す
-std::string ExtractHttpServerInfoCheckPath(const std::string &fullPath) {
+std::string ExtractHttpServerInfoCheckPath(const std::string &full_path) {
 	const std::string target = ROOT_DIR;
-	size_t            pos    = fullPath.find(target);
+	size_t            pos    = full_path.find(target);
 	if (pos != std::string::npos) {
-		return fullPath.substr(pos + target.length());
+		return full_path.substr(pos + target.length());
 	} else {
 		return "";
 	}


### PR DESCRIPTION
## CheckServerInfoの部分を修正してリクエストuriのルートをrootディレクトリにしました

- [x] リクエストuriの先頭にrootディレクトリのパス追加
- [x] どこから呼ばれてもrootディレクトリにパスが遷移するように`__FILE__`を使用
- [x] aliasを修正 -> aliasはただ置き換えるだけなので、`/`がないといけません(`location /` `alias /html/`の場合、`/`が`/html/`に)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- サーバー設定が更新され、ポート番号が8000に変更され、エラーページやクライアントの最大ボディサイズが設定されました。
	- 新しいアップロードおよびCGI-binのロケーションブロックが追加されました。

- **バグ修正**
	- テストでのパスの一貫性が向上し、すべての指定されたパスが末尾にスラッシュを持つようになりました。
	- HTTP GETリクエストのテストが有効化され、テストの精度が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->