### PR TITLE
logic_error 追加

### DIFF
--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -1,4 +1,5 @@
 #include "cgi_manager.hpp"
+#include <stdexcept> // logic_error
 
 namespace server {
 
@@ -14,7 +15,10 @@ CgiManager::~CgiManager() {
 void CgiManager::AddNewCgi(int client_fd, const cgi::CgiRequest &request) {
 	// todo: new error handling
 	Cgi *cgi = new Cgi(request);
-	// todo: add logic_error?
+
+	if (cgi_addr_map_.count(client_fd) != 0) {
+		throw std::logic_error("AddNewCgi: client_fd already exists");
+	}
 	cgi_addr_map_[client_fd] = cgi;
 }
 
@@ -27,7 +31,6 @@ CgiManager::Cgi::CgiResult CgiManager::RunCgi(int client_fd) {
 		return cgi_result;
 	}
 	// pipe_fdとclient_fdの紐づけをFdMapに追加
-	// todo: add logic_error?
 	if (cgi->IsReadRequired()) {
 		client_fd_map_[cgi->GetReadFd()] = client_fd;
 	}
@@ -54,19 +57,30 @@ void CgiManager::DeleteCgi(int client_fd) {
 }
 
 bool CgiManager::IsResponseComplete(int client_fd) const {
-	const Cgi *cgi = cgi_addr_map_.at(client_fd);
-	return cgi->IsResponseComplete();
+	try {
+		const Cgi *cgi = cgi_addr_map_.at(client_fd);
+		return cgi->IsResponseComplete();
+	} catch (const std::exception &e) {
+		throw std::logic_error("IsResponseComplete: " + std::string(e.what()));
+	}
 }
 
 void CgiManager::AddReadBuf(int client_fd, const std::string &read_buf) {
-	Cgi *cgi = cgi_addr_map_.at(client_fd);
-	cgi->AddReadBuf(read_buf);
+	try {
+		Cgi *cgi = cgi_addr_map_.at(client_fd);
+		cgi->AddReadBuf(read_buf);
+	} catch (const std::exception &e) {
+		throw std::logic_error("AddReadBuf: " + std::string(e.what()));
+	}
 }
 
 CgiManager::GetFdResult CgiManager::GetReadFd(int client_fd) const {
-	GetFdResult result;
+	if (cgi_addr_map_.count(client_fd) == 0) {
+		throw std::logic_error("GetReadFd: client_fd doesn't exists");
+	}
 
-	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	GetFdResult result;
+	const Cgi  *cgi = cgi_addr_map_.at(client_fd);
 	if (!cgi->IsReadRequired()) {
 		result.Set(false);
 		return result;
@@ -76,9 +90,12 @@ CgiManager::GetFdResult CgiManager::GetReadFd(int client_fd) const {
 }
 
 CgiManager::GetFdResult CgiManager::GetWriteFd(int client_fd) const {
-	GetFdResult result;
+	if (cgi_addr_map_.count(client_fd) == 0) {
+		throw std::logic_error("GetWriteFd: client_fd doesn't exists");
+	}
 
-	const Cgi *cgi = cgi_addr_map_.at(client_fd);
+	GetFdResult result;
+	const Cgi  *cgi = cgi_addr_map_.at(client_fd);
 	if (!cgi->IsWriteRequired()) {
 		result.Set(false);
 		return result;
@@ -88,34 +105,55 @@ CgiManager::GetFdResult CgiManager::GetWriteFd(int client_fd) const {
 }
 
 int CgiManager::GetClientFd(int pipe_fd) const {
-	// todo: add logic_error?
-	return client_fd_map_.at(pipe_fd);
+	try {
+		return client_fd_map_.at(pipe_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetClientFd: " + std::string(e.what()));
+	}
 }
 
 const std::string &CgiManager::GetRequest(int client_fd) const {
-	const Cgi *cgi = cgi_addr_map_.at(client_fd);
-	return cgi->GetRequest();
+	try {
+		const Cgi *cgi = cgi_addr_map_.at(client_fd);
+		return cgi->GetRequest();
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetRequest: " + std::string(e.what()));
+	}
 }
 
 // todo: 返り値がcgi::CgiResponseになりそう
 const std::string &CgiManager::GetResponse(int client_fd) const {
-	const Cgi *cgi = cgi_addr_map_.at(client_fd);
-	return cgi->GetResponse();
+	try {
+		const Cgi *cgi = cgi_addr_map_.at(client_fd);
+		return cgi->GetResponse();
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetResponse: " + std::string(e.what()));
+	}
 }
 
 void CgiManager::ReplaceNewRequest(int client_fd, const std::string &new_request_str) {
-	Cgi *cgi = cgi_addr_map_.at(client_fd);
-	cgi->ReplaceNewRequest(new_request_str);
+	try {
+		Cgi *cgi = cgi_addr_map_.at(client_fd);
+		cgi->ReplaceNewRequest(new_request_str);
+	} catch (const std::exception &e) {
+		throw std::logic_error("ReplaceNewRequest: " + std::string(e.what()));
+	}
 }
 
 CgiManager::Cgi *CgiManager::GetCgi(int client_fd) {
-	// todo: add logic_error?
-	return cgi_addr_map_.at(client_fd);
+	try {
+		return cgi_addr_map_.at(client_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetCgi: " + std::string(e.what()));
+	}
 }
 
 const CgiManager::Cgi *CgiManager::GetCgi(int client_fd) const {
-	// todo: add logic_error?
-	return cgi_addr_map_.at(client_fd);
+	try {
+		return cgi_addr_map_.at(client_fd);
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetCgi: " + std::string(e.what()));
+	}
 }
 
 } // namespace server

--- a/srcs/server/context_manager/virtual_server_storage/virtual_server_storage.cpp
+++ b/srcs/server/context_manager/virtual_server_storage/virtual_server_storage.cpp
@@ -67,7 +67,11 @@ void VirtualServerStorage::AddMapping(
 const VirtualServerStorage::VirtualServerAddrList &
 VirtualServerStorage::GetVirtualServerAddrList(const HostPortPair &host_port) const {
 	if (virtual_server_addr_list_map_.count(host_port) == 0) {
-		return virtual_server_addr_list_map_.at(std::make_pair(IPV4_ADDR_ANY, host_port.second));
+		const HostPortPair any_ip_and_port = std::make_pair(IPV4_ADDR_ANY, host_port.second);
+		if (virtual_server_addr_list_map_.count(any_ip_and_port) == 0) {
+			throw std::logic_error("GetVirtualServerAddrList: 0.0.0.0:port doesn't exist");
+		}
+		return virtual_server_addr_list_map_.at(any_ip_and_port);
 	}
 	return virtual_server_addr_list_map_.at(host_port);
 }

--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -24,7 +24,7 @@ void MessageManager::AddNewMessage(int client_fd) {
 	message::Message message(client_fd);
 	InsertResult     result = messages_.insert(std::make_pair(client_fd, message));
 	if (result.second == false) {
-		throw std::logic_error("AddNewMessage(): message is already exist");
+		throw std::logic_error("AddNewMessage: message is already exist");
 	}
 }
 
@@ -51,58 +51,98 @@ MessageManager::TimeoutFds MessageManager::GetNewTimeoutFds(double timeout) {
 // todo: 全てのresponse_strをsend()できた場合かつkeep-aliveの場合に呼ばれる想定
 // For Connection: keep-alive
 void MessageManager::UpdateTime(int client_fd) {
-	message::Message &message = messages_.at(client_fd);
-	message.UpdateTime();
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.UpdateTime();
+	} catch (const std::exception &e) {
+		throw std::logic_error("UpdateTime: " + std::string(e.what()));
+	}
 }
 
 void MessageManager::AddRequestBuf(int client_fd, const std::string &request_buf) {
-	message::Message &message = messages_.at(client_fd);
-	message.AddRequestBuf(request_buf);
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.AddRequestBuf(request_buf);
+	} catch (const std::exception &e) {
+		throw std::logic_error("AddRequestBuf: " + std::string(e.what()));
+	}
 }
 
 void MessageManager::SetNewRequestBuf(int client_fd, const std::string &request_buf) {
-	message::Message &message = messages_.at(client_fd);
-	message.DeleteRequestBuf();
-	message.AddRequestBuf(request_buf);
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.DeleteRequestBuf();
+		message.AddRequestBuf(request_buf);
+	} catch (const std::exception &e) {
+		throw std::logic_error("SetNewRequestBuf: " + std::string(e.what()));
+	}
 }
 
 void MessageManager::AddNormalResponse(
 	int client_fd, message::ConnectionState connection_state, const std::string &response
 ) {
-	message::Message &message = messages_.at(client_fd);
-	message.AddBackResponse(connection_state, response);
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.AddBackResponse(connection_state, response);
+	} catch (const std::exception &e) {
+		throw std::logic_error("AddNormalResponse: " + std::string(e.what()));
+	}
 }
 
 void MessageManager::AddPrimaryResponse(
 	int client_fd, message::ConnectionState connection_state, const std::string &response
 ) {
-	message::Message &message = messages_.at(client_fd);
-	message.AddFrontResponse(connection_state, response);
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.AddFrontResponse(connection_state, response);
+	} catch (const std::exception &e) {
+		throw std::logic_error("AddPrimaryResponse: " + std::string(e.what()));
+	}
 }
 
 message::Response MessageManager::PopHeadResponse(int client_fd) {
-	message::Message &message = messages_.at(client_fd);
-	return message.PopFrontResponse();
+	try {
+		message::Message &message = messages_.at(client_fd);
+		return message.PopFrontResponse();
+	} catch (const std::exception &e) {
+		throw std::logic_error("PopHeadResponse: " + std::string(e.what()));
+	}
 }
 
 bool MessageManager::IsResponseExist(int client_fd) const {
-	const message::Message &message = messages_.at(client_fd);
-	return message.IsResponseExist();
+	try {
+		const message::Message &message = messages_.at(client_fd);
+		return message.IsResponseExist();
+	} catch (const std::exception &e) {
+		throw std::logic_error("IsResponseExist: " + std::string(e.what()));
+	}
 }
 
 bool MessageManager::IsCompleteRequest(int client_fd) const {
-	const message::Message &message = messages_.at(client_fd);
-	return message.GetIsCompleteRequest();
+	try {
+		const message::Message &message = messages_.at(client_fd);
+		return message.GetIsCompleteRequest();
+	} catch (const std::exception &e) {
+		throw std::logic_error("IsCompleteRequest: " + std::string(e.what()));
+	}
 }
 
 const std::string &MessageManager::GetRequestBuf(int client_fd) const {
-	const message::Message &message = messages_.at(client_fd);
-	return message.GetRequestBuf();
+	try {
+		const message::Message &message = messages_.at(client_fd);
+		return message.GetRequestBuf();
+	} catch (const std::exception &e) {
+		throw std::logic_error("GetRequestBuf: " + std::string(e.what()));
+	}
 }
 
 void MessageManager::SetIsCompleteRequest(int client_fd, bool is_complete_request) {
-	message::Message &message = messages_.at(client_fd);
-	message.SetIsCompleteRequest(is_complete_request);
+	try {
+		message::Message &message = messages_.at(client_fd);
+		message.SetIsCompleteRequest(is_complete_request);
+	} catch (const std::exception &e) {
+		throw std::logic_error("SetIsCompleteRequest: " + std::string(e.what()));
+	}
 }
 
 } // namespace server

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -214,6 +214,7 @@ void Server::ReadRequest(int client_fd) {
 		return;
 	}
 	message_manager_.AddRequestBuf(client_fd, read_result.GetValue().read_buf);
+	std::cerr << message_manager_.GetRequestBuf(client_fd) << std::endl;
 }
 
 void Server::RunHttp(const event::Event &event) {
@@ -235,7 +236,6 @@ void Server::RunHttp(const event::Event &event) {
 	}
 	message_manager_.SetIsCompleteRequest(client_fd, true);
 	utils::Debug("server", "received all request from client", client_fd);
-	std::cerr << message_manager_.GetRequestBuf(client_fd) << std::endl;
 
 	const message::ConnectionState connection_state =
 		http_result.is_connection_keep ? message::KEEP : message::CLOSE;

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -97,7 +97,7 @@ int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_i
 }
 
 int TestGetBadRequest6LowerHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -133,7 +133,7 @@ int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_
 }
 
 int TestGetBadRequest8WrongHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -162,8 +162,7 @@ int TestGetBadRequest9NoHost(const server::VirtualServerAddrList &server_infos) 
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
@@ -179,13 +178,12 @@ int TestGetBadRequest10DuplicateHost(const server::VirtualServerAddrList &server
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -196,13 +194,12 @@ int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &s
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -218,7 +215,7 @@ int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &ser
 }
 
 int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -234,7 +231,7 @@ int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &se
 }
 
 int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -250,7 +247,7 @@ int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList 
 }
 
 int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -265,11 +262,13 @@ int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
