### PR TITLE
[implement] CgiResponseからHttpResponseを取得する部分を実装

### DIFF
--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -26,11 +26,16 @@ Http::Run(const ClientInfos &client_info, const server::VirtualServerAddrList &s
 	return result;
 }
 
-// todo
 HttpResult Http::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response) {
-	(void)client_fd;
-	(void)cgi_response;
-	return HttpResult();
+	HttpResult            result;
+	HttpRequestParsedData data = storage_.GetClientSaveData(client_fd);
+	result.is_connection_keep =
+		HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
+	result.is_response_complete = true;
+	result.request_buf          = data.current_buf;
+	result.response             = ""; // todo
+	storage_.DeleteClientSaveData(client_fd);
+	return result;
 }
 
 utils::Result<void> Http::ParseHttpRequestFormat(int client_fd, const std::string &read_buf) {

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -33,7 +33,8 @@ HttpResult Http::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_r
 		HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
 	result.is_response_complete = true;
 	result.request_buf          = data.current_buf;
-	result.response             = ""; // todo
+	result.response =
+		HttpResponse::GetResponseFromCgi(client_fd, cgi_response, data.request_result);
 	storage_.DeleteClientSaveData(client_fd);
 	return result;
 }

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -33,8 +33,7 @@ HttpResult Http::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_r
 		HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
 	result.is_response_complete = true;
 	result.request_buf          = data.current_buf;
-	result.response =
-		HttpResponse::GetResponseFromCgi(client_fd, cgi_response, data.request_result);
+	result.response = HttpResponse::GetResponseFromCgi(cgi_response, data.request_result);
 	storage_.DeleteClientSaveData(client_fd);
 	return result;
 }

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -184,9 +184,8 @@ std::string HttpResponse::CreateErrorResponse(const StatusCode &status_code) {
 }
 
 std::string HttpResponse::GetResponseFromCgi(
-	int client_fd, const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
+	const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
 ) {
-	(void)client_fd;
 	StatusCode  status_code(OK);
 	std::string response_body_message = cgi_response.response;
 

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -182,4 +182,18 @@ std::string HttpResponse::CreateErrorResponse(const StatusCode &status_code) {
 	return CreateHttpResponse(response);
 }
 
+std::string HttpResponse::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response) {
+	StatusCode   status_code(OK);
+	HeaderFields response_header_fields;
+	std::string  response_body_message;
+
+	HttpResponseFormat response_format(
+		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),
+		response_header_fields,
+		response_body_message
+	);
+
+	return CreateHttpResponse(response_format);
+}
+
 } // namespace http

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -1,4 +1,5 @@
 #include "http_response.hpp"
+#include "cgi.hpp"
 #include "cgi_parse.hpp"
 #include "client_infos.hpp"
 #include "http_exception.hpp"
@@ -185,6 +186,7 @@ std::string HttpResponse::CreateErrorResponse(const StatusCode &status_code) {
 std::string HttpResponse::GetResponseFromCgi(
 	int client_fd, const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
 ) {
+	(void)client_fd;
 	StatusCode  status_code(OK);
 	std::string response_body_message = cgi_response.response;
 

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -183,9 +183,14 @@ std::string HttpResponse::CreateErrorResponse(const StatusCode &status_code) {
 }
 
 std::string HttpResponse::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response) {
-	StatusCode   status_code(OK);
+	StatusCode  status_code(OK);
+	std::string response_body_message = cgi_response.response;
+
 	HeaderFields response_header_fields;
-	std::string  response_body_message;
+	response_header_fields[SERVER]         = SERVER_VERSION;
+	response_header_fields[CONTENT_TYPE]   = cgi_response.content_type;
+	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
+	// keep-alive or close
 
 	HttpResponseFormat response_format(
 		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -182,7 +182,9 @@ std::string HttpResponse::CreateErrorResponse(const StatusCode &status_code) {
 	return CreateHttpResponse(response);
 }
 
-std::string HttpResponse::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response) {
+std::string HttpResponse::GetResponseFromCgi(
+	int client_fd, const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
+) {
 	StatusCode  status_code(OK);
 	std::string response_body_message = cgi_response.response;
 
@@ -190,7 +192,11 @@ std::string HttpResponse::GetResponseFromCgi(int client_fd, const cgi::CgiRespon
 	response_header_fields[SERVER]         = SERVER_VERSION;
 	response_header_fields[CONTENT_TYPE]   = cgi_response.content_type;
 	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
-	// keep-alive or close
+	if (IsConnectionKeep(request_info.request.header_fields)) {
+		response_header_fields[CONNECTION] = KEEP_ALIVE;
+	} else {
+		response_header_fields[CONNECTION] = CLOSE;
+	} // InitResponseHeaderFields が完成したらそれを使う
 
 	HttpResponseFormat response_format(
 		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -32,6 +32,8 @@ class Stat;
 //    GetInternalServerErrorBodyMessage();
 // };
 
+#include "cgi.hpp"
+
 class HttpResponse {
   public:
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
@@ -42,6 +44,7 @@ class HttpResponse {
 	static std::string CreateErrorResponse(const StatusCode &status_code);
 	static bool        IsConnectionKeep(const HeaderFields &request_header_fields);
 	static std::string CreateDefaultBodyMessage(const StatusCode &status_code);
+	static std::string GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response);
 
   private:
 	HttpResponse();

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -44,7 +44,9 @@ class HttpResponse {
 	static std::string CreateErrorResponse(const StatusCode &status_code);
 	static bool        IsConnectionKeep(const HeaderFields &request_header_fields);
 	static std::string CreateDefaultBodyMessage(const StatusCode &status_code);
-	static std::string GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response);
+	static std::string GetResponseFromCgi(
+		int client_fd, const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
+	);
 
   private:
 	HttpResponse();

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -10,6 +10,12 @@
 #include <map>
 #include <string>
 
+namespace cgi {
+
+struct CgiResponse;
+
+}
+
 namespace http {
 
 struct HttpRequestResult;
@@ -31,8 +37,6 @@ class Stat;
 //    GetTimeoutRequestBodyMessage();
 //    GetInternalServerErrorBodyMessage();
 // };
-
-#include "cgi.hpp"
 
 class HttpResponse {
   public:

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -48,9 +48,8 @@ class HttpResponse {
 	static std::string CreateErrorResponse(const StatusCode &status_code);
 	static bool        IsConnectionKeep(const HeaderFields &request_header_fields);
 	static std::string CreateDefaultBodyMessage(const StatusCode &status_code);
-	static std::string GetResponseFromCgi(
-		int client_fd, const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info
-	);
+	static std::string
+	GetResponseFromCgi(const cgi::CgiResponse &cgi_response, const HttpRequestResult &request_info);
 
   private:
 	HttpResponse();

--- a/test/webserv/unit/http/Makefile
+++ b/test/webserv/unit/http/Makefile
@@ -19,7 +19,6 @@ WS_HTTP_PARSE_DIR		:=	$(WS_HTTP_REQUEST_DIR)/parse
 WS_HTTP_SERVER_INFO_CHECK_DIR	:=	$(WS_HTTP_RESPONSE_DIR)/http_serverinfo_check
 WS_HTTP_CGI_PARSE_DIR		:=	$(WS_HTTP_RESPONSE_DIR)/cgi_parse
 WS_VIRTUAL_SERVER_DIR			:=	$(WS_SRCS_DIR)/server/virtual_server
-WS_CGI_DIR				:=	$(WS_SRCS_DIR)/cgi
 
 SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
@@ -39,7 +38,6 @@ SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 						$(WS_HTTP_SERVER_INFO_CHECK_DIR)/http_serverinfo_check.cpp \
 						$(WS_HTTP_CGI_PARSE_DIR)/cgi_parse.cpp \
 						$(WS_VIRTUAL_SERVER_DIR)/virtual_server.cpp \
-						$(WS_CGI_DIR)/cgi_request.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_http.cpp \
@@ -55,8 +53,7 @@ SRCS_DIR	:=	$(WS_EXCEPTION_DIR) \
 				$(WS_HTTP_PARSE_DIR) \
 				$(WS_HTTP_SERVER_INFO_CHECK_DIR) \
 				$(WS_HTTP_CGI_PARSE_DIR) \
-				$(WS_VIRTUAL_SERVER_DIR) \
-				$(WS_CGI_DIR)
+				$(WS_VIRTUAL_SERVER_DIR)
 
 # 3. Add unit test files
 TEST_CASE_DIR := test_case

--- a/test/webserv/unit/http/Makefile
+++ b/test/webserv/unit/http/Makefile
@@ -63,6 +63,7 @@ TEST_CASE_FOR_GET := get
 SRCS	+=	test_http.cpp \
 			$(TEST_CASE_DIR)/test_handler.cpp \
 			$(TEST_CASE_DIR)/test_get_error_response.cpp \
+			$(TEST_CASE_DIR)/test_get_response_from_cgi.cpp \
 			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)/test_2xx.cpp \
 			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)/test_4xx.cpp \
 			$(TEST_CASE_DIR)/$(TEST_CASE_FOR_GET)/test_5xx.cpp

--- a/test/webserv/unit/http/test_case/test_case.hpp
+++ b/test/webserv/unit/http/test_case/test_case.hpp
@@ -46,6 +46,7 @@ int TestInternalServerErrorResponse();
 
 // GetResponseFromCgi
 int TestGetResponseFromCgi1();
+int TestGetResponseFromCgi2();
 
 } // namespace test
 

--- a/test/webserv/unit/http/test_case/test_case.hpp
+++ b/test/webserv/unit/http/test_case/test_case.hpp
@@ -44,6 +44,9 @@ int TestGetNotImplemented1NotExistMethod(const server::VirtualServerAddrList &se
 int TestRequestTimeoutResponse();
 int TestInternalServerErrorResponse();
 
+// GetResponseFromCgi
+int TestGetResponseFromCgi1();
+
 } // namespace test
 
 #endif

--- a/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
+++ b/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
@@ -1,0 +1,50 @@
+#include "client_infos.hpp"
+#include "http.hpp"
+#include "http_message.hpp"
+#include "http_result.hpp"
+#include "test_expected_response.hpp"
+#include "test_handler.hpp"
+#include "utils.hpp"
+#include <cstdlib>
+
+#include "cgi.hpp"
+
+namespace test {
+
+template <typename T>
+int HandleResult(const T &result, const T &expected, int number) {
+	if (result == expected) {
+		std::cout << utils::color::GREEN << number << ".[OK]" << utils::color::RESET << std::endl;
+		return EXIT_SUCCESS;
+	} else {
+		std::cerr << "Error: " << std::endl;
+		std::cerr << utils::color::RED << number << ".[NG] " << utils::color::RESET << std::endl;
+		std::cerr << "result: [" << result << "]" << std::endl;
+		std::cerr << "expected: [" << expected << "]" << std::endl;
+		return EXIT_FAILURE;
+	}
+}
+
+int TestGetResponseFromCgi1() {
+	const std::string &response = "response";
+	cgi::CgiResponse   cgi_response(response, "text/html", true);
+
+	http::HttpRequestParsedData data;
+	data.request_result.request.header_fields[http::CONNECTION]     = http::KEEP_ALIVE;
+	data.request_result.request.header_fields[http::CONTENT_TYPE]   = "text/html";
+	data.request_result.request.header_fields[http::CONTENT_LENGTH] = "8";
+
+	HeaderFields expected_header_fields;
+	expected_header_fields[http::CONNECTION]     = http::KEEP_ALIVE;
+	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(response.length());
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
+	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
+	const std::string &expected_response =
+		CreateHttpResponseFormat(EXPECTED_STATUS_LINE_OK, expected_header_fields, response);
+
+	http::Http       http;
+	http::HttpResult result = http.GetResponseFromCgi(1, cgi_response);
+	return HandleResult(result.response, expected_response, 1);
+}
+
+} // namespace test

--- a/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
+++ b/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
@@ -25,14 +25,10 @@ int HandleResult(const T &result, const T &expected, int number) {
 	}
 }
 
+/* これらのテストではHttpStorageは未使用(Parseからの一連の流れは別のテストを作成) */
 int TestGetResponseFromCgi1() {
 	const std::string &response = "response";
 	cgi::CgiResponse   cgi_response(response, "text/html", true);
-
-	http::HttpRequestParsedData data;
-	data.request_result.request.header_fields[http::CONNECTION]     = http::KEEP_ALIVE;
-	data.request_result.request.header_fields[http::CONTENT_TYPE]   = "text/html";
-	data.request_result.request.header_fields[http::CONTENT_LENGTH] = "8";
 
 	HeaderFields expected_header_fields;
 	expected_header_fields[http::CONNECTION]     = http::KEEP_ALIVE;
@@ -45,6 +41,23 @@ int TestGetResponseFromCgi1() {
 	http::Http       http;
 	http::HttpResult result = http.GetResponseFromCgi(1, cgi_response);
 	return HandleResult(result.response, expected_response, 1);
+}
+
+int TestGetResponseFromCgi2() {
+	const std::string &response = "Hello World";
+	cgi::CgiResponse   cgi_response(response, "text/plain", true);
+
+	HeaderFields expected_header_fields;
+	expected_header_fields[http::CONNECTION]     = http::KEEP_ALIVE;
+	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(response.length());
+	expected_header_fields[http::CONTENT_TYPE]   = "text/plain"; // todo: http::TEXT_HTML;
+	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
+	const std::string &expected_response =
+		CreateHttpResponseFormat(EXPECTED_STATUS_LINE_OK, expected_header_fields, response);
+
+	http::Http       http;
+	http::HttpResult result = http.GetResponseFromCgi(2, cgi_response);
+	return HandleResult(result.response, expected_response, 2);
 }
 
 } // namespace test

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -1,5 +1,6 @@
 #include "test_case.hpp"
 #include <cstdlib>
+#include <iostream>
 
 /**
  * @brief Test Http class: HttpResultの返り値を確認するテスト。
@@ -81,7 +82,12 @@ int  main(void) {
     DeleteVirtualServerAddrList(server_infos);
 
     // test GetErrorResponse
+    std::cout << "\n\033[44;37m[ Test GetErrorResponse ]\033[m" << std::endl;
     ret_code |= test::TestRequestTimeoutResponse();
     ret_code |= test::TestInternalServerErrorResponse();
+
+    // test GetResponseFromCgi
+    std::cout << "\n\033[44;37m[ Test GetResponseFromCgi ]\033[m" << std::endl;
+    ret_code |= test::TestGetResponseFromCgi1();
     return ret_code;
 }

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -89,5 +89,6 @@ int  main(void) {
     // test GetResponseFromCgi
     std::cout << "\n\033[44;37m[ Test GetResponseFromCgi ]\033[m" << std::endl;
     ret_code |= test::TestGetResponseFromCgi1();
+    ret_code |= test::TestGetResponseFromCgi2();
     return ret_code;
 }


### PR DESCRIPTION
## Http::GetResponseFromCgiを実装しました

- [x] HttpRunとHttpResponseを参考に同じ流れで
- [x] HttpStorageを使用しないGetResponseFromCgi単体のTestも作成しました

## TODO

- #537 
- prを取り込んだら`text/plain`をhttpで定義されているものに直す
- CgiParseからの一連の流れのテストを作成(Cgiが実際に動いてからになるかもしれません)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - CGIレスポンスに基づくHTTPレスポンスを生成する新しいメソッドを追加しました。
  - クライアント固有のデータを取得し、HTTP結果を構築する機能を強化しました。

- **バグ修正**
  - 以前のプレースホルダーコードを修正し、実際のデータ処理を行うようにしました。

- **ドキュメント**
  - 新しい名前空間`cgi`と構造体`CgiResponse`を追加しました。
  - テストケースのカバレッジを拡張するための新しいテスト関数を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->