### PR TITLE
HttpParseクラスバグ修正

### DIFF
--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -38,7 +38,7 @@ utils::Result<void> Http::ParseHttpRequestFormat(int client_fd, const std::strin
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);
 	save_data.current_buf += read_buf;
 	try {
-		HttpParse::TmpRunHttpResultVersion(save_data);
+		HttpParse::Run(save_data);
 	} catch (const HttpException &e) {
 		save_data.request_result.status_code = e.GetStatusCode();
 		result.Set(false);

--- a/srcs/http/http_exception.cpp
+++ b/srcs/http/http_exception.cpp
@@ -1,9 +1,13 @@
 #include "http_exception.hpp"
+#include <iostream>
+#include "utils.hpp"
 
 namespace http {
 
 HttpException::HttpException(const std::string &error_message, const StatusCode &status_code)
-	: runtime_error(error_message), status_code_(status_code) {}
+	: runtime_error(error_message), status_code_(status_code) {
+		std::cerr << utils::color::GRAY << "[HttpException] " << error_message << utils::color::RESET << std::endl;
+}
 
 HttpException::~HttpException() throw() {}
 

--- a/srcs/http/http_exception.cpp
+++ b/srcs/http/http_exception.cpp
@@ -1,12 +1,13 @@
 #include "http_exception.hpp"
-#include <iostream>
 #include "utils.hpp"
+#include <iostream>
 
 namespace http {
 
 HttpException::HttpException(const std::string &error_message, const StatusCode &status_code)
 	: runtime_error(error_message), status_code_(status_code) {
-		std::cerr << utils::color::GRAY << "[HttpException] " << error_message << utils::color::RESET << std::endl;
+	std::cerr << utils::color::GRAY << "[HttpException] " << error_message << utils::color::RESET
+			  << std::endl;
 }
 
 HttpException::~HttpException() throw() {}

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -210,21 +210,14 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 	typedef std::vector<std::string>::const_iterator It;
 	for (It it = header_fields_info.begin(); it != header_fields_info.end(); ++it) {
 		std::vector<std::string> header_field_name_and_value = utils::SplitStr(*it, ":");
-		// if (header_field_name_and_value.size() != 2) {
-		// 	throw HttpException(
-		// 		"Error: Missing colon or multiple colons found in header filed",
-		// 		StatusCode(BAD_REQUEST)
-		// 	);
-		// }
-
-		// Todo: `Host: localhost:8080`のような場合どうするのか
-
-		// header_field_valueを初期化してるためheader_field_nameも初期化した
 		const std::string &header_field_name = header_field_name_and_value[0];
 		CheckValidHeaderFieldName(header_fields, header_field_name);
+		// todo:
+		// マルチパートを対応する場合はutils::SplitStrを使用して、セミコロン区切りのstd::vector<std::string>になる。
+		// ex) Content-Type: multipart/form-data; boundary=----WebKitFormBoundary64XhQJfFNRKx7oK7
 		const std::string &header_field_value =
 			StrTrimLeadingOptionalWhitespace(header_field_name_and_value[1]);
-		// to do: #189  ヘッダフィールドをパースする関数（value）-> CheckValidHeaderFieldValue
+		// todo: #189  ヘッダフィールドをパースする関数（value）-> CheckValidHeaderFieldValue
 		typedef std::pair<HeaderFields::const_iterator, bool> Result;
 		Result result = header_fields.insert(std::make_pair(header_field_name, header_field_value));
 		if (result.second == false) {

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -237,16 +237,15 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 }
 
 void HttpParse::CheckValidRequestLine(const std::vector<std::string> &request_line_info) {
-	if (!request_line_info[0].size()) {
-		throw HttpException("Error: Request line don't exist.", StatusCode(BAD_REQUEST));
-	}
 	CheckValidMethod(request_line_info[0]);
 	CheckValidRequestTarget(request_line_info[1]);
 	CheckValidVersion(request_line_info[2]);
 }
 
 void HttpParse::CheckValidMethod(const std::string &method) {
-	// US-ASCIIかまたは大文字かどうか -> 400
+	if (!method.size()) {
+		throw HttpException("Error: the method don't exist.", StatusCode(BAD_REQUEST));
+	}
 	if (IsStringUsAscii(method) == false || IsStringUpper(method) == false) {
 		throw HttpException(
 			"Error: This method contains lowercase or non-USASCII characters.",
@@ -256,7 +255,9 @@ void HttpParse::CheckValidMethod(const std::string &method) {
 }
 
 void HttpParse::CheckValidRequestTarget(const std::string &request_target) {
-	// /が先頭になかったら場合 -> 400
+	if (!request_target.size()) {
+		throw HttpException("Error: the request target don't exist.", StatusCode(BAD_REQUEST));
+	}
 	if (request_target.empty() || request_target[0] != '/') {
 		throw HttpException(
 			"Error: the request target is missing the '/' character at the beginning",
@@ -266,7 +267,9 @@ void HttpParse::CheckValidRequestTarget(const std::string &request_target) {
 }
 
 void HttpParse::CheckValidVersion(const std::string &version) {
-	// HTTP/1.1かどうか -> 400
+	if (!version.size()) {
+		throw HttpException("Error: the http version don't exist.", StatusCode(BAD_REQUEST));
+	}
 	if (version != HTTP_VERSION) {
 		throw HttpException(
 			"Error: The version is not supported by webserv", StatusCode(BAD_REQUEST)

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -266,7 +266,7 @@ void HttpParse::CheckValidVersion(const std::string &version) {
 }
 
 void HttpParse::CheckValidHeaderFieldName(const std::string &header_field_name) {
-	(void) header_field_name;
+	(void)header_field_name;
 	// todo: 複数指定ありの場合はthrowしないようにする。
 	// if (header_field_value != CONNECTION &&
 	// 	std::find(

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -210,7 +210,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 	typedef std::vector<std::string>::const_iterator It;
 	for (It it = header_fields_info.begin(); it != header_fields_info.end(); ++it) {
 		std::vector<std::string> header_field_name_and_value = utils::SplitStr(*it, ":");
-		const std::string &header_field_name = header_field_name_and_value[0];
+		const std::string       &header_field_name           = header_field_name_and_value[0];
 		CheckValidHeaderFieldName(header_fields, header_field_name);
 		// todo:
 		// マルチパートを対応する場合はutils::SplitStrを使用して、セミコロン区切りのstd::vector<std::string>になる。
@@ -270,17 +270,21 @@ void HttpParse::CheckValidVersion(const std::string &version) {
 	}
 }
 
-void HttpParse::CheckValidHeaderFieldName(const HeaderFields &header_fields, const std::string &header_field_name) {
+void HttpParse::CheckValidHeaderFieldName(
+	const HeaderFields &header_fields, const std::string &header_field_name
+) {
 	if (!header_field_name.size()) {
-		throw HttpException("Error: the name of Header field don't exist.", StatusCode(BAD_REQUEST));
+		throw HttpException(
+			"Error: the name of Header field don't exist.", StatusCode(BAD_REQUEST)
+		);
 	}
 	if (HasSpace(header_field_name)) {
-		throw HttpException("Error: the name of Header field has a space.", StatusCode(BAD_REQUEST));
+		throw HttpException(
+			"Error: the name of Header field has a space.", StatusCode(BAD_REQUEST)
+		);
 	}
 	if (header_fields.find(header_field_name) != header_fields.end() && header_field_name == HOST) {
-		throw HttpException(
-			"Error: Host header fields already exists", StatusCode(BAD_REQUEST)
-		);
+		throw HttpException("Error: Host header fields already exists", StatusCode(BAD_REQUEST));
 	}
 }
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -181,38 +181,10 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 	data.is_request_format.is_body_message = true;
 }
 
-void HttpParse::TmpRun(HttpRequestParsedData &data) {
-	// todo: 外側でHttpParse::TmpRunを呼ぶため try, catchを削除する
-	try {
-		ParseRequestLine(data);
-		ParseHeaderFields(data);
-		ParseBodyMessage(data);
-	} catch (const HttpException &e) {
-		data.request_result.status_code = e.GetStatusCode();
-	}
-}
-
-void HttpParse::TmpRunHttpResultVersion(HttpRequestParsedData &data) {
+void HttpParse::Run(HttpRequestParsedData &data) {
 	ParseRequestLine(data);
 	ParseHeaderFields(data);
 	ParseBodyMessage(data);
-}
-
-// todo: tmp request_
-HttpRequestResult HttpParse::Run(const std::string &read_buf) {
-	HttpRequestResult result;
-	// a: [request_line ＋ header_fields, message-body]
-	// b: [request_line, header_fields]
-	std::vector<std::string> a = utils::SplitStr(read_buf, HEADER_FIELDS_END);
-	std::vector<std::string> b = utils::SplitStr(a[0], CRLF);
-	try {
-		result.request.request_line = SetRequestLine(utils::SplitStr(b[0], SP));
-		const std::vector<std::string> header_fields_info(b.begin() + 1, b.end());
-		result.request.header_fields = SetHeaderFields(header_fields_info);
-	} catch (const HttpException &e) {
-		result.status_code = e.GetStatusCode();
-	}
-	return result;
 }
 
 RequestLine HttpParse::SetRequestLine(const std::vector<std::string> &request_line_info) {

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -59,6 +59,15 @@ utils::Result<int> HexToDec(const std::string &hex_str) {
 	return utils::Result<int>(decimal_value);
 }
 
+bool HasSpace(const std::string &str) {
+	for (std::string::const_iterator it = str.begin(); it != str.end(); ++it) {
+		if (std::isspace(*it)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 } // namespace
 
 void HttpParse::ParseRequestLine(HttpRequestParsedData &data) {
@@ -266,6 +275,12 @@ void HttpParse::CheckValidVersion(const std::string &version) {
 }
 
 void HttpParse::CheckValidHeaderFieldName(const HeaderFields &header_fields, const std::string &header_field_name) {
+	if (!header_field_name.size()) {
+		throw HttpException("Error: the name of Header field don't exist.", StatusCode(BAD_REQUEST));
+	}
+	if (HasSpace(header_field_name)) {
+		throw HttpException("Error: the name of Header field has a space.", StatusCode(BAD_REQUEST));
+	}
 	if (header_fields.find(header_field_name) != header_fields.end() && header_field_name == HOST) {
 		throw HttpException(
 			"Error: Host header fields already exists", StatusCode(BAD_REQUEST)

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -228,6 +228,9 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 }
 
 void HttpParse::CheckValidRequestLine(const std::vector<std::string> &request_line_info) {
+	if (!request_line_info[0].size()) {
+		throw HttpException("Error: Request line don't exist.", StatusCode(BAD_REQUEST));
+	}
 	CheckValidMethod(request_line_info[0]);
 	CheckValidRequestTarget(request_line_info[1]);
 	CheckValidVersion(request_line_info[2]);
@@ -262,8 +265,8 @@ void HttpParse::CheckValidVersion(const std::string &version) {
 	}
 }
 
-void HttpParse::CheckValidHeaderFieldName(const std::string &header_field_value) {
-	(void)header_field_value;
+void HttpParse::CheckValidHeaderFieldName(const std::string &header_field_name) {
+	(void) header_field_name;
 	// todo: 複数指定ありの場合はthrowしないようにする。
 	// if (header_field_value != CONNECTION &&
 	// 	std::find(

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -212,7 +212,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 
 		// header_field_valueを初期化してるためheader_field_nameも初期化した
 		const std::string &header_field_name = header_field_name_and_value[0];
-		CheckValidHeaderFieldName(header_field_name);
+		CheckValidHeaderFieldName(header_fields, header_field_name);
 		const std::string &header_field_value =
 			StrTrimLeadingOptionalWhitespace(header_field_name_and_value[1]);
 		// to do: #189  ヘッダフィールドをパースする関数（value）-> CheckValidHeaderFieldValue
@@ -265,21 +265,12 @@ void HttpParse::CheckValidVersion(const std::string &version) {
 	}
 }
 
-void HttpParse::CheckValidHeaderFieldName(const std::string &header_field_name) {
-	(void)header_field_name;
-	// todo: 複数指定ありの場合はthrowしないようにする。
-	// if (header_field_value != CONNECTION &&
-	// 	std::find(
-	// 		REQUEST_HEADER_FIELDS,
-	// 		REQUEST_HEADER_FIELDS + REQUEST_HEADER_FIELDS_SIZE,
-	// 		header_field_value
-	// 	) == REQUEST_HEADER_FIELDS + REQUEST_HEADER_FIELDS_SIZE) {
-	// 	throw HttpException(
-	// 		"Error: the value does not exist in format of header fields", StatusCode(BAD_REQUEST)
-	// 	);
-	// }
-
-	// Todo: ブラウザでデフォルト以外のヘッダーが送られてくることがある
+void HttpParse::CheckValidHeaderFieldName(const HeaderFields &header_fields, const std::string &header_field_name) {
+	if (header_fields.find(header_field_name) != header_fields.end() && header_field_name == HOST) {
+		throw HttpException(
+			"Error: Host header fields already exists", StatusCode(BAD_REQUEST)
+		);
+	}
 }
 
 // status_line && header

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -53,8 +53,8 @@ class HttpParse {
 	static void         CheckValidVersion(const std::string &version);
 
 	static void CheckValidHeaderFieldName(
-        const HeaderFields &header_fields, const std::string &header_field_name
-    )
+		const HeaderFields &header_fields, const std::string &header_field_name
+	)
 };
 
 } // namespace http

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -35,9 +35,7 @@ struct HttpRequestParsedData {
 
 class HttpParse {
   public:
-	static HttpRequestResult Run(const std::string &read_buf);
-	static void              TmpRun(HttpRequestParsedData &data);
-	static void              TmpRunHttpResultVersion(HttpRequestParsedData &data);
+	static void              Run(HttpRequestParsedData &data);
 
   private:
 	HttpParse();

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -54,7 +54,7 @@ class HttpParse {
 
 	static void CheckValidHeaderFieldName(
 		const HeaderFields &header_fields, const std::string &header_field_name
-	)
+	);
 };
 
 } // namespace http

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -52,7 +52,9 @@ class HttpParse {
 	static void         CheckValidRequestTarget(const std::string &request_target);
 	static void         CheckValidVersion(const std::string &version);
 
-	static void CheckValidHeaderFieldName(const std::string &header_field_value);
+	static void CheckValidHeaderFieldName(
+        const HeaderFields &header_fields, const std::string &header_field_name
+    )
 };
 
 } // namespace http

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -35,7 +35,7 @@ struct HttpRequestParsedData {
 
 class HttpParse {
   public:
-	static void              Run(HttpRequestParsedData &data);
+	static void Run(HttpRequestParsedData &data);
 
   private:
 	HttpParse();

--- a/test/common/request/get/4xx/400_15_not_exist_header_field.txt
+++ b/test/common/request/get/4xx/400_15_not_exist_header_field.txt
@@ -1,5 +1,0 @@
-GET / HTTP/1.1
-Host: localhost
-Connection: close
-NonExistFieldName: unknown
-

--- a/test/common/request/get/4xx/400_15_space_in_header_field_name.txt
+++ b/test/common/request/get/4xx/400_15_space_in_header_field_name.txt
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Ho st: localhost
+Connection: close
+

--- a/test/webserv/unit/http/test_case/get/test_2xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_2xx.cpp
@@ -21,7 +21,7 @@ int TestGetOk1ConnectionClose(const server::VirtualServerAddrList &server_infos)
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "200-01");
 }
 
 int TestGetOk13ExtraRequest(const server::VirtualServerAddrList &server_infos) {
@@ -38,7 +38,7 @@ int TestGetOk13ExtraRequest(const server::VirtualServerAddrList &server_infos) {
     );
 	const std::string &request_buffer = "HELLO";
 	http::HttpResult   expected = CreateHttpResult(true, false, request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "200-13");
 }
 
 } // namespace test

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -97,7 +97,7 @@ int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_i
 }
 
 int TestGetBadRequest6LowerHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_6_LOWER_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -133,7 +133,7 @@ int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_
 }
 
 int TestGetBadRequest8WrongHttpVersion(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_8_WRONG_HTTP_VERSION);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -162,8 +162,7 @@ int TestGetBadRequest9NoHost(const server::VirtualServerAddrList &server_infos) 
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
@@ -179,13 +178,12 @@ int TestGetBadRequest10DuplicateHost(const server::VirtualServerAddrList &server
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_11_NO_HEADER_FIELD_COLON);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -196,13 +194,12 @@ int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &s
 	const std::string &expected_response         = CreateHttpResponseFormat(
         expected_status_line, expected_header_fields, expected_body_message
     );
-	http::HttpResult   expected =
-		CreateHttpResult(true, false, "", expected_response);
+	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
 int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_12_NO_CONNECTION_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -218,7 +215,7 @@ int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &ser
 }
 
 int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_13_NO_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -234,7 +231,7 @@ int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &se
 }
 
 int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_14_WRONG_CONNECTION_VALUE);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -250,7 +247,7 @@ int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList 
 }
 
 int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;
@@ -265,11 +262,13 @@ int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &
 	return HandleHttpResult(client_infos, server_infos, expected);
 }
 
-int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
-	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
-	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
-	HeaderFields      expected_header_fields;
+int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos
+) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_16_HEADER_FIELD_NAME_SPACE_COLON);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
 	expected_header_fields[http::CONTENT_TYPE]   = "test/html";
@@ -282,7 +281,7 @@ int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddr
 }
 
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos          = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
+	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_17_SPACE_HEADER_FIELD_NAME);
 	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
 	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
 	HeaderFields      expected_header_fields;

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -246,11 +246,12 @@ int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList 
 	return HandleHttpResult(client_infos, server_infos, expected, "400-14");
 }
 
-int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos) {
-	http::ClientInfos client_infos = CreateClientInfos(request::GET_400_15_NOT_EXIST_HEADER_FIELD);
-	std::string       expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
-	std::string       expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
-	HeaderFields      expected_header_fields;
+int TestGetBadRequest15SpaceInHeaderFieldName(const server::VirtualServerAddrList &server_infos) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_15_SPACE_IN_HEADER_FIELD_NAME);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::CLOSE;
 	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
 	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -21,7 +21,7 @@ int TestGetBadRequest1OnlyCrlf(const server::VirtualServerAddrList &server_infos
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-01");
 }
 
 int TestGetBadRequest2LowerMethod(const server::VirtualServerAddrList &server_infos) {
@@ -39,7 +39,7 @@ int TestGetBadRequest2LowerMethod(const server::VirtualServerAddrList &server_in
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-02");
 }
 
 int TestGetBadRequest3NoAsciiMethod(const server::VirtualServerAddrList &server_infos) {
@@ -57,7 +57,7 @@ int TestGetBadRequest3NoAsciiMethod(const server::VirtualServerAddrList &server_
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-03");
 }
 
 int TestGetBadRequest4NoRoot(const server::VirtualServerAddrList &server_infos) {
@@ -75,7 +75,7 @@ int TestGetBadRequest4NoRoot(const server::VirtualServerAddrList &server_infos) 
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-04");
 }
 
 int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_infos) {
@@ -93,7 +93,7 @@ int TestGetBadRequest5RelativePath(const server::VirtualServerAddrList &server_i
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-05");
 }
 
 int TestGetBadRequest6LowerHttpVersion(const server::VirtualServerAddrList &server_infos) {
@@ -111,7 +111,7 @@ int TestGetBadRequest6LowerHttpVersion(const server::VirtualServerAddrList &serv
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-06");
 }
 
 int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_infos) {
@@ -129,7 +129,7 @@ int TestGetBadRequest7WrongHttpName(const server::VirtualServerAddrList &server_
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-07");
 }
 
 int TestGetBadRequest8WrongHttpVersion(const server::VirtualServerAddrList &server_infos) {
@@ -147,7 +147,7 @@ int TestGetBadRequest8WrongHttpVersion(const server::VirtualServerAddrList &serv
 	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
 	http::HttpResult   expected =
 		CreateHttpResult(true, false, expected_request_buffer, expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-08");
 }
 
 int TestGetBadRequest9NoHost(const server::VirtualServerAddrList &server_infos) {
@@ -163,7 +163,7 @@ int TestGetBadRequest9NoHost(const server::VirtualServerAddrList &server_infos) 
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-09");
 }
 
 int TestGetBadRequest10DuplicateHost(const server::VirtualServerAddrList &server_infos) {
@@ -179,7 +179,7 @@ int TestGetBadRequest10DuplicateHost(const server::VirtualServerAddrList &server
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-10");
 }
 
 int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &server_infos) {
@@ -195,7 +195,7 @@ int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &s
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-11");
 }
 
 int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &server_infos) {
@@ -211,7 +211,7 @@ int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &ser
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-12");
 }
 
 int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &server_infos) {
@@ -227,7 +227,7 @@ int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &se
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-13");
 }
 
 int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList &server_infos) {
@@ -243,7 +243,7 @@ int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList 
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-14");
 }
 
 int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos) {
@@ -259,7 +259,7 @@ int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-15");
 }
 
 int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos
@@ -277,7 +277,7 @@ int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddr
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-16");
 }
 
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos) {
@@ -293,7 +293,7 @@ int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList 
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-17");
 }
 
 int TestGetNotFound1NotExistFile(const server::VirtualServerAddrList &server_infos) {
@@ -310,7 +310,7 @@ int TestGetNotFound1NotExistFile(const server::VirtualServerAddrList &server_inf
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "404-01");
 }
 
 int TestGetMethodNotAllowed(const server::VirtualServerAddrList &server_infos) {
@@ -326,7 +326,7 @@ int TestGetMethodNotAllowed(const server::VirtualServerAddrList &server_infos) {
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "405-01");
 }
 
 int TestGetTimeout1NoCrlf(const server::VirtualServerAddrList &server_infos) {
@@ -342,7 +342,7 @@ int TestGetTimeout1NoCrlf(const server::VirtualServerAddrList &server_infos) {
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, true, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "408-01");
 }
 
 } // namespace test

--- a/test/webserv/unit/http/test_case/get/test_5xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_5xx.cpp
@@ -21,7 +21,7 @@ int TestGetNotImplemented1NotExistMethod(const server::VirtualServerAddrList &se
         expected_status_line, expected_header_fields, expected_body_message
     );
 	http::HttpResult expected = CreateHttpResult(true, false, "", expected_response);
-	return HandleHttpResult(client_infos, server_infos, expected);
+	return HandleHttpResult(client_infos, server_infos, expected, "501-01");
 }
 
 } // namespace test

--- a/test/webserv/unit/http/test_case/test_case.hpp
+++ b/test/webserv/unit/http/test_case/test_case.hpp
@@ -30,7 +30,7 @@ int TestGetBadRequest11NoHeaderFieldColon(const server::VirtualServerAddrList &s
 int TestGetBadRequest12NoConnectionName(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest13NoConnectionValue(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest14WrongConnectionValue(const server::VirtualServerAddrList &server_infos);
-int TestGetBadRequest15NotExistHeaderField(const server::VirtualServerAddrList &server_infos);
+int TestGetBadRequest15SpaceInHeaderFieldName(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos);
 

--- a/test/webserv/unit/http/test_case/test_handler.cpp
+++ b/test/webserv/unit/http/test_case/test_handler.cpp
@@ -43,24 +43,18 @@ std::string CreateHttpResponseFormat(
 	return response;
 }
 
-int GetTestCaseNum() {
-	static unsigned int test_case_num = 0;
-	++test_case_num;
-	return test_case_num;
-}
-
 template <typename T>
 bool IsSame(const T &result, const T &expected) {
 	return result == expected;
 }
 
-int HandleResult(const Result &result) {
+int HandleResult(const Result &result, const std::string& current_number) {
 	if (result.is_success) {
-		std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+		std::cout << utils::color::GREEN << current_number << ".[OK]" << utils::color::RESET
 				  << std::endl;
 		return EXIT_SUCCESS;
 	} else {
-		std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+		std::cerr << utils::color::RED << current_number << ".[NG] " << utils::color::RESET
 				  << std::endl;
 		std::cerr << result.error_log;
 		return EXIT_FAILURE;
@@ -162,12 +156,13 @@ Result IsSameHttpResult(const http::HttpResult &http_result, const http::HttpRes
 int HandleHttpResult(
 	const http::ClientInfos             &client_infos,
 	const server::VirtualServerAddrList &server_infos,
-	const http::HttpResult               expected
+	const http::HttpResult               expected,
+	const std::string                   &current_number
 ) {
 	http::Http       http;
 	http::HttpResult http_result = http.Run(client_infos, server_infos);
 	const Result    &result      = IsSameHttpResult(http_result, expected);
-	return HandleResult(result);
+	return HandleResult(result, current_number);
 }
 
 } // namespace test

--- a/test/webserv/unit/http/test_case/test_handler.cpp
+++ b/test/webserv/unit/http/test_case/test_handler.cpp
@@ -48,7 +48,7 @@ bool IsSame(const T &result, const T &expected) {
 	return result == expected;
 }
 
-int HandleResult(const Result &result, const std::string& current_number) {
+int HandleResult(const Result &result, const std::string &current_number) {
 	if (result.is_success) {
 		std::cout << utils::color::GREEN << current_number << ".[OK]" << utils::color::RESET
 				  << std::endl;

--- a/test/webserv/unit/http/test_case/test_handler.hpp
+++ b/test/webserv/unit/http/test_case/test_handler.hpp
@@ -39,7 +39,8 @@ http::HttpResult  CreateHttpResult(
 int HandleHttpResult(
 	const http::ClientInfos             &client_infos,
 	const server::VirtualServerAddrList &server_infos,
-	const http::HttpResult               expected
+	const http::HttpResult               expected,
+	const std::string                   &current_number
 );
 
 } // namespace test

--- a/test/webserv/unit/http/test_case/test_request.hpp
+++ b/test/webserv/unit/http/test_case/test_request.hpp
@@ -48,8 +48,8 @@ static const std::string &GET_400_13_NO_CONNECTION_VALUE =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_13_no_connection_value.txt");
 static const std::string &GET_400_14_WRONG_CONNECTION_VALUE =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_14_wrong_connection_value.txt");
-static const std::string &GET_400_15_NOT_EXIST_HEADER_FIELD =
-	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_15_not_exist_header_field.txt");
+static const std::string &GET_400_15_SPACE_IN_HEADER_FIELD_NAME =
+	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_15_space_in_header_field_name.txt");
 static const std::string &GET_400_16_HEADER_FIELD_NAME_SPACE_COLON =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_16_header_field_name_space_colon.txt");
 static const std::string &GET_400_17_SPACE_HEADER_FIELD_NAME =

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -63,17 +63,15 @@ int  main(void) {
     // todo: Fix: std::out_of_range: map::at:  key not found
     // ret_code |= test::TestGetBadRequest9NoHost(server_infos);
     ret_code |= test::TestGetBadRequest10DuplicateHost(server_infos);
-    // >>>> 統合によって失敗するテスト
-    // ret_code |= test::TestGetBadRequest11NoHeaderFieldColon(server_infos);
-    // ret_code |= test::TestGetBadRequest12NoConnectionName(server_infos);
-    // <<<<
-    // todo: 13, 14 Connectionがkeep-aliveとclose以外の場合
+    ret_code |= test::TestGetBadRequest11NoHeaderFieldColon(server_infos);
+    ret_code |= test::TestGetBadRequest12NoConnectionName(server_infos);
+    // todo: CheckHeaderFieldValue() / Connectionがkeep-aliveとclose以外の場合
     // ret_code |= test::TestGetBadRequest13NoConnectionValue(server_infos);
     // ret_code |= test::TestGetBadRequest14WrongConnectionValue(server_infos);
-    // >>>> 統合によって失敗するテスト
+    // todo: 対応していないヘッダーフィールドは無視する場合はこのテストを削除する
     // ret_code |= test::TestGetBadRequest15NotExistHeaderField(server_infos);
-    // ret_code |= test::TestGetBadRequest16HeaderFieldNameSpaceColon(server_infos);
-    // ret_code |= test::TestGetBadRequest17SpaceHeaderFieldName(server_infos);
+    ret_code |= test::TestGetBadRequest16HeaderFieldNameSpaceColon(server_infos);
+    ret_code |= test::TestGetBadRequest17SpaceHeaderFieldName(server_infos);
     // <<<<
     ret_code |= test::TestGetNotFound1NotExistFile(server_infos);
     ret_code |= test::TestGetMethodNotAllowed(server_infos);

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -69,7 +69,7 @@ int  main(void) {
     // ret_code |= test::TestGetBadRequest13NoConnectionValue(server_infos);
     // ret_code |= test::TestGetBadRequest14WrongConnectionValue(server_infos);
     // todo: 対応していないヘッダーフィールドは無視する場合はこのテストを削除する
-    // ret_code |= test::TestGetBadRequest15NotExistHeaderField(server_infos);
+    ret_code |= test::TestGetBadRequest15SpaceInHeaderFieldName(server_infos);
     ret_code |= test::TestGetBadRequest16HeaderFieldNameSpaceColon(server_infos);
     ret_code |= test::TestGetBadRequest17SpaceHeaderFieldName(server_infos);
     // <<<<

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -50,9 +50,9 @@ int  main(void) {
 
     server::VirtualServerAddrList server_infos = BuildVirtualServerAddrList();
     ret_code |= test::TestGetOk1ConnectionClose(server_infos);
-    // todo: segv
-    // ret_code |= test::TestGetBadRequest1OnlyCrlf(server_infos);
     ret_code |= test::TestGetOk13ExtraRequest(server_infos);
+
+    ret_code |= test::TestGetBadRequest1OnlyCrlf(server_infos);
     ret_code |= test::TestGetBadRequest2LowerMethod(server_infos);
     ret_code |= test::TestGetBadRequest3NoAsciiMethod(server_infos);
     ret_code |= test::TestGetBadRequest4NoRoot(server_infos);

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -221,7 +221,7 @@ http::HttpRequestParsedData ParseHttpRequestFormat(const std::string &read_buf) 
 	http::HttpRequestParsedData save_data;
 	save_data.current_buf += read_buf;
 	try {
-		http::HttpParse::TmpRunHttpResultVersion(save_data);
+		http::HttpParse::Run(save_data);
 	} catch (const http::HttpException &e) {
 		save_data.request_result.status_code = e.GetStatusCode();
 	}


### PR DESCRIPTION
# 仕様変更
* HttpParseクラスのpublicはRun関数のみにした
* CheckValidHeaderFieldName 
  * ヘッダーフィールド名が存在するかどうか
  * ヘッダーフィールド名が空白がないかどうか
  * 一つしか指定できない場合のヘッダーフィールドを確認する / 現在`Host`のみ対応
  * webservが対応していないheader_filedsは無視するようにした

# 修正点
* リクエストがCRLFのみの場合、SEGV修正
* HttpExceptionのエラーメッセージを出力するようにした（デバック用）
* コメント修正

# してないこと
* CheckValidHeaderFieldValue / webservが対応するヘッダフィールドの値を正しいかどうかを確認すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- HTTPリクエストの解析方法が改善され、より効率的なパースが可能になりました。
	- `HttpException`のコンストラクタがエラーメッセージを標準エラー出力にログする機能を追加しました。

- **バグ修正**
	- テストケース`TestGetBadRequest1OnlyCrlf`が実行されるようになりました。
	- 特定のHTTPステータスコードを持つテストケースが追加され、エラーハンドリングが強化されました。

- **ドキュメント**
	- HTTPリクエストのパースに関するメソッドのシグネチャが更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->