-int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
-	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
-	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
-	HeaderFields      expected_header_fields;
+int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos
+) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
 	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
@@ -282,7 +281,7 @@ int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddr
 }
 
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -60,8 +60,8 @@ int  main(void) {
     ret_code |= test::TestGetBadRequest6LowerHttpVersion(server_infos);
     ret_code |= test::TestGetBadRequest7WrongHttpName(server_infos);
     ret_code |= test::TestGetBadRequest8WrongHttpVersion(server_infos);
-	// todo: Fix: std::out_of_range: map::at:  key not found
-	// ret_code |= test::TestGetBadRequest9NoHost(server_infos);
+    // todo: Fix: std::out_of_range: map::at:  key not found
+    // ret_code |= test::TestGetBadRequest9NoHost(server_infos);
     ret_code |= test::TestGetBadRequest10DuplicateHost(server_infos);
     ret_code |= test::TestGetBadRequest11NoHeaderFieldColon(server_infos);
     ret_code |= test::TestGetBadRequest12NoConnectionName(server_infos);


### PR DESCRIPTION
主に debug のため、`map.at()` の `logic_error` を追加しました

これにより、現在 Http 統合後 branch で connection: keep-alive を送ると `Error: map::at` になる原因が `message_manager_.GetRequestBuf()` だと分かったので、別 Issue (#496 ) で修正します

最初 `__func__` 使ったのですが、 C++11 からというのしか見当たらず、各関数名を書くようにしました… C で使えてたので使えそうな気もするのですが…

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- エラーハンドリング機能を追加し、各メソッドでの例外処理を強化しました。
	- クライアントのリクエストバッファを標準エラー出力にログ出力する機能を追加しました。

- **バグ修正**
	- 不正なクライアントファイルディスクリプタに対するチェックを追加し、例外をスローするようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->