### PR TITLE
[update] ClientInfoをCgiParseに渡すように

### DIFF
--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -56,7 +56,8 @@ HttpResult Http::CreateHttpResponse(
 		HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
 	result.is_response_complete = true;
 	result.request_buf          = data.current_buf;
-	result.response = HttpResponse::Run(server_info, data.request_result, result.cgi_result);
+	result.response =
+		HttpResponse::Run(client_info, server_info, data.request_result, result.cgi_result);
 	if (!result.cgi_result.is_cgi) { // cgiの場合はcgiのhttp_responseを作るときにsave_dataが必要
 		storage_.DeleteClientSaveData(client_info.fd);
 	}

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -34,7 +34,8 @@ cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	const http::HttpRequestFormat &request,
 	const std::string             &cgi_script,
 	const std::string             &cgi_extension,
-	const std::string             &server_port
+	const std::string             &server_port,
+	const std::string             &client_ip
 ) {
 	cgi::MetaMap request_meta_variables;
 	request_meta_variables[cgi::AUTH_TYPE]         = "";
@@ -45,7 +46,7 @@ cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	request_meta_variables[cgi::PATH_TRANSLATED] =
 		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
 	request_meta_variables[cgi::QUERY_STRING]    = "";
-	request_meta_variables[cgi::REMOTE_ADDR]     = "";
+	request_meta_variables[cgi::REMOTE_ADDR]     = client_ip;
 	request_meta_variables[cgi::REMOTE_HOST]     = "";
 	request_meta_variables[cgi::REMOTE_IDENT]    = "";
 	request_meta_variables[cgi::REMOTE_USER]     = "";
@@ -62,14 +63,15 @@ utils::Result<cgi::CgiRequest> CgiParse::Parse(
 	const http::HttpRequestFormat &request,
 	const std::string             &cgi_script,
 	const std::string             &cgi_extension,
-	const std::string             &server_port
+	const std::string             &server_port,
+	const std::string             &client_ip
 ) {
 	cgi::CgiRequest                cgi_request;
 	utils::Result<cgi::CgiRequest> result;
 
 	try {
 		cgi_request.meta_variables =
-			CreateRequestMetaVariables(request, cgi_script, cgi_extension, server_port);
+			CreateRequestMetaVariables(request, cgi_script, cgi_extension, server_port, client_ip);
 		cgi_request.body_message = request.body_message;
 		result.SetValue(cgi_request);
 	} catch (const std::exception &e) {

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -16,7 +16,8 @@ class CgiParse {
 		const http::HttpRequestFormat &request,
 		const std::string             &cgi_script,
 		const std::string             &cgi_extension,
-		const std::string             &server_port
+		const std::string             &server_port,
+		const std::string             &client_ip
 	);
 
   private:
@@ -28,7 +29,8 @@ class CgiParse {
 		const http::HttpRequestFormat &request,
 		const std::string             &cgi_script,
 		const std::string             &cgi_extension,
-		const std::string             &server_port
+		const std::string             &server_port,
+		const std::string             &client_ip
 	); // alias等を通過したパスが必要なため、requestのpathではなくcgi_scriptをpathとして使用する
 };
 

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -23,11 +23,13 @@ std::string GetExtension(const std::string &path) {
 namespace http {
 
 std::string HttpResponse::Run(
+	const http::ClientInfos             &client_info,
 	const server::VirtualServerAddrList &server_info,
 	const HttpRequestResult             &request_info,
 	CgiResult                           &cgi_result
 ) {
-	HttpResponseFormat response = CreateHttpResponseFormat(server_info, request_info, cgi_result);
+	HttpResponseFormat response =
+		CreateHttpResponseFormat(client_info, server_info, request_info, cgi_result);
 	if (cgi_result.is_cgi) {
 		return "";
 	}
@@ -37,6 +39,7 @@ std::string HttpResponse::Run(
 // todo: HttpResponseFormat HttpResponse::CreateHttpResponseFormat(const HttpRequestResult
 // &request_info) 作成
 HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
+	const http::ClientInfos             &client_info,
 	const server::VirtualServerAddrList &server_info,
 	const HttpRequestResult             &request_info,
 	CgiResult                           &cgi_result

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -64,7 +64,8 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				request_info.request,
 				server_info_result.path,
 				server_info_result.cgi_extension,
-				utils::ToString(client_info.listen_server_port)
+				utils::ToString(client_info.listen_server_port),
+				client_info.ip
 			);
 			if (!cgi_parse_result.IsOk()) { // parserが直でthrowするように変更か
 				throw HttpException("CGI Parse Error", StatusCode(BAD_REQUEST));

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -64,7 +64,7 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				request_info.request,
 				server_info_result.path,
 				server_info_result.cgi_extension,
-				"8080" // tmp: server_info_resultにポートを追加する
+				utils::ToString(client_info.listen_server_port)
 			);
 			if (!cgi_parse_result.IsOk()) { // parserが直でthrowするように変更か
 				throw HttpException("CGI Parse Error", StatusCode(BAD_REQUEST));

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -36,7 +36,8 @@ class HttpResponse {
   public:
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
 	static std::string
-					   Run(const server::VirtualServerAddrList &server_info,
+					   Run(const http::ClientInfos             &client_info,
+						   const server::VirtualServerAddrList &server_info,
 						   const HttpRequestResult             &request_info,
 						   CgiResult                           &cgi_result);
 	static std::string CreateErrorResponse(const StatusCode &status_code);
@@ -49,6 +50,7 @@ class HttpResponse {
 
 	static std::string        CreateHttpResponse(const HttpResponseFormat &response);
 	static HttpResponseFormat CreateHttpResponseFormat(
+		const http::ClientInfos             &client_info,
 		const server::VirtualServerAddrList &server_info,
 		const HttpRequestResult             &request_info,
 		CgiResult                           &cgi_result

--- a/test/webserv/unit/cgi_parse/test_cgi_parse.cpp
+++ b/test/webserv/unit/cgi_parse/test_cgi_parse.cpp
@@ -70,9 +70,10 @@ int Test1() {
 	std::string cgi_path_info = "/aa/b";
 	std::string cgi_extension = ".cgi";
 	std::string server_port   = "8080";
+	std::string client_ip     = "127.0.0.1";
 
 	utils::Result<cgi::CgiRequest> parse_result =
-		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port);
+		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port, client_ip);
 	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
 
 	try {
@@ -80,6 +81,7 @@ int Test1() {
 		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
 		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
 		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at(cgi::REMOTE_ADDR), client_ip);
 		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
 		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
 		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
@@ -107,9 +109,10 @@ int Test2() {
 	std::string cgi_path_info = "/aa/b";
 	std::string cgi_extension = ".cgi";
 	std::string server_port   = "8080";
+	std::string client_ip     = "127.0.0.2";
 
 	utils::Result<cgi::CgiRequest> parse_result =
-		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port);
+		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port, client_ip);
 	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
 
 	try {
@@ -117,6 +120,7 @@ int Test2() {
 		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
 		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
 		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at(cgi::REMOTE_ADDR), client_ip);
 		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
 		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
 		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -146,7 +146,8 @@ std::string SetDefaultHeaderFields(
 } // namespace
 
 int main(void) {
-	int                                 ret_code    = 0;
+	int                                 ret_code = EXIT_SUCCESS;
+	http::ClientInfos                   client_infos;
 	const server::VirtualServerAddrList server_info = BuildVirtualServerAddrList();
 	http::HttpRequestResult             request_info;
 	http::CgiResult                     cgi_result;
@@ -160,7 +161,8 @@ int main(void) {
 	request_info.request.request_line.request_target = "/";
 	request_info.request.request_line.version        = http::HTTP_VERSION;
 	request_info.request.header_fields[http::HOST]   = "sawa";
-	std::string response1 = http::HttpResponse::Run(server_info, request_info, cgi_result);
+	std::string response1 =
+		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected1_status_line =
 		LoadFileContent("../../expected_response/default_status_line/200_ok.txt");
@@ -175,7 +177,8 @@ int main(void) {
 
 	// GETメソッドの許可がないhost2に/html/index.htmlを取得するリクエスト
 	request_info.request.header_fields[http::HOST] = "host2";
-	std::string response2 = http::HttpResponse::Run(server_info, request_info, cgi_result);
+	std::string response2 =
+		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected2_status_line =
 		LoadFileContent("../../expected_response/default_status_line/405_method_not_allowed.txt");


### PR DESCRIPTION
## ClientInfoをCgiParseに渡すようにしました

- [x] ClientInfoのserver_portとclient_ipを渡したことで、cgiの環境変数に入れられるように
- [x] そのためにHttpResponse自体にも渡すように変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTPレスポンスの処理において、クライアント情報を含む新しいパラメータを追加しました。これにより、クライアントに関する詳細な情報がレスポンスに含まれるようになります。
  - CGIリクエストのメタデータにクライアントのIPアドレスを追加し、リクエスト処理の精度を向上させました。

- **バグ修正**
  - リダイレクト処理のデフォルト位置を「http://localhost:8080/」に設定し、異なる環境でのリダイレクト処理を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->