### PR TITLE
[fix] connection: keep-alive で 2 個目の request が返らない 

### DIFF
--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -185,9 +185,9 @@ void Server::HandleExistingConnection(const event::Event &event) {
 	if (event.type & event::EVENT_WRITE) {
 		HandleWriteEvent(event.fd);
 	}
-	// Call RunHttp() if request_buf contains data, even without a read event.
+	// Call RunHttpAndCgi() if request_buf contains data, even without a read event.
 	if (IsHttpRequestBufExist(event.fd)) {
-		RunHttp(event);
+		RunHttpAndCgi(event);
 	}
 }
 
@@ -235,7 +235,7 @@ bool Server::IsHttpRequestBufExist(int fd) const {
 	return !message_manager_.GetRequestBuf(fd).empty();
 }
 
-void Server::RunHttp(const event::Event &event) {
+void Server::RunHttpAndCgi(const event::Event &event) {
 	const int client_fd = event.fd;
 
 	// Prepare to http.Run()

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -47,7 +47,7 @@ class Server {
 	void      HandleReadEvent(const event::Event &event);
 	void      HandleHttpReadResult(const event::Event &event, const Read::ReadResult &read_result);
 	bool      IsHttpRequestBufExist(int fd) const;
-	void      RunHttp(const event::Event &event);
+	void      RunHttpAndCgi(const event::Event &event);
 	void      HandleWriteEvent(int fd);
 	void      SendHttpResponse(int client_fd);
 	void      HandleTimeoutMessages();

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -46,6 +46,7 @@ class Server {
 	void      HandleExistingConnection(const event::Event &event);
 	void      HandleReadEvent(const event::Event &event);
 	void      HandleHttpReadResult(const event::Event &event, const Read::ReadResult &read_result);
+	bool      IsHttpRequestBufExist(int fd) const;
 	void      RunHttp(const event::Event &event);
 	void      HandleWriteEvent(int fd);
 	void      SendHttpResponse(int client_fd);


### PR DESCRIPTION
### 問題点
1 つの client から `Connection: keep-alive` の request の後に続いて次の request が来た時、1 個目の response は返り、2 個目以降の response が返らず通信が切れてしまっていた

### 原因
read event が発生し `Read()` した直後にだけ `http.Run()` を呼んでいたが、1 回分以上の request が 1 回の `Read()` で読み込まれ、以降 read event が発生しない場合、2 個目以降の request を Http に渡せていなかった


### 修正点
read event の発生に関わらず、`request_buf` がまだある場合は `http.Run()` を呼び、渡すようにした

### 実行
commit を 1 つ戻ってもらうと以下の実行が即終了していたことが確認でき、
この PR では 2 回、200 OK response が返った後、timeout するのが確認できると思います
```sh
# server
make run

# client
make -C test/common/client run PORT=8080 INFILE_PATH=../request/get/2xx/200_04_connection_keep_alive_and_200_connection_keep_alive.txt
```

(ちなみに #514 の integration test をローカルでここに merge して動かしてみて ok でした)

timeout の integration test どうすれば良いんでしょう…追加しておらず🙏


<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - HTTPリクエストバッファの存在を確認する新しい機能を追加しました。これにより、リクエストバッファが存在する場合にのみHTTPリクエストを処理できるようになります。
  - `RunHttp` メソッドが `RunHttpAndCgi` に名称変更され、HTTPリクエストとCGI処理の両方を扱えるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->