### PR TITLE
[update] chunked request で終端を待つように

### DIFF
--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -375,7 +375,7 @@ int main(void) {
 
 	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
 	http::HttpRequestParsedData test7_body_message;
-	test7_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test7_body_message.request_result.status_code = http::StatusCode(http::OK);
 	test7_body_message.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
 	test7_body_message.is_request_format.is_request_line   = true;
@@ -405,7 +405,7 @@ int main(void) {
 
 	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
 	http::HttpRequestParsedData test10_body_message;
-	test10_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test10_body_message.request_result.status_code = http::StatusCode(http::OK);
 	test10_body_message.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
 	test10_body_message.is_request_format.is_request_line   = true;


### PR DESCRIPTION
## Chunked Requestで終端を待つようにしました

少しだけ処理を追加してChunked Requestで`0\r\n\r\n`を待つようにしました
keep-aliveでのテストの方法はわかりませんでした(chunked requestを分けて送る方法)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- チャンクHTTPリクエストの処理を改善し、無効なリクエストに対するエラーハンドリングを強化しました。
	- テストケースの期待されるステータスコードを修正し、リクエストが成功した場合の処理を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->