### PR TITLE
[fix] content-type: test/html -> text/html に修正

### DIFF
--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -9,6 +9,7 @@ const std::string CRLF                = "\r\n";
 const std::string HEADER_FIELDS_END   = CRLF + CRLF;
 const std::string HTTP_VERSION        = "HTTP/1.1";
 const std::string SERVER_VERSION      = "webserv/1.1";
+const std::string TEXT_HTML           = "text/html";
 
 const std::string GET                       = "GET";
 const std::string DELETE                    = "DELETE";

--- a/srcs/http/http_message.hpp
+++ b/srcs/http/http_message.hpp
@@ -12,6 +12,7 @@ extern const std::string CRLF;
 extern const std::string HEADER_FIELDS_END;
 extern const std::string HTTP_VERSION;
 extern const std::string SERVER_VERSION;
+extern const std::string TEXT_HTML;
 
 extern const std::string GET;
 extern const std::string DELETE;

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -126,7 +126,7 @@ HeaderFields HttpResponse::InitResponseHeaderFields(const HttpRequestResult &req
 	// todo: request_infoから情報取得
 	// GetContentType(request_info);
 	// GetConnection(request_info);
-	response_header_fields[CONTENT_TYPE] = "test/html";
+	response_header_fields[CONTENT_TYPE] = TEXT_HTML;
 	if (IsConnectionKeep(request_info.request.header_fields)) {
 		response_header_fields[CONNECTION] = KEEP_ALIVE;
 	} else {
@@ -174,7 +174,7 @@ std::string HttpResponse::CreateBadRequestResponse(const HttpRequestResult &requ
 		request_info.status_code.GetReasonPhrase()
 	);
 	response.header_fields[SERVER]       = SERVER_VERSION;
-	response.header_fields[CONTENT_TYPE] = "test/html";
+	response.header_fields[CONTENT_TYPE] = TEXT_HTML;
 	response.header_fields[CONNECTION]   = CLOSE;
 	response.body_message                = CreateDefaultBodyMessageFormat(request_info.status_code);
 	response.header_fields[CONTENT_LENGTH] = utils::ToString(response.body_message.length());

--- a/test/webserv/unit/http/test_case/get/test_2xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_2xx.cpp
@@ -15,7 +15,7 @@ int TestGetOk1ConnectionClose(const server::VirtualServerAddrList &server_infos)
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -15,7 +15,7 @@ int TestGetBadRequest1OnlyCrlf(const server::VirtualServerAddrList &server_infos
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -31,7 +31,7 @@ int TestGetBadRequest2LowerMethod(const server::VirtualServerAddrList &server_in
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -49,7 +49,7 @@ int TestGetBadRequest3NoAsciiMethod(const server::VirtualServerAddrList &server_
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -67,7 +67,7 @@ int TestGetBadRequest4NoRoot(const server::VirtualServerAddrList &server_infos) 
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -85,7 +85,7 @@ int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_i
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -97,13 +97,13 @@ int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_i
 }
 
 int TestGetBadRequest6LowerHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -121,7 +121,7 @@ int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -133,13 +133,13 @@ int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_
 }
 
 int TestGetBadRequest8WrongHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -157,13 +157,12 @@ int TestGetBadRequest9NoHost(const server::VirtualServerAddrList &server_infos) 
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
@@ -174,41 +173,39 @@ int TestGetBadRequest10DuplicateHost(const server::VirtualServerAddrList &server
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -218,13 +215,13 @@ int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &ser
 }
 
 int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -234,13 +231,13 @@ int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &se
 }
 
 int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -250,13 +247,13 @@ int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList 
 }
 
 int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -265,14 +262,16 @@ int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
-int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
-	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
-	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
-	HeaderFields      expected_header_fields;
+int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos
+) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -282,13 +281,13 @@ int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddr
 }
 
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -305,7 +304,7 @@ int TestGetNotFound1NotExistFile(const server::VirtualServerAddrList &server_inf
 	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -321,7 +320,7 @@ int TestGetMethodNotAllowed(const server::VirtualServerAddrList &server_infos) {
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
@@ -337,7 +336,7 @@ int TestGetTimeout1NoCrlf(const server::VirtualServerAddrList &server_infos) {
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message

--- a/test/webserv/unit/http/test_case/get/test_5xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_5xx.cpp
@@ -15,7 +15,7 @@ int TestGetNotImplemented1NotExistMethod(const server::VirtualServerAddrList &se
 	HeaderFields      expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
-	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
 	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -165,7 +165,7 @@ int main(void) {
 		LoadFileContent("../../expected_response/default_status_line/200_ok.txt");
 	std::string expected1_body_message  = LoadFileContent("../../../../root/html/index.html");
 	std::string expected1_header_fields = SetDefaultHeaderFields(
-		http::KEEP_ALIVE, utils::ToString(expected1_body_message.length()), "test/html"
+		http::KEEP_ALIVE, utils::ToString(expected1_body_message.length()), http::TEXT_HTML
 	);
 	const std::string &expected1_response =
 		expected1_status_line + expected1_header_fields + http::CRLF + expected1_body_message;
@@ -181,7 +181,7 @@ int main(void) {
 	std::string expected2_body_message =
 		LoadFileContent("../../expected_response/default_body_message/405_method_not_allowed.txt");
 	std::string expected2_header_fields = SetDefaultHeaderFields(
-		http::KEEP_ALIVE, utils::ToString(expected2_body_message.length()), "test/html"
+		http::KEEP_ALIVE, utils::ToString(expected2_body_message.length()), http::TEXT_HTML
 	);
 	const std::string &expected2_response =
 		expected2_status_line + expected2_header_fields + http::CRLF + expected2_body_message;


### PR DESCRIPTION
GET のリクエストなどで default の index.html を返すとき、ブラウザで localhost:8080 にアクセスするとなぜかダウンロードを始めてしまう、ということが起きていたのですが、
http response の header fields の `Content-type` を、`text/html` とすべきところを `test/html` になっていたため、ブラウザが正しい MIME タイプと認識できずに index.html をダウンロードしようとしていたようです

http_message の定義に `text/html` を追加してそれを `srcs/`, `test/` で使うように修正しました