### PR TITLE
[fix] server / エラー時・cgi 終了時の event 監視周りの見直し・修正

### DIFF
--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -1,7 +1,6 @@
 #include "cgi.hpp"
 #include "cgi_request.hpp"
 #include "http_message.hpp"
-#include "status_code.hpp"
 #include "system_exception.hpp"
 #include "utils.hpp"
 #include <cerrno>

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -2,7 +2,6 @@
 #define CGI_HPP_
 
 #include "cgi_request.hpp"
-#include <map>
 #include <string>
 
 namespace cgi {

--- a/srcs/server/cgi_manager/cgi_manager.cpp
+++ b/srcs/server/cgi_manager/cgi_manager.cpp
@@ -122,6 +122,18 @@ void CgiManager::ReplaceNewRequest(int client_fd, const std::string &new_request
 	}
 }
 
+bool CgiManager::IsCgiExist(int fd) const {
+	// fd: client_fd
+	if (cgi_addr_map_.count(fd) != 0) {
+		return true;
+	}
+	// fd: pipe_fd
+	if (client_fd_map_.count(fd) != 0) {
+		return true;
+	}
+	return false;
+}
+
 CgiManager::Cgi *CgiManager::GetCgi(int client_fd) {
 	try {
 		return cgi_addr_map_.at(client_fd);

--- a/srcs/server/cgi_manager/cgi_manager.hpp
+++ b/srcs/server/cgi_manager/cgi_manager.hpp
@@ -29,6 +29,7 @@ class CgiManager {
 	const std::string &GetRequest(int client_fd) const;
 	cgi::CgiResponse   AddAndGetResponse(int client_fd, const std::string &read_buf);
 	void               ReplaceNewRequest(int client_fd, const std::string &new_request_str);
+	bool               IsCgiExist(int fd) const;
 
   private:
 	// Prohibit copy

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -534,7 +534,7 @@ void Server::SendCgiRequest(int pipe_fd) {
 	const std::string &new_request_str = send_result.GetValue();
 	cgi_manager_.ReplaceNewRequest(client_fd, new_request_str);
 	if (new_request_str.empty()) {
-		ReplaceEvent(pipe_fd, event::EVENT_READ);
+		event_monitor_.Delete(pipe_fd);
 	}
 }
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -292,7 +292,6 @@ void Server::SendHttpResponse(int client_fd) {
 		// Even if sending fails, continue the server
 		// e.g., in case of a SIGPIPE(EPIPE) when the client disconnects
 		utils::Debug("server", "failed to send response to client", client_fd);
-		// todo: close()だけしない？
 		Disconnect(client_fd);
 		return;
 	}
@@ -556,7 +555,6 @@ void Server::SendCgiRequest(int write_fd) {
 		utils::Debug(
 			"cgi", "Failed to send the request to the child process through pipe_fd", write_fd
 		);
-		// todo: close()だけしない？
 		Disconnect(client_fd);
 		return;
 	}

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -41,6 +41,7 @@ class Server {
 	void      ListenAllHostPorts(const VirtualServerList &virtual_server_list);
 	PortIpMap CreatePortIpMap(const VirtualServerList &virtual_server_list);
 	void      Listen(const HostPortPair &host_port);
+	void      HandleErrorEvent(int fd);
 	void      HandleEvent(const event::Event &event);
 	void      HandleNewConnection(int server_fd);
 	void      HandleExistingConnection(const event::Event &event);

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -78,7 +78,7 @@ class Server {
 	void              SendCgiRequest(int write_fd);
 	void              HandleCgiReadResult(int read_fd, const Read::ReadResult &read_result);
 	CgiResponseResult AddAndGetCgiResponse(int read_fd, const std::string &read_buf);
-	void GetHttpResponseFromCgiResponse(int read_fd, const cgi::CgiResponse &cgi_response);
+	void GetHttpResponseFromCgiResponse(int client_fd, const cgi::CgiResponse &cgi_response);
 	void UpdateEventInCgiResponseComplete(
 		const message::ConnectionState connection_state, int client_fd
 	);

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -74,10 +74,10 @@ class Server {
 	bool              IsCgi(int fd) const;
 	void              HandleCgi(int client_fd, const http::CgiResult &cgi_result);
 	void              AddEventForCgi(int client_fd);
-	void              SendCgiRequest(int pipe_fd);
-	void              HandleCgiReadResult(int pipe_fd, const Read::ReadResult &read_result);
-	CgiResponseResult AddAndGetCgiResponse(int pipe_fd, const std::string &read_buf);
-	void GetHttpResponseFromCgiResponse(int pipe_fd, const cgi::CgiResponse &cgi_response);
+	void              SendCgiRequest(int write_fd);
+	void              HandleCgiReadResult(int read_fd, const Read::ReadResult &read_result);
+	CgiResponseResult AddAndGetCgiResponse(int read_fd, const std::string &read_buf);
+	void GetHttpResponseFromCgiResponse(int read_fd, const cgi::CgiResponse &cgi_response);
 	void UpdateEventInCgiResponseComplete(
 		const message::ConnectionState connection_state, int client_fd
 	);

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -44,6 +44,7 @@ class Server {
 	void      HandleEvent(const event::Event &event);
 	void      HandleNewConnection(int server_fd);
 	void      HandleExistingConnection(const event::Event &event);
+	bool      IsMessageExist(int fd) const;
 	void      HandleReadEvent(const event::Event &event);
 	void      HandleHttpReadResult(const event::Event &event, const Read::ReadResult &read_result);
 	bool      IsHttpRequestBufExist(int fd) const;

--- a/srcs/server/virtual_server/virtual_server.cpp
+++ b/srcs/server/virtual_server/virtual_server.cpp
@@ -39,7 +39,6 @@ const VirtualServer::ServerNameList &VirtualServer::GetServerNameList() const {
 	return server_names_;
 }
 
-// todo: not used yet
 const VirtualServer::LocationList &VirtualServer::GetLocationList() const {
 	return locations_;
 }

--- a/test/webserv/unit/cgi/Makefile
+++ b/test/webserv/unit/cgi/Makefile
@@ -20,8 +20,6 @@ SRCS				+=	$(WS_CGI_DIR)/cgi.cpp \
 						$(WS_CGI_DIR)/cgi_request.cpp \
 						$(WS_HTTP_CGI_PARSE_DIR)/cgi_parse.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
-						$(WS_HTTP_DIR)/http_exception.cpp \
-						$(WS_HTTP_DIR)/status_code.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
 						$(WS_EXCEPTION_DIR)/system_exception.cpp
 

--- a/test/webserv/unit/cgi_manager/Makefile
+++ b/test/webserv/unit/cgi_manager/Makefile
@@ -16,11 +16,8 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 WS_EXCEPTION_DIR	:=	$(WS_SRCS_DIR)/exception
 SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp
 
-# todo: remove (http_excetion.cpp, status_code.cpp)
 WS_HTTP_DIR			:=	$(WS_SRCS_DIR)/http
-SRCS				+=	$(WS_HTTP_DIR)/http_exception.cpp \
-						$(WS_HTTP_DIR)/http_message.cpp \
-						$(WS_HTTP_DIR)/status_code.cpp
+SRCS				+=	$(WS_HTTP_DIR)/http_message.cpp
 
 WS_CGI_DIR			:=	$(WS_SRCS_DIR)/cgi
 SRCS				+=	$(WS_CGI_DIR)/cgi.cpp \

--- a/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
+++ b/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
@@ -1,7 +1,5 @@
 #include "cgi_manager.hpp"
-#include "http_exception.hpp" // todo: remove
 #include "http_message.hpp"
-#include "status_code.hpp" // todo: remove
 #include "utils.hpp"
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
`srcs/ +77, -43`, 残りが unit test

---
Server class のエラー処理を CgiManager を含めて見直しました
- ミス修正
- fd がきちんと close されれば `event_monitor_.Delete()` を明示的に呼ばなくても epoll の interst list から削除されるようなので、CGI に関しては destructor で close されるため、cgi instance の削除をもって `event_monitor_.Delete()` したものとしました (でないとちょっと面倒な処理が発生しそうで一旦断念しました…)
- client_fd, pipe_fd が同時に epoll の interest list に入った場合、例えば
`client_fd -> write_fd -> read_fd` の順で `HandleEvent()` した場合、client_fd や write_fd のイベント処理中にエラーなどが起きて `Disconnect()` されることもあり、そのような場合は後の read_fd の処理で何もしない、とする必要がありそうだったので、各イベント処理の前にまず client_fd の Message が存在するか・CGI なら cgi instance が存在するかをチェックするようにしました


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- `CgiManager`クラスに新しいメソッド`IsCgiExist`を追加し、CGI関連のファイル記述子の存在を確認可能にしました。
	- `Server`クラスに新しいメソッド`IsMessageExist`と`HandleErrorEvent`を追加し、エラーハンドリングとメッセージの存在確認機能を強化しました。

- **バグ修正**
	- エラーハンドリングのロジックを改善し、接続管理を強化しました。

- **ドキュメント**
	- 不要なコメントを削除し、コードの可読性を向上させました。

- **テスト**
	- テスト用のMakefileから不要なソースファイルを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->