### PR TITLE
[update] integration testを追加

### DIFF
--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -147,15 +147,17 @@ def test_get_405_01():
 def test_get_501_01():
     send_request_and_assert_response("test/common/request/get/5xx/501_01_not_exist_method.txt", not_implemented_response)
 
-def test_webserv():
-    try:
-        test_get_root_close_200()
-        test_get_root_keep_200()
-        test_get_sub_close_200()
-        test_get_404()
-        test_get_405()
-    except Exception as e:
-        print(f"Test failed: {e}")
+
+# >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+# def test_webserv():
+#     try:
+#         test_get_root_close_200()
+#         test_get_root_keep_200()
+#         test_get_sub_close_200()
+#         test_get_404()
+#         test_get_405()
+#     except Exception as e:
+#         print(f"Test failed: {e}")
 
 
 # def test1():
@@ -198,5 +200,7 @@ def test_webserv():
 #     # assert
 
 
-if __name__ == "__main__":
-    test_webserv()
+# if __name__ == "__main__":
+#     test_webserv()
+
+# <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -47,11 +47,13 @@ root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
 not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
+not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {sub_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_get_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
 def test_get_root_close_200():
     expected_response = response_header_get_root_200_close + root_index_file
@@ -92,12 +94,23 @@ def test_get_404():
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
+def test_get_405():
+    expected_response = response_header_get_405.encode('utf-8') + not_allowed_file_405
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/405_01_not_allowed.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
 def test_webserv():
     try:
         test_get_root_close_200()
         test_get_root_keep_200()
         test_get_sub_close_200()
         test_get_404()
+        test_get_405()
     except Exception as e:
         print(f"Test failed: {e}")
 

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -46,12 +46,14 @@ def assert_response(response, expected_response):
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
+# bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webserv/expected_response/default_body_message/400_bad_request.txt")
 not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
 not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {sub_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+# response_header_get_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
@@ -82,6 +84,16 @@ def test_get_sub_close_200():
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert_response(response, expected_response)
+
+
+# def test_get_400():
+#     expected_response = response_header_get_400.encode('utf-8') + bad_request_file_400
+#     client_instance = client.Client(8080)
+#     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
+#     response = client_instance.SendRequestAndReceiveResponse(request)
+#     assert (
+#         response.encode('utf-8') == expected_response
+#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_404():

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -46,14 +46,14 @@ def assert_response(response, expected_response):
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
-# bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webserv/expected_response/default_body_message/400_bad_request.txt")
+bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webserv/expected_response/default_body_message/400_bad_request.txt")
 not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
 not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {sub_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
-# response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
@@ -90,6 +90,106 @@ def test_get_sub_close_200():
 #     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
+#     response = client_instance.SendRequestAndReceiveResponse(request)
+#     assert (
+#         response.encode('utf-8') == expected_response
+#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_02():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_02_lower_method.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_03():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_03_no_ascii_method.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_04():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_04_no_root.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_05():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_05_relative_path.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_06():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_06_lower_http_version.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_07():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_07_wrong_http_name.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_08():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_08_wrong_http_version.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+# def test_get_400_09():
+#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+#     client_instance = client.Client(8080)
+#     request, _ = read_file_binary("test/common/request/get/4xx/400_09_no_host.txt")
+#     response = client_instance.SendRequestAndReceiveResponse(request)
+#     assert (
+#         response.encode('utf-8') == expected_response
+#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def test_get_400_10():
+    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/400_10_duplicate_host.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+# def test_get_400_11():
+#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+#     client_instance = client.Client(8080)
+#     request, _ = read_file_binary("test/common/request/get/4xx/400_11_no_header_field_colon.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
 #     assert (
 #         response.encode('utf-8') == expected_response

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -56,6 +56,7 @@ sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webserv/expected_response/default_body_message/400_bad_request.txt")
 not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
 not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
+timeout_file_408, timeout_file_408_length = read_file_binary("test/webserv/expected_response/default_body_message/408_timeout.txt")
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
@@ -63,10 +64,12 @@ response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nCo
 response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_408 = f"HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: {timeout_file_408_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
 bad_request_response = response_header_400 + bad_request_file_400.decode('utf-8')
 not_found_response = response_header_404 + not_found_file_404.decode('utf-8')
 not_allowed_response = response_header_405 + not_allowed_file_405.decode('utf-8')
+timeout_response = response_header_408 + timeout_file_408.decode('utf-8')
 
 def test_get_root_close_200():
     send_request_and_assert_response(
@@ -135,6 +138,8 @@ def test_get_404_01():
 def test_get_405_01():
     send_request_and_assert_response("test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response)
 
+# def test_get_408_01():
+#     send_request_and_assert_response("test/common/request/get/4xx/408_01_no_crlf.txt", timeout_response)
 
 def test_webserv():
     try:

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -74,20 +74,23 @@ not_allowed_response = response_header_405 + not_allowed_file_405.decode('utf-8'
 timeout_response = response_header_408 + timeout_file_408.decode('utf-8')
 not_implemented_response = response_header_501 + not_implemented_file_501.decode('utf-8')
 
-def test_get_root_close_200():
+def test_get_200_01():
     send_request_and_assert_response(
         "test/common/request/get/2xx/200_01_connection_close.txt",
         response_header_get_root_200_close + root_index_file
                                      )
 
 
-def test_get_root_keep_200():
+def test_get_200_02():
     send_request_and_assert_response("test/common/request/get/2xx/200_02_connection_keep.txt", response_header_get_root_200_keep + root_index_file)
 
 
-def test_get_sub_close_200():
+def test_get_200_03():
     send_request_and_assert_response("test/common/request/get/2xx/200_03_sub_connection_close.txt", response_header_get_sub_200_close + sub_index_file)
 
+
+# def test_get_200_04():
+#     send_request_and_assert_response("test/common/request/get/2xx/200_04_connection_keep_alive_and_200_connection_keep_alive.txt", response_header_get_root_200_keep + root_index_file)
 
 # def test_get_400_01():
 #   send_request_and_assert_response("test/common/request/get/4xx/400_01_only_crlf.txt", bad_request_response)

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+import pytest
+
 
 def build_client_module():
     # client_module ディレクトリに移動
@@ -53,21 +55,28 @@ def send_request_and_assert_response(request_file, expected_response):
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
-bad_request_file_400, bad_request_file_400_length = read_file_binary(
-    "test/webserv/expected_response/default_body_message/400_bad_request.txt"
-)
-not_found_file_404, not_found_file_404_length = read_file_binary(
-    "test/webserv/expected_response/default_body_message/404_not_found.txt"
-)
-not_allowed_file_405, not_allowed_file_405_length = read_file_binary(
-    "test/webserv/expected_response/default_body_message/405_method_not_allowed.txt"
-)
-timeout_file_408, timeout_file_408_length = read_file_binary(
-    "test/webserv/expected_response/default_body_message/408_timeout.txt"
-)
-not_implemented_file_501, not_implemented_file_501_length = read_file_binary(
-    "test/webserv/expected_response/default_body_message/501_not_implemented.txt"
-)
+error_files = [
+    ("400_bad_request.txt", "bad_request_file_400", "bad_request_file_400_length"),
+    ("404_not_found.txt", "not_found_file_404", "not_found_file_404_length"),
+    (
+        "405_method_not_allowed.txt",
+        "not_allowed_file_405",
+        "not_allowed_file_405_length",
+    ),
+    ("408_timeout.txt", "timeout_file_408", "timeout_file_408_length"),
+    (
+        "501_not_implemented.txt",
+        "not_implemented_file_501",
+        "not_implemented_file_501_length",
+    ),
+]
+
+for filename, data_var, length_var in error_files:
+    data, length = read_file_binary(
+        f"test/webserv/expected_response/default_body_message/{filename}"
+    )
+    globals()[data_var] = data
+    globals()[length_var] = length
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
@@ -87,113 +96,51 @@ not_implemented_response = response_header_501 + not_implemented_file_501.decode
 )
 
 
-def test_get_200_01():
-    send_request_and_assert_response(
-        "test/common/request/get/2xx/200_01_connection_close.txt",
-        response_header_get_root_200_close + root_index_file,
-    )
-
-
-def test_get_200_02():
-    send_request_and_assert_response(
-        "test/common/request/get/2xx/200_02_connection_keep.txt",
-        response_header_get_root_200_keep + root_index_file,
-    )
-
-
-def test_get_200_03():
-    send_request_and_assert_response(
-        "test/common/request/get/2xx/200_03_sub_connection_close.txt",
-        response_header_get_sub_200_close + sub_index_file,
-    )
-
-
-# def test_get_200_04():
-#     send_request_and_assert_response("test/common/request/get/2xx/200_04_connection_keep_alive_and_200_connection_keep_alive.txt", response_header_get_root_200_keep + root_index_file)
-
-# def test_get_400_01():
-#   send_request_and_assert_response("test/common/request/get/4xx/400_01_only_crlf.txt", bad_request_response)
-
-
-def test_get_400_02():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_02_lower_method.txt", bad_request_response
-    )
-
-
-def test_get_400_03():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_03_no_ascii_method.txt", bad_request_response
-    )
-
-
-def test_get_400_04():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_04_no_root.txt", bad_request_response
-    )
-
-
-def test_get_400_05():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_05_relative_path.txt", bad_request_response
-    )
-
-
-def test_get_400_06():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_06_lower_http_version.txt",
-        bad_request_response,
-    )
-
-
-def test_get_400_07():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_07_wrong_http_name.txt", bad_request_response
-    )
-
-
-def test_get_400_08():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_08_wrong_http_version.txt",
-        bad_request_response,
-    )
-
-
-# def test_get_400_09():
-#    send_request_and_assert_response("test/common/request/get/4xx/400_09_no_host.txt", bad_request_response)
-
-
-def test_get_400_10():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/400_10_duplicate_host.txt", bad_request_response
-    )
-
-
-# def test_get_400_11():
-#     send_request_and_assert_response("test/common/request/get/4xx/400_11_no_header_field_colon.txt", bad_request_response)
-
-
-def test_get_404_01():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/404_01_not_exist_path.txt", not_found_response
-    )
-
-
-def test_get_405_01():
-    send_request_and_assert_response(
-        "test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response
-    )
-
-
-# def test_get_408_01():
-#     send_request_and_assert_response("test/common/request/get/4xx/408_01_no_crlf.txt", timeout_response)
-
-
-def test_get_501_01():
-    send_request_and_assert_response(
-        "test/common/request/get/5xx/501_01_not_exist_method.txt",
-        not_implemented_response,
-    )
+@pytest.mark.parametrize(
+    "request_file, expected_response",
+    [
+        (
+            "test/common/request/get/2xx/200_01_connection_close.txt",
+            response_header_get_root_200_close + root_index_file,
+        ),
+        (
+            "test/common/request/get/2xx/200_02_connection_keep.txt",
+            response_header_get_root_200_keep + root_index_file,
+        ),
+        (
+            "test/common/request/get/2xx/200_03_sub_connection_close.txt",
+            response_header_get_sub_200_close + sub_index_file,
+        ),
+        ("test/common/request/get/4xx/400_02_lower_method.txt", bad_request_response),
+        (
+            "test/common/request/get/4xx/400_03_no_ascii_method.txt",
+            bad_request_response,
+        ),
+        ("test/common/request/get/4xx/400_04_no_root.txt", bad_request_response),
+        ("test/common/request/get/4xx/400_05_relative_path.txt", bad_request_response),
+        (
+            "test/common/request/get/4xx/400_06_lower_http_version.txt",
+            bad_request_response,
+        ),
+        (
+            "test/common/request/get/4xx/400_07_wrong_http_name.txt",
+            bad_request_response,
+        ),
+        (
+            "test/common/request/get/4xx/400_08_wrong_http_version.txt",
+            bad_request_response,
+        ),
+        ("test/common/request/get/4xx/400_10_duplicate_host.txt", bad_request_response),
+        ("test/common/request/get/4xx/404_01_not_exist_path.txt", not_found_response),
+        ("test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response),
+        (
+            "test/common/request/get/5xx/501_01_not_exist_method.txt",
+            not_implemented_response,
+        ),
+    ],
+)
+def test_get_responses(request_file, expected_response):
+    send_request_and_assert_response(request_file, expected_response)
 
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -43,6 +43,13 @@ def assert_response(response, expected_response):
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
+def send_request_and_assert_response(request_file, expected_response):
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary(request_file)
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert_response(response, expected_response)
+
+
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
@@ -57,167 +64,76 @@ response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent
 response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
-bad_request_response = response_header_400.encode('utf-8') + bad_request_file_400
-not_found_response = response_header_404.encode('utf-8') + not_found_file_404
-not_allowed_response = response_header_405.encode('utf-8') + not_allowed_file_405
+bad_request_response = response_header_400 + bad_request_file_400.decode('utf-8')
+not_found_response = response_header_404 + not_found_file_404.decode('utf-8')
+not_allowed_response = response_header_405 + not_allowed_file_405.decode('utf-8')
 
 def test_get_root_close_200():
-    expected_response = response_header_get_root_200_close + root_index_file
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary(
-        "test/common/request/get/2xx/200_01_connection_close.txt"
-    )
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert_response(response, expected_response)
+    send_request_and_assert_response(
+        "test/common/request/get/2xx/200_01_connection_close.txt",
+        response_header_get_root_200_close + root_index_file
+                                     )
 
 
 def test_get_root_keep_200():
-    expected_response = response_header_get_root_200_keep + root_index_file
-    # responseヘッダーもkeepaliveになる？
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/2xx/200_02_connection_keep.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert_response(response, expected_response)
+    send_request_and_assert_response("test/common/request/get/2xx/200_02_connection_keep.txt", response_header_get_root_200_keep + root_index_file)
 
 
 def test_get_sub_close_200():
-    expected_response = response_header_get_sub_200_close + sub_index_file
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary(
-        "test/common/request/get/2xx/200_03_sub_connection_close.txt"
-    )
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert_response(response, expected_response)
+    send_request_and_assert_response("test/common/request/get/2xx/200_03_sub_connection_close.txt", response_header_get_sub_200_close + sub_index_file)
 
 
 # def test_get_400_01():
-#     expected_response = bad_request_response.decode('utf-8')
-#     client_instance = client.Client(8080)
-#     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
-#     response = client_instance.SendRequestAndReceiveResponse(request)
-#     assert (
-#         response == expected_response
-#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+#   send_request_and_assert_response("test/common/request/get/4xx/400_01_only_crlf.txt", bad_request_response)
 
 
 def test_get_400_02():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_02_lower_method.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_02_lower_method.txt", bad_request_response)
+
 
 
 def test_get_400_03():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_03_no_ascii_method.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_03_no_ascii_method.txt", bad_request_response)
 
 
 def test_get_400_04():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_04_no_root.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_04_no_root.txt", bad_request_response)
 
 
 def test_get_400_05():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_05_relative_path.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_05_relative_path.txt", bad_request_response)
 
 
 def test_get_400_06():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_06_lower_http_version.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_06_lower_http_version.txt", bad_request_response)
 
 
 def test_get_400_07():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_07_wrong_http_name.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_07_wrong_http_name.txt", bad_request_response)
 
 
 def test_get_400_08():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_08_wrong_http_version.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_08_wrong_http_version.txt", bad_request_response)
 
 
 # def test_get_400_09():
-#     expected_response = bad_request_response.decode('utf-8')
-#     client_instance = client.Client(8080)
-#     request, _ = read_file_binary("test/common/request/get/4xx/400_09_no_host.txt")
-#     response = client_instance.SendRequestAndReceiveResponse(request)
-#     assert (
-#         response == expected_response
-#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+#    send_request_and_assert_response("test/common/request/get/4xx/400_09_no_host.txt", bad_request_response)
 
 
 def test_get_400_10():
-    expected_response = bad_request_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/400_10_duplicate_host.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/400_10_duplicate_host.txt", bad_request_response)
 
 
 # def test_get_400_11():
-#     expected_response = bad_request_response.decode('utf-8')
-#     client_instance = client.Client(8080)
-#     request, _ = read_file_binary("test/common/request/get/4xx/400_11_no_header_field_colon.txt")
-#     response = client_instance.SendRequestAndReceiveResponse(request)
-#     assert (
-#         response == expected_response
-#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+#     send_request_and_assert_response("test/common/request/get/4xx/400_11_no_header_field_colon.txt", bad_request_response)
 
 
 def test_get_404_01():
-    expected_response = not_found_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/404_01_not_exist_path.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/404_01_not_exist_path.txt", not_found_response)
 
 
 def test_get_405_01():
-    expected_response = not_allowed_response.decode('utf-8')
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary("test/common/request/get/4xx/405_01_not_allowed.txt")
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+    send_request_and_assert_response("test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response)
 
 
 def test_webserv():

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -33,7 +33,8 @@ def read_file(file):
 # \r\nをそのまま読み込む用(ヘッダー部分)
 def read_file_binary(file):
     with open(file, "rb") as f:
-        return f.read()
+        data = f.read()
+    return data, len(data)
 
 
 def assert_response(response, expected_response):
@@ -45,15 +46,17 @@ def assert_response(response, expected_response):
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
+not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
+
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {sub_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
-
+response_header_get_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
 def test_get_root_close_200():
     expected_response = response_header_get_root_200_close + root_index_file
     client_instance = client.Client(8080)
-    request = read_file_binary(
+    request, _ = read_file_binary(
         "test/common/request/get/2xx/200_01_connection_close.txt"
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -64,7 +67,7 @@ def test_get_root_keep_200():
     expected_response = response_header_get_root_200_keep + root_index_file
     # responseヘッダーもkeepaliveになる？
     client_instance = client.Client(8080)
-    request = read_file_binary("test/common/request/get/2xx/200_02_connection_keep.txt")
+    request, _ = read_file_binary("test/common/request/get/2xx/200_02_connection_keep.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert_response(response, expected_response)
 
@@ -72,21 +75,21 @@ def test_get_root_keep_200():
 def test_get_sub_close_200():
     expected_response = response_header_get_sub_200_close + sub_index_file
     client_instance = client.Client(8080)
-    request = read_file_binary(
+    request, _ = read_file_binary(
         "test/common/request/get/2xx/200_03_sub_connection_close.txt"
     )
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert_response(response, expected_response)
 
 
-# def test_get_404():
-#     expected_response = response_header_get_404 + read_file("../../html/sub/index.html")
-#     client_instance = client.Client(8080)
-#     request = read_file_binary("../request_messages/webserv/get/404_not-exist-path_connection-close.txt")
-#     response = client_instance.SendRequestAndReceiveResponse(request)
-#     assert (
-#         response == expected_response
-#     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+def test_get_404():
+    expected_response = response_header_get_404.encode('utf-8') + not_found_file_404
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary("test/common/request/get/4xx/404_01_not_exist_path.txt")
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert (
+        response.encode('utf-8') == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_webserv():
@@ -94,7 +97,7 @@ def test_webserv():
         test_get_root_close_200()
         test_get_root_keep_200()
         test_get_sub_close_200()
-        # test_get_404()
+        test_get_404()
     except Exception as e:
         print(f"Test failed: {e}")
 

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -53,11 +53,21 @@ def send_request_and_assert_response(request_file, expected_response):
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
-bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webserv/expected_response/default_body_message/400_bad_request.txt")
-not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
-not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
-timeout_file_408, timeout_file_408_length = read_file_binary("test/webserv/expected_response/default_body_message/408_timeout.txt")
-not_implemented_file_501, not_implemented_file_501_length = read_file_binary("test/webserv/expected_response/default_body_message/501_not_implemented.txt")
+bad_request_file_400, bad_request_file_400_length = read_file_binary(
+    "test/webserv/expected_response/default_body_message/400_bad_request.txt"
+)
+not_found_file_404, not_found_file_404_length = read_file_binary(
+    "test/webserv/expected_response/default_body_message/404_not_found.txt"
+)
+not_allowed_file_405, not_allowed_file_405_length = read_file_binary(
+    "test/webserv/expected_response/default_body_message/405_method_not_allowed.txt"
+)
+timeout_file_408, timeout_file_408_length = read_file_binary(
+    "test/webserv/expected_response/default_body_message/408_timeout.txt"
+)
+not_implemented_file_501, not_implemented_file_501_length = read_file_binary(
+    "test/webserv/expected_response/default_body_message/501_not_implemented.txt"
+)
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
@@ -68,25 +78,34 @@ response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n
 response_header_408 = f"HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: {timeout_file_408_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_501 = f"HTTP/1.1 501 Not Implemented\r\nConnection: close\r\nContent-Length: {not_implemented_file_501_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
-bad_request_response = response_header_400 + bad_request_file_400.decode('utf-8')
-not_found_response = response_header_404 + not_found_file_404.decode('utf-8')
-not_allowed_response = response_header_405 + not_allowed_file_405.decode('utf-8')
-timeout_response = response_header_408 + timeout_file_408.decode('utf-8')
-not_implemented_response = response_header_501 + not_implemented_file_501.decode('utf-8')
+bad_request_response = response_header_400 + bad_request_file_400.decode("utf-8")
+not_found_response = response_header_404 + not_found_file_404.decode("utf-8")
+not_allowed_response = response_header_405 + not_allowed_file_405.decode("utf-8")
+timeout_response = response_header_408 + timeout_file_408.decode("utf-8")
+not_implemented_response = response_header_501 + not_implemented_file_501.decode(
+    "utf-8"
+)
+
 
 def test_get_200_01():
     send_request_and_assert_response(
         "test/common/request/get/2xx/200_01_connection_close.txt",
-        response_header_get_root_200_close + root_index_file
-                                     )
+        response_header_get_root_200_close + root_index_file,
+    )
 
 
 def test_get_200_02():
-    send_request_and_assert_response("test/common/request/get/2xx/200_02_connection_keep.txt", response_header_get_root_200_keep + root_index_file)
+    send_request_and_assert_response(
+        "test/common/request/get/2xx/200_02_connection_keep.txt",
+        response_header_get_root_200_keep + root_index_file,
+    )
 
 
 def test_get_200_03():
-    send_request_and_assert_response("test/common/request/get/2xx/200_03_sub_connection_close.txt", response_header_get_sub_200_close + sub_index_file)
+    send_request_and_assert_response(
+        "test/common/request/get/2xx/200_03_sub_connection_close.txt",
+        response_header_get_sub_200_close + sub_index_file,
+    )
 
 
 # def test_get_200_04():
@@ -97,32 +116,47 @@ def test_get_200_03():
 
 
 def test_get_400_02():
-    send_request_and_assert_response("test/common/request/get/4xx/400_02_lower_method.txt", bad_request_response)
-
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_02_lower_method.txt", bad_request_response
+    )
 
 
 def test_get_400_03():
-    send_request_and_assert_response("test/common/request/get/4xx/400_03_no_ascii_method.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_03_no_ascii_method.txt", bad_request_response
+    )
 
 
 def test_get_400_04():
-    send_request_and_assert_response("test/common/request/get/4xx/400_04_no_root.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_04_no_root.txt", bad_request_response
+    )
 
 
 def test_get_400_05():
-    send_request_and_assert_response("test/common/request/get/4xx/400_05_relative_path.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_05_relative_path.txt", bad_request_response
+    )
 
 
 def test_get_400_06():
-    send_request_and_assert_response("test/common/request/get/4xx/400_06_lower_http_version.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_06_lower_http_version.txt",
+        bad_request_response,
+    )
 
 
 def test_get_400_07():
-    send_request_and_assert_response("test/common/request/get/4xx/400_07_wrong_http_name.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_07_wrong_http_name.txt", bad_request_response
+    )
 
 
 def test_get_400_08():
-    send_request_and_assert_response("test/common/request/get/4xx/400_08_wrong_http_version.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_08_wrong_http_version.txt",
+        bad_request_response,
+    )
 
 
 # def test_get_400_09():
@@ -130,7 +164,9 @@ def test_get_400_08():
 
 
 def test_get_400_10():
-    send_request_and_assert_response("test/common/request/get/4xx/400_10_duplicate_host.txt", bad_request_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/400_10_duplicate_host.txt", bad_request_response
+    )
 
 
 # def test_get_400_11():
@@ -138,17 +174,26 @@ def test_get_400_10():
 
 
 def test_get_404_01():
-    send_request_and_assert_response("test/common/request/get/4xx/404_01_not_exist_path.txt", not_found_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/404_01_not_exist_path.txt", not_found_response
+    )
 
 
 def test_get_405_01():
-    send_request_and_assert_response("test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response)
+    send_request_and_assert_response(
+        "test/common/request/get/4xx/405_01_not_allowed.txt", not_allowed_response
+    )
+
 
 # def test_get_408_01():
 #     send_request_and_assert_response("test/common/request/get/4xx/408_01_no_crlf.txt", timeout_response)
 
+
 def test_get_501_01():
-    send_request_and_assert_response("test/common/request/get/5xx/501_01_not_exist_method.txt", not_implemented_response)
+    send_request_and_assert_response(
+        "test/common/request/get/5xx/501_01_not_exist_method.txt",
+        not_implemented_response,
+    )
 
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -57,6 +57,7 @@ bad_request_file_400, bad_request_file_400_length = read_file_binary("test/webse
 not_found_file_404, not_found_file_404_length = read_file_binary("test/webserv/expected_response/default_body_message/404_not_found.txt")
 not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webserv/expected_response/default_body_message/405_method_not_allowed.txt")
 timeout_file_408, timeout_file_408_length = read_file_binary("test/webserv/expected_response/default_body_message/408_timeout.txt")
+not_implemented_file_501, not_implemented_file_501_length = read_file_binary("test/webserv/expected_response/default_body_message/501_not_implemented.txt")
 
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
@@ -65,11 +66,13 @@ response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent
 response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_408 = f"HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: {timeout_file_408_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_501 = f"HTTP/1.1 501 Not Implemented\r\nConnection: close\r\nContent-Length: {not_implemented_file_501_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
 bad_request_response = response_header_400 + bad_request_file_400.decode('utf-8')
 not_found_response = response_header_404 + not_found_file_404.decode('utf-8')
 not_allowed_response = response_header_405 + not_allowed_file_405.decode('utf-8')
 timeout_response = response_header_408 + timeout_file_408.decode('utf-8')
+not_implemented_response = response_header_501 + not_implemented_file_501.decode('utf-8')
 
 def test_get_root_close_200():
     send_request_and_assert_response(
@@ -140,6 +143,9 @@ def test_get_405_01():
 
 # def test_get_408_01():
 #     send_request_and_assert_response("test/common/request/get/4xx/408_01_no_crlf.txt", timeout_response)
+
+def test_get_501_01():
+    send_request_and_assert_response("test/common/request/get/5xx/501_01_not_exist_method.txt", not_implemented_response)
 
 def test_webserv():
     try:

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -53,9 +53,9 @@ not_allowed_file_405, not_allowed_file_405_length = read_file_binary("test/webse
 response_header_get_root_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_root_200_keep = f"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {root_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_get_sub_200_close = f"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {sub_index_file_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
-# response_header_get_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
-response_header_get_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
-response_header_get_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+# response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: {bad_request_file_400_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
+response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
 def test_get_root_close_200():
     expected_response = response_header_get_root_200_close + root_index_file
@@ -86,8 +86,8 @@ def test_get_sub_close_200():
     assert_response(response, expected_response)
 
 
-# def test_get_400():
-#     expected_response = response_header_get_400.encode('utf-8') + bad_request_file_400
+# def test_get_400_01():
+#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -96,8 +96,8 @@ def test_get_sub_close_200():
 #     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
-def test_get_404():
-    expected_response = response_header_get_404.encode('utf-8') + not_found_file_404
+def test_get_404_01():
+    expected_response = response_header_404.encode('utf-8') + not_found_file_404
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/404_01_not_exist_path.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -106,8 +106,8 @@ def test_get_404():
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
-def test_get_405():
-    expected_response = response_header_get_405.encode('utf-8') + not_allowed_file_405
+def test_get_405_01():
+    expected_response = response_header_405.encode('utf-8') + not_allowed_file_405
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/405_01_not_allowed.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -91,132 +91,132 @@ def test_get_sub_close_200():
 
 
 # def test_get_400_01():
-#     expected_response = bad_request_response
+#     expected_response = bad_request_response.decode('utf-8')
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
 #     assert (
-#         response.encode('utf-8') == expected_response
+#         response == expected_response
 #     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_02():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_02_lower_method.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_03():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_03_no_ascii_method.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_04():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_04_no_root.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_05():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_05_relative_path.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_06():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_06_lower_http_version.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_07():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_07_wrong_http_name.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_08():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_08_wrong_http_version.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 # def test_get_400_09():
-#     expected_response = bad_request_response
+#     expected_response = bad_request_response.decode('utf-8')
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_09_no_host.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
 #     assert (
-#         response.encode('utf-8') == expected_response
+#         response == expected_response
 #     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_400_10():
-    expected_response = bad_request_response
+    expected_response = bad_request_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_10_duplicate_host.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 # def test_get_400_11():
-#     expected_response = bad_request_response
+#     expected_response = bad_request_response.decode('utf-8')
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_11_no_header_field_colon.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
 #     assert (
-#         response.encode('utf-8') == expected_response
+#         response == expected_response
 #     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_404_01():
-    expected_response = not_found_response
+    expected_response = not_found_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/404_01_not_exist_path.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 
 def test_get_405_01():
-    expected_response = not_allowed_response
+    expected_response = not_allowed_response.decode('utf-8')
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/405_01_not_allowed.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert (
-        response.encode('utf-8') == expected_response
+        response == expected_response
     ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
 
 

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -57,6 +57,10 @@ response_header_400 = f"HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent
 response_header_404 = f"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: {not_found_file_404_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 response_header_405 = f"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: {not_allowed_file_405_length}\r\nContent-Type: text/html\r\nServer: webserv/1.1\r\n\r\n"
 
+bad_request_response = response_header_400.encode('utf-8') + bad_request_file_400
+not_found_response = response_header_404.encode('utf-8') + not_found_file_404
+not_allowed_response = response_header_405.encode('utf-8') + not_allowed_file_405
+
 def test_get_root_close_200():
     expected_response = response_header_get_root_200_close + root_index_file
     client_instance = client.Client(8080)
@@ -87,7 +91,7 @@ def test_get_sub_close_200():
 
 
 # def test_get_400_01():
-#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+#     expected_response = bad_request_response
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_01_only_crlf.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -97,7 +101,7 @@ def test_get_sub_close_200():
 
 
 def test_get_400_02():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_02_lower_method.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -107,7 +111,7 @@ def test_get_400_02():
 
 
 def test_get_400_03():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_03_no_ascii_method.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -117,7 +121,7 @@ def test_get_400_03():
 
 
 def test_get_400_04():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_04_no_root.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -127,7 +131,7 @@ def test_get_400_04():
 
 
 def test_get_400_05():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_05_relative_path.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -137,7 +141,7 @@ def test_get_400_05():
 
 
 def test_get_400_06():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_06_lower_http_version.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -147,7 +151,7 @@ def test_get_400_06():
 
 
 def test_get_400_07():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_07_wrong_http_name.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -157,7 +161,7 @@ def test_get_400_07():
 
 
 def test_get_400_08():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_08_wrong_http_version.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -167,7 +171,7 @@ def test_get_400_08():
 
 
 # def test_get_400_09():
-#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+#     expected_response = bad_request_response
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_09_no_host.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -177,7 +181,7 @@ def test_get_400_08():
 
 
 def test_get_400_10():
-    expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+    expected_response = bad_request_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/400_10_duplicate_host.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -187,7 +191,7 @@ def test_get_400_10():
 
 
 # def test_get_400_11():
-#     expected_response = response_header_400.encode('utf-8') + bad_request_file_400
+#     expected_response = bad_request_response
 #     client_instance = client.Client(8080)
 #     request, _ = read_file_binary("test/common/request/get/4xx/400_11_no_header_field_colon.txt")
 #     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -197,7 +201,7 @@ def test_get_400_10():
 
 
 def test_get_404_01():
-    expected_response = response_header_404.encode('utf-8') + not_found_file_404
+    expected_response = not_found_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/404_01_not_exist_path.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)
@@ -207,7 +211,7 @@ def test_get_404_01():
 
 
 def test_get_405_01():
-    expected_response = response_header_405.encode('utf-8') + not_allowed_file_405
+    expected_response = not_allowed_response
     client_instance = client.Client(8080)
     request, _ = read_file_binary("test/common/request/get/4xx/405_01_not_allowed.txt")
     response = client_instance.SendRequestAndReceiveResponse(request)


### PR DESCRIPTION
## test_integration.pyの関数を追加しました

- 関数のテストファイルの名称と揃えるように関数名を`test_get_4xx_xx`のようにしました
- ファイル追加と共に順次追加していく予定です
- 通っていないものはコメントアウトしています

作ってて気づいたのですが、index等のgetしたファイルはbinaryで読み込んだ状態ではないContent-Lengthを返し、デフォルトのメッセージ場合はbinaryで読み込んだContent-Lengthを返しているようです。
(コードの中を見るとindexファイルはread_fileを使っていますが、error_fileはread_file_binaryしているのがわかるかと思います)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - HTTPレスポンスのテストを強化するための新しいヘルパー関数を追加。
  - 様々なHTTPレスポンスシナリオ（200、400、404、405、501）をカバーする追加のテストケースを実装。

- **バグ修正**
  - レスポンスヘッダーに正しい`Content-Length`を含めるためのファイル読み込み機能を更新。

- **ドキュメント**
  - テストスイートの構造を改善し、モジュール性と再利用性に焦点を当てました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->