### PR TITLE
[fix] Server / `message_manager_.GetRequestBuf()` で起きてる Error: map::at 修正

### DIFF
--- a/srcs/server/message_manager/message_manager.cpp
+++ b/srcs/server/message_manager/message_manager.cpp
@@ -33,6 +33,10 @@ void MessageManager::DeleteMessage(int client_fd) {
 	messages_.erase(client_fd);
 }
 
+bool MessageManager::IsMessageExist(int client_fd) const {
+	return messages_.count(client_fd) != 0;
+}
+
 MessageManager::TimeoutFds MessageManager::GetNewTimeoutFds(double timeout) {
 	TimeoutFds timeout_fds_;
 

--- a/srcs/server/message_manager/message_manager.hpp
+++ b/srcs/server/message_manager/message_manager.hpp
@@ -21,6 +21,7 @@ class MessageManager {
 	// functions
 	void       AddNewMessage(int client_fd);
 	void       DeleteMessage(int client_fd);
+	bool       IsMessageExist(int client_fd) const;
 	TimeoutFds GetNewTimeoutFds(double timeout);
 	void       UpdateTime(int client_fd);
 	// request_buf

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -186,7 +186,10 @@ void Server::HandleExistingConnection(const event::Event &event) {
 		}
 	}
 	if (event.type & event::EVENT_WRITE) {
-		// todo: RunHttp内でDisconnect()されていた場合の処理追加
+		// Prevent SendResponse() if Disconnect() was called during EVENT_READ handling.
+		if (!message_manager_.IsMessageExist(event.fd)) {
+			return;
+		}
 		SendResponse(event.fd);
 	}
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -2,7 +2,6 @@
 #include "client_info.hpp"
 #include "define.hpp"
 #include "event.hpp"
-#include "read.hpp"
 #include "send.hpp"
 #include "start_up_exception.hpp"
 #include "system_exception.hpp"
@@ -181,8 +180,10 @@ void Server::HandleExistingConnection(const event::Event &event) {
 		return;
 	}
 	if (event.type & event::EVENT_READ) {
-		ReadRequest(event.fd);
-		RunHttp(event);
+		const Read::ReadResult read_result = ReadRequest(event.fd);
+		if (read_result.IsOk()) {
+			RunHttp(event);
+		}
 	}
 	if (event.type & event::EVENT_WRITE) {
 		// todo: RunHttp内でDisconnect()されていた場合の処理追加
@@ -201,19 +202,19 @@ VirtualServerAddrList Server::GetVirtualServerList(int client_fd) const {
 	return context_.GetVirtualServerAddrList(client_fd);
 }
 
-void Server::ReadRequest(int client_fd) {
-	const Read::ReadResult read_result = Read::ReadRequest(client_fd);
+Read::ReadResult Server::ReadRequest(int client_fd) {
+	Read::ReadResult read_result = Read::ReadRequest(client_fd);
 	if (!read_result.IsOk()) {
 		SetInternalServerError(client_fd);
-		return;
+		return read_result;
 	}
 	if (read_result.GetValue().read_size == 0) {
-		// todo: not close?
 		// clientが正しくshutdownした場合・長さ0のデータグラムを受信した場合などにここに入るらしい
-		Disconnect(client_fd);
-		return;
+		read_result.Set(false);
+		return read_result;
 	}
 	message_manager_.AddRequestBuf(client_fd, read_result.GetValue().read_buf);
+	return read_result;
 }
 
 void Server::RunHttp(const event::Event &event) {

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -9,6 +9,7 @@
 #include "http_result.hpp"
 #include "message_manager.hpp"
 #include "mock_http.hpp"
+#include "read.hpp"
 #include <list>
 #include <string>
 
@@ -34,24 +35,24 @@ class Server {
 	Server(const Server &other);
 	Server &operator=(const Server &other);
 	// functions
-	void      AddVirtualServers(const ConfigServers &config_servers);
-	void      AddServerInfoToContext(const VirtualServerList &virtual_server_list);
-	void      ListenAllHostPorts(const VirtualServerList &virtual_server_list);
-	PortIpMap CreatePortIpMap(const VirtualServerList &virtual_server_list);
-	void      Listen(const HostPortPair &host_port);
-	void      HandleEvent(const event::Event &event);
-	void      HandleNewConnection(int server_fd);
-	void      HandleExistingConnection(const event::Event &event);
-	void      ReadRequest(int client_fd);
-	void      RunHttp(const event::Event &event);
-	void      SendResponse(int client_fd);
-	void      HandleTimeoutMessages();
-	void      SetInternalServerError(int client_fd);
-	void      KeepConnection(int client_fd);
-	void      Disconnect(int client_fd);
-	void      UpdateEventInResponseComplete(
-			 const message::ConnectionState connection_state, const event::Event &event
-		 );
+	void             AddVirtualServers(const ConfigServers &config_servers);
+	void             AddServerInfoToContext(const VirtualServerList &virtual_server_list);
+	void             ListenAllHostPorts(const VirtualServerList &virtual_server_list);
+	PortIpMap        CreatePortIpMap(const VirtualServerList &virtual_server_list);
+	void             Listen(const HostPortPair &host_port);
+	void             HandleEvent(const event::Event &event);
+	void             HandleNewConnection(int server_fd);
+	void             HandleExistingConnection(const event::Event &event);
+	Read::ReadResult ReadRequest(int client_fd);
+	void             RunHttp(const event::Event &event);
+	void             SendResponse(int client_fd);
+	void             HandleTimeoutMessages();
+	void             SetInternalServerError(int client_fd);
+	void             KeepConnection(int client_fd);
+	void             Disconnect(int client_fd);
+	void             UpdateEventInResponseComplete(
+					const message::ConnectionState connection_state, const event::Event &event
+				);
 	void UpdateConnectionAfterSendResponse(
 		int client_fd, const message::ConnectionState connection_state
 	);


### PR DESCRIPTION
### 原因
`read_size == 0` の時 `Disconnect()` していて、その直後に `http_.Run()` を呼ぶために `GetClientInfos()` しており、既に通信を切った `client_fd` の `request_buf` を取得しようとして (問題の `message_manager_.GetRequestBuf()`)、存在しないので `map.at` のエラーになっていました

### 修正
- `ReadResult` をもう 1 つ上まで伝達し、エラー or `read_size == 0` の場合には `http.Run()` を呼ばないようにしました
- ついでに todo だった、`Send()` する前にも `Disconnect()` してないか確認してから `Send()` するようにしました

### 実行
これが Error: map::at  にならなくなりました
siege でも Error: map::at 出なくなったと思います
```sh
make run
curl -v -H "Connection: keep-alive" localhost:8080
```
