### PR TITLE
[add] Server に CgiManager を組み込む 

### DIFF
--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -156,7 +156,7 @@ char *const *Cgi::SetCgiArgv() {
 	char **argv = new (std::nothrow) char *[2];
 	char  *dest = new (std::nothrow) char[cgi_script_.size() + 1];
 	if (argv == NULL || dest == NULL) {
-		throw SystemException(std::strerror(errno));
+		throw SystemException("SetCgiArgv: Failed to allocate memory");
 	}
 	std::strcpy(dest, cgi_script_.c_str());
 	argv[0] = dest;
@@ -167,16 +167,16 @@ char *const *Cgi::SetCgiArgv() {
 char *const *Cgi::SetCgiEnv(const MetaMap &meta_variables) {
 	char **cgi_env = new (std::nothrow) char *[meta_variables.size() + 1];
 	if (cgi_env == NULL) {
-		throw SystemException(std::strerror(errno));
+		throw SystemException("SetCgiEnv: cgi_env: Failed to allocate memory");
 	}
 	std::size_t i = 0;
 
 	typedef MetaMap::const_iterator It;
-	for (It it = meta_variables.begin(); it != meta_variables.end(); it++) {
+	for (It it = meta_variables.begin(); it != meta_variables.end(); ++it) {
 		const std::string element = it->first + "=" + it->second;
 		char             *dest    = new (std::nothrow) char[element.size() + 1];
 		if (dest == NULL) {
-			throw SystemException(std::strerror(errno));
+			throw SystemException("SetCgiEnv: dest: Failed to allocate memory");
 		}
 		std::strcpy(dest, element.c_str());
 		cgi_env[i] = dest;

--- a/srcs/http/IHttp.hpp
+++ b/srcs/http/IHttp.hpp
@@ -1,6 +1,7 @@
 #ifndef IHTTP_HPP_
 #define IHTTP_HPP_
 
+#include "cgi.hpp"
 #include "client_infos.hpp"
 #include "virtual_server.hpp"
 
@@ -39,6 +40,7 @@ class IHttp {
 	virtual HttpResult
 	Run(const ClientInfos &client_infos, const server::VirtualServerAddrList &virtual_servers) = 0;
 	virtual HttpResult GetErrorResponse(const ClientInfos &client_info, ErrState state)        = 0;
+	virtual void       SetCgiResponse(int client_fd, const cgi::CgiResponse &cgi_response)     = 0;
 };
 
 } // namespace http

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -33,6 +33,12 @@ HttpResult Http::GetErrorResponse(const ClientInfos &client_info, ErrState state
 	return result;
 }
 
+// todo
+void Http::SetCgiResponse(int client_fd, const cgi::CgiResponse &cgi_response) {
+	(void)client_fd;
+	(void)cgi_response;
+}
+
 utils::Result<void> Http::ParseHttpRequestFormat(int client_fd, const std::string &read_buf) {
 	utils::Result<void>   result;
 	HttpRequestParsedData save_data = storage_.GetClientSaveData(client_fd);

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -30,6 +30,7 @@ class Http : public IHttp {
 	HttpResult
 	Run(const ClientInfos &client_info, const server::VirtualServerAddrList &server_info);
 	HttpResult GetErrorResponse(const ClientInfos &client_info, ErrState state);
+	void       SetCgiResponse(int client_fd, const cgi::CgiResponse &cgi_response);
 
   private:
 	Http(const Http &other);

--- a/srcs/http/http_result.hpp
+++ b/srcs/http/http_result.hpp
@@ -1,9 +1,17 @@
 #ifndef HTTP_RESULT_HPP_
 #define HTTP_RESULT_HPP_
 
+#include "cgi_request.hpp"
 #include <string>
 
 namespace http {
+
+struct CgiResult {
+	CgiResult() : is_cgi(false) {}
+
+	bool            is_cgi;
+	cgi::CgiRequest cgi_request;
+};
 
 struct HttpResult {
 	HttpResult() : is_response_complete(false), is_connection_keep(true) {}
@@ -12,6 +20,7 @@ struct HttpResult {
 	bool        is_connection_keep;
 	std::string request_buf;
 	std::string response;
+	CgiResult   cgi_result;
 };
 
 } // namespace http

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -19,7 +19,7 @@ CgiManager::~CgiManager() {
 void CgiManager::AddNewCgi(int client_fd, const cgi::CgiRequest &request) {
 	Cgi *cgi = new (std::nothrow) Cgi(request);
 	if (cgi == NULL) {
-		throw SystemException(std::strerror(errno));
+		throw SystemException("AddNewCgi: Failed to allocate memory");
 	}
 	if (cgi_addr_map_.count(client_fd) != 0) {
 		throw std::logic_error("AddNewCgi: client_fd already exists");

--- a/srcs/server/read.cpp
+++ b/srcs/server/read.cpp
@@ -9,7 +9,7 @@ Read::Read() {}
 
 Read::~Read() {}
 
-Read::ReadResult Read::ReadRequest(int client_fd) {
+Read::ReadResult Read::ReadStr(int client_fd) {
 	ReadResult read_result;
 
 	char    buffer[BUFFER_SIZE];

--- a/srcs/server/read.hpp
+++ b/srcs/server/read.hpp
@@ -16,7 +16,7 @@ class Read {
 	typedef utils::Result<ReadBuf> ReadResult;
 
 	// function
-	static ReadResult ReadRequest(int client_fd);
+	static ReadResult ReadStr(int client_fd);
 
   private:
 	Read();

--- a/srcs/server/send.cpp
+++ b/srcs/server/send.cpp
@@ -1,8 +1,9 @@
 #include "send.hpp"
 #include "utils.hpp"
 #include <cerrno>
-#include <cstring>      // strerror
-#include <sys/socket.h> // send
+#include <cstring>     // strerror
+#include <sys/types.h> // ssize_t
+#include <unistd.h>    // write
 
 namespace server {
 
@@ -10,20 +11,20 @@ Send::Send() {}
 
 Send::~Send() {}
 
-Send::SendResult Send::SendResponse(int client_fd, const Response &response) {
+Send::SendResult Send::SendStr(int client_fd, const std::string &send_str) {
 	SendResult send_result;
 
-	ssize_t send_size = send(client_fd, response.c_str(), response.size(), 0);
+	ssize_t send_size = write(client_fd, send_str.c_str(), send_str.size());
 	utils::Debug("Send", "send_size: ", send_size);
 	if (send_size == SYSTEM_ERROR) {
-		utils::PrintError(__func__, strerror(errno));
+		utils::PrintError("write: ", strerror(errno));
 		send_result.Set(false);
 		return send_result;
 	}
 	// Returns the substring starting from the send_size-th character.
-	// If the entire response was sent, an empty string is returned.
-	const Response unsent_response = response.substr(send_size);
-	send_result.SetValue(unsent_response);
+	// If the entire send_str was sent, an empty string is returned.
+	const std::string unsent_str = send_str.substr(send_size);
+	send_result.SetValue(unsent_str);
 	return send_result;
 }
 

--- a/srcs/server/send.hpp
+++ b/srcs/server/send.hpp
@@ -3,24 +3,22 @@
 
 #include "utils.hpp"
 #include <string>
-#include <sys/types.h> // ssize_t
 
 namespace server {
 
 /**
- * @brief Sends an response to the client and returns the result.
+ * @brief Sends a string to the client and returns the result.
  *
- * Sends the given response to the client using the provided file descriptor.
+ * Sends the given string to the client using the provided file descriptor.
  * The result is `false` if an error occurs, otherwise `true`.
- * If any part of the response is not sent, it is stored in the result value.
+ * If any part of the string is not sent, it is stored in the result value.
  */
 class Send {
   public:
-	typedef std::string             Response;
-	typedef utils::Result<Response> SendResult;
+	typedef utils::Result<std::string> SendResult;
 
 	// function
-	static SendResult SendResponse(int client_fd, const Response &response);
+	static SendResult SendStr(int client_fd, const std::string &send_str);
 
   private:
 	Send();

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -506,10 +506,16 @@ void Server::HandleCgi(int client_fd, const http::CgiResult &cgi_result) {
 	if (!cgi_result.is_cgi) {
 		return;
 	}
-	// todo: try-catch
-	cgi_manager_.AddNewCgi(client_fd, cgi_result.cgi_request);
-	// RunCgi() is called only when a new Cgi is added via AddNewCgi().
-	cgi_manager_.RunCgi(client_fd);
+	try {
+		cgi_manager_.AddNewCgi(client_fd, cgi_result.cgi_request);
+		// RunCgi() is called only when a new Cgi is added via AddNewCgi().
+		cgi_manager_.RunCgi(client_fd);
+	} catch (const SystemException &e) {
+		cgi_manager_.DeleteCgi(client_fd);
+		SetInternalServerError(client_fd);
+		return;
+	}
+	// AddEventForCgi(client_fd);
 }
 
 void Server::HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result) {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -270,7 +270,7 @@ void Server::SendResponse(int client_fd) {
 	const message::ConnectionState connection_state = response.connection_state;
 	const std::string             &response_str     = response.response_str;
 
-	const Send::SendResult send_result = Send::SendResponse(client_fd, response_str);
+	const Send::SendResult send_result = Send::SendStr(client_fd, response_str);
 	if (!send_result.IsOk()) {
 		// Even if sending fails, continue the server
 		// e.g., in case of a SIGPIPE(EPIPE) when the client disconnects

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -243,6 +243,7 @@ void Server::RunHttp(const event::Event &event) {
 	// If not completed, the request will be re-read by the event_monitor.
 	if (!http_result.is_response_complete) {
 		message_manager_.SetIsCompleteRequest(client_fd, false);
+		HandleCgi(client_fd, http_result.cgi_result);
 		return;
 	}
 	message_manager_.SetIsCompleteRequest(client_fd, true);
@@ -502,6 +503,16 @@ void Server::SetNonBlockingMode(int sock_fd) {
 
 bool Server::IsCgi(int fd) const {
 	return !message_manager_.IsMessageExist(fd);
+}
+
+void Server::HandleCgi(int client_fd, const http::CgiResult &cgi_result) {
+	if (!cgi_result.is_cgi) {
+		return;
+	}
+	// todo: try-catch?
+	cgi_manager_.AddNewCgi(client_fd, cgi_result.cgi_request);
+	// RunCgi() is called only when a new Cgi is added via AddNewCgi().
+	cgi_manager_.RunCgi(client_fd);
 }
 
 } // namespace server

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -506,7 +506,7 @@ void Server::HandleCgi(int client_fd, const http::CgiResult &cgi_result) {
 	if (!cgi_result.is_cgi) {
 		return;
 	}
-	// todo: try-catch?
+	// todo: try-catch
 	cgi_manager_.AddNewCgi(client_fd, cgi_result.cgi_request);
 	// RunCgi() is called only when a new Cgi is added via AddNewCgi().
 	cgi_manager_.RunCgi(client_fd);
@@ -535,8 +535,7 @@ void Server::SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf) {
 	}
 	utils::Debug("cgi", "Read the entire response from the child process through pipe_fd", pipe_fd);
 
-	// todo: IHttpに作る
-	// http_.SetCgiResponse(client_fd, cgi_response);
+	http_.SetCgiResponse(client_fd, cgi_response);
 	cgi_manager_.DeleteCgi(client_fd);
 	event_monitor_.Delete(client_fd);
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -517,34 +517,6 @@ void Server::HandleCgi(int client_fd, const http::CgiResult &cgi_result) {
 	}
 }
 
-void Server::HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result) {
-	const int client_fd = cgi_manager_.GetClientFd(pipe_fd);
-
-	if (!read_result.IsOk()) {
-		utils::Debug(
-			"cgi", "Failed to read the response from the child process through pipe_fd", pipe_fd
-		);
-		cgi_manager_.DeleteCgi(client_fd);
-		SetInternalServerError(client_fd);
-		return;
-	}
-	SetCgiResponseToHttp(pipe_fd, read_result.GetValue().read_buf);
-}
-
-void Server::SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf) {
-	const int client_fd = cgi_manager_.GetClientFd(pipe_fd);
-
-	const cgi::CgiResponse cgi_response = cgi_manager_.AddAndGetResponse(client_fd, read_buf);
-	if (!cgi_response.is_response_complete) {
-		return;
-	}
-	utils::Debug("cgi", "Read the entire response from the child process through pipe_fd", pipe_fd);
-
-	http_.SetCgiResponse(client_fd, cgi_response);
-	cgi_manager_.DeleteCgi(client_fd);
-	event_monitor_.Delete(client_fd);
-}
-
 // throw(SystemException)
 void Server::AddEventForCgi(int client_fd) {
 	const CgiManager::GetFdResult read_fd_result = cgi_manager_.GetReadFd(client_fd);
@@ -577,6 +549,34 @@ void Server::SendCgiRequest(int pipe_fd) {
 	if (new_request_str.empty()) {
 		ReplaceEvent(pipe_fd, event::EVENT_READ);
 	}
+}
+
+void Server::HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result) {
+	const int client_fd = cgi_manager_.GetClientFd(pipe_fd);
+
+	if (!read_result.IsOk()) {
+		utils::Debug(
+			"cgi", "Failed to read the response from the child process through pipe_fd", pipe_fd
+		);
+		cgi_manager_.DeleteCgi(client_fd);
+		SetInternalServerError(client_fd);
+		return;
+	}
+	SetCgiResponseToHttp(pipe_fd, read_result.GetValue().read_buf);
+}
+
+void Server::SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf) {
+	const int client_fd = cgi_manager_.GetClientFd(pipe_fd);
+
+	const cgi::CgiResponse cgi_response = cgi_manager_.AddAndGetResponse(client_fd, read_buf);
+	if (!cgi_response.is_response_complete) {
+		return;
+	}
+	utils::Debug("cgi", "Read the entire response from the child process through pipe_fd", pipe_fd);
+
+	http_.SetCgiResponse(client_fd, cgi_response);
+	cgi_manager_.DeleteCgi(client_fd);
+	event_monitor_.Delete(client_fd);
 }
 
 } // namespace server

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -189,7 +189,7 @@ void Server::HandleExistingConnection(const event::Event &event) {
 
 void Server::HandleReadEvent(const event::Event &event) {
 	const int              fd          = event.fd;
-	const Read::ReadResult read_result = Read::ReadRequest(fd);
+	const Read::ReadResult read_result = Read::ReadStr(fd);
 
 	if (IsCgi(fd)) {
 		HandleCgiReadResult(fd, read_result);

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -73,9 +73,9 @@ class Server {
 	bool IsCgi(int fd) const;
 	void HandleCgi(int client_fd, const http::CgiResult &cgi_result);
 	void AddEventForCgi(int client_fd);
+	void SendCgiRequest(int pipe_fd);
 	void HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
 	void SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf);
-	void SendCgiRequest(int pipe_fd);
 
 	// const
 	static const int    SYSTEM_ERROR = -1;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -48,7 +48,7 @@ class Server {
 	void      HandleHttpReadResult(const event::Event &event, const Read::ReadResult &read_result);
 	void      RunHttp(const event::Event &event);
 	void      HandleWriteEvent(int fd);
-	void      SendResponse(int client_fd);
+	void      SendHttpResponse(int client_fd);
 	void      HandleTimeoutMessages();
 	void      SetInternalServerError(int client_fd);
 	void      KeepConnection(int client_fd);
@@ -75,6 +75,7 @@ class Server {
 	void AddEventForCgi(int client_fd);
 	void HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
 	void SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf);
+	void SendCgiRequest(int pipe_fd);
 
 	// const
 	static const int    SYSTEM_ERROR = -1;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -73,6 +73,7 @@ class Server {
 	bool IsCgi(int fd) const;
 	void HandleCgi(int client_fd, const http::CgiResult &cgi_result);
 	void HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
+	void SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf);
 
 	// const
 	static const int    SYSTEM_ERROR = -1;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -43,8 +43,10 @@ class Server {
 	void             HandleEvent(const event::Event &event);
 	void             HandleNewConnection(int server_fd);
 	void             HandleExistingConnection(const event::Event &event);
+	void             HandleReadEvent(const event::Event &event);
 	Read::ReadResult ReadRequest(int client_fd);
 	void             RunHttp(const event::Event &event);
+	void             HandleWriteEvent(int fd);
 	void             SendResponse(int client_fd);
 	void             HandleTimeoutMessages();
 	void             SetInternalServerError(int client_fd);
@@ -66,6 +68,8 @@ class Server {
 	// for Server to Http
 	http::ClientInfos     GetClientInfos(int client_fd) const;
 	VirtualServerAddrList GetVirtualServerList(int client_fd) const;
+	// for Cgi
+	bool IsCgi(int fd) const;
 
 	// const
 	static const int    SYSTEM_ERROR = -1;

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -72,6 +72,7 @@ class Server {
 	// for Cgi
 	bool IsCgi(int fd) const;
 	void HandleCgi(int client_fd, const http::CgiResult &cgi_result);
+	void AddEventForCgi(int client_fd);
 	void HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
 	void SetCgiResponseToHttp(int pipe_fd, const std::string &read_buf);
 

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_SERVER_HPP_
 #define SERVER_SERVER_HPP_
 
+#include "cgi_manager.hpp"
 #include "config_parse/context.hpp"
 #include "connection.hpp"
 #include "context_manager.hpp"
@@ -70,6 +71,7 @@ class Server {
 	VirtualServerAddrList GetVirtualServerList(int client_fd) const;
 	// for Cgi
 	bool IsCgi(int fd) const;
+	void HandleCgi(int client_fd, const http::CgiResult &cgi_result);
 
 	// const
 	static const int    SYSTEM_ERROR = -1;
@@ -84,6 +86,8 @@ class Server {
 	http::Http http_;
 	// message manager with time control
 	MessageManager message_manager_;
+	// cgi
+	CgiManager cgi_manager_;
 };
 
 } // namespace server

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -36,26 +36,26 @@ class Server {
 	Server(const Server &other);
 	Server &operator=(const Server &other);
 	// functions
-	void             AddVirtualServers(const ConfigServers &config_servers);
-	void             AddServerInfoToContext(const VirtualServerList &virtual_server_list);
-	void             ListenAllHostPorts(const VirtualServerList &virtual_server_list);
-	PortIpMap        CreatePortIpMap(const VirtualServerList &virtual_server_list);
-	void             Listen(const HostPortPair &host_port);
-	void             HandleEvent(const event::Event &event);
-	void             HandleNewConnection(int server_fd);
-	void             HandleExistingConnection(const event::Event &event);
-	void             HandleReadEvent(const event::Event &event);
-	Read::ReadResult ReadRequest(int client_fd);
-	void             RunHttp(const event::Event &event);
-	void             HandleWriteEvent(int fd);
-	void             SendResponse(int client_fd);
-	void             HandleTimeoutMessages();
-	void             SetInternalServerError(int client_fd);
-	void             KeepConnection(int client_fd);
-	void             Disconnect(int client_fd);
-	void             UpdateEventInResponseComplete(
-					const message::ConnectionState connection_state, const event::Event &event
-				);
+	void      AddVirtualServers(const ConfigServers &config_servers);
+	void      AddServerInfoToContext(const VirtualServerList &virtual_server_list);
+	void      ListenAllHostPorts(const VirtualServerList &virtual_server_list);
+	PortIpMap CreatePortIpMap(const VirtualServerList &virtual_server_list);
+	void      Listen(const HostPortPair &host_port);
+	void      HandleEvent(const event::Event &event);
+	void      HandleNewConnection(int server_fd);
+	void      HandleExistingConnection(const event::Event &event);
+	void      HandleReadEvent(const event::Event &event);
+	void      HandleHttpReadResult(const event::Event &event, const Read::ReadResult &read_result);
+	void      RunHttp(const event::Event &event);
+	void      HandleWriteEvent(int fd);
+	void      SendResponse(int client_fd);
+	void      HandleTimeoutMessages();
+	void      SetInternalServerError(int client_fd);
+	void      KeepConnection(int client_fd);
+	void      Disconnect(int client_fd);
+	void      UpdateEventInResponseComplete(
+			 const message::ConnectionState connection_state, const event::Event &event
+		 );
 	void UpdateConnectionAfterSendResponse(
 		int client_fd, const message::ConnectionState connection_state
 	);
@@ -72,6 +72,7 @@ class Server {
 	// for Cgi
 	bool IsCgi(int fd) const;
 	void HandleCgi(int client_fd, const http::CgiResult &cgi_result);
+	void HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
 
 	// const
 	static const int    SYSTEM_ERROR = -1;

--- a/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
+++ b/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
@@ -232,7 +232,6 @@ int RunTest3() {
 	return ret_code;
 }
 
-// todo: cgi.Run()が動くまではif文に入らずTest()が呼ばれてない
 // -----------------------------------------------------------------------------
 // CgiManager classの主なテスト対象関数
 // - RunCgi()
@@ -243,7 +242,7 @@ int RunTest3() {
 int RunTest4() {
 	int ret_code = EXIT_SUCCESS;
 
-	const int         expected_client_fd = 3;
+	const int         expected_client_fd = 10; // 3,4はpipe_fdで使われる
 	const std::string expected_request   = "abcde";
 
 	// 最低限のCgiRequest準備
@@ -255,7 +254,7 @@ int RunTest4() {
 	// CgiManager内で新規Cgiを複数作成
 	CgiManager cgi_manager;
 	cgi_manager.AddNewCgi(expected_client_fd, cgi_request);
-	cgi_manager.AddNewCgi(4, cgi_request);
+	cgi_manager.AddNewCgi(11, cgi_request);
 
 	// cgiを実行する(子プロセスで実行 & pipe_fdがclient_fdと紐づけられる)
 	cgi_manager.RunCgi(expected_client_fd);

--- a/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
+++ b/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
@@ -18,6 +18,9 @@ typedef CgiManager::GetFdResult GetFdResult;
 
 struct Result {
 	Result() : is_success(true) {}
+	Result(bool is_success, const std::string &error_message)
+		: is_success(is_success), error_log(error_message) {}
+
 	bool        is_success;
 	std::string error_log;
 };
@@ -238,6 +241,7 @@ int RunTest3() {
 // - GetClientFd()
 // - GetReadFd()
 // - GetWriteFd()
+// - method == GET
 // -----------------------------------------------------------------------------
 int RunTest4() {
 	int ret_code = EXIT_SUCCESS;
@@ -264,17 +268,17 @@ int RunTest4() {
 	if (read_fd_result.IsOk()) {
 		const int read_pipe_fd = read_fd_result.GetValue();
 		// read_pipe_fdとclient_fdの紐づけ確認
-		ret_code |= Test(IsSameClientFd(cgi_manager, read_pipe_fd, expected_client_fd)
-		); // Test7 or 入らない
+		ret_code |= Test(IsSameClientFd(cgi_manager, read_pipe_fd, expected_client_fd)); // Test7
+	} else {
+		ret_code |= Test(Result(false, "read pipe_fd was not created"));
 	}
 
 	// pipe_fd(write)を取得
 	const GetFdResult write_fd_result = cgi_manager.GetWriteFd(expected_client_fd);
 	if (write_fd_result.IsOk()) {
-		const int write_pipe_fd = write_fd_result.GetValue();
-		// write_pipe_fdとclient_fdの紐づけ確認
-		ret_code |=
-			Test(IsSameClientFd(cgi_manager, write_pipe_fd, expected_client_fd)); // Test7 or Test8
+		ret_code |= Test(Result(false, "write pipe_fd was created")); // GETなのでここには入らない
+	} else {
+		ret_code |= Test(Result()); // Test8
 	}
 
 	return ret_code;

--- a/test/webserv/unit/http/Makefile
+++ b/test/webserv/unit/http/Makefile
@@ -17,6 +17,7 @@ WS_HTTP_RESPONSE_DIR	:=	$(WS_HTTP_DIR)/response
 WS_HTTP_PARSE_DIR		:=	$(WS_HTTP_REQUEST_DIR)/parse
 WS_HTTP_SERVER_INFO_CHECK_DIR	:=	$(WS_HTTP_RESPONSE_DIR)/http_serverinfo_check
 WS_VIRTUAL_SERVER_DIR			:=	$(WS_SRCS_DIR)/server/virtual_server
+WS_CGI_DIR				:=	$(WS_SRCS_DIR)/cgi
 
 SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
@@ -33,7 +34,8 @@ SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 						$(WS_HTTP_RESPONSE_DIR)/stat.cpp \
 						$(WS_HTTP_PARSE_DIR)/http_parse.cpp \
 						$(WS_HTTP_SERVER_INFO_CHECK_DIR)/http_serverinfo_check.cpp \
-						$(WS_VIRTUAL_SERVER_DIR)/virtual_server.cpp
+						$(WS_VIRTUAL_SERVER_DIR)/virtual_server.cpp \
+						$(WS_CGI_DIR)/cgi_request.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http.cpp \
@@ -47,7 +49,8 @@ SRCS_DIR	:=	$(WS_EXCEPTION_DIR) \
 				$(WS_HTTP_RESPONSE_DIR) \
 				$(WS_HTTP_PARSE_DIR) \
 				$(WS_HTTP_SERVER_INFO_CHECK_DIR) \
-				$(WS_VIRTUAL_SERVER_DIR)
+				$(WS_VIRTUAL_SERVER_DIR) \
+				$(WS_CGI_DIR)
 
 # 3. Add unit test files
 TEST_CASE_DIR := test_case


### PR DESCRIPTION
`Server class` のメンバに `CgiManager class` を追加し、`Cgi class` のインスタンス化や実行・read/write イベント監視・削除などの処理全般を追加しました

CGI 実行が終了したら、`CgiResponse` を Http に伝える必要があるので、`IHttp` に新しく関数を 1 つ追加しています (未実装。-> Issue #519 )

```cpp
  virtual void  SetCgiResponse(int client_fd, const cgi::CgiResponse &cgi_response)     = 0;
```

実行確認はまだ unit test のみです
```sh
make unit
or
make -C test/webserv/unit/cgi_manager run
```

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - CGIレスポンスを処理するための新しいメソッド `SetCgiResponse` が追加されました。
  - サーバーがCGIリクエストを管理するための新しいメソッド群が追加されました。
  - 新しい構造体 `CgiResult` が導入され、HTTP結果に関連情報が追加されました。

- **バグ修正**
  - `CgiManager` におけるメモリ割り当てのエラーハンドリングが改善されました。

- **リファクタリング**
  - サーバーのイベント処理が改善され、読み取りおよび書き込みイベントの処理が新しいメソッドに分割されました。

- **テスト**
  - テストケースにコメントが追加され、各アサーションの関連性が明確になりました。
  - 新しいCGIリクエストをテストするためのテスト関数が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->