### PR TITLE
[fix] ConfigParseで被っているlocationを弾くように

### DIFF
--- a/srcs/config_parse/custom_const_iterator.hpp
+++ b/srcs/config_parse/custom_const_iterator.hpp
@@ -33,9 +33,20 @@ class CustomConstIterator {
 	}
 
 	CustomConstIterator operator++(int) {
-		CustomConstIterator temp = *this;
+		CustomConstIterator tmp = *this;
 		++(*this);
-		return temp;
+		return tmp;
+	}
+
+	CustomConstIterator &operator--() {
+		--it_;
+		return *this;
+	}
+
+	CustomConstIterator operator--(int) {
+		CustomConstIterator tmp = *this;
+		--(*this);
+		return tmp;
 	}
 
 	const T &operator*() const {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -55,6 +55,7 @@ context::ServerCon Parser::CreateServerContext(NodeItr &it) {
 	context::ServerCon server;
 
 	server_directive_set_.clear();
+	location_uri_list_.clear();
 	if ((*it).token_type != node::L_BRACKET) {
 		throw std::runtime_error("expect { after server");
 	}
@@ -197,7 +198,11 @@ context::LocationCon Parser::CreateLocationContext(NodeItr &it) {
 	if ((*it).token_type != node::WORD) {
 		throw std::runtime_error("invalid number of arguments in 'location' directive");
 	}
+	if (FindDuplicated(location_uri_list_, (*it).token)) {
+		throw std::runtime_error("a duplicated parameter in 'location' directive: " + (*it).token);
+	}
 	location.request_uri = (*it).token;
+	location_uri_list_.push_back((*it).token);
 	++it; // skip /www/
 	if ((*it).token_type != node::L_BRACKET) {
 		throw std::runtime_error("expect { after location argument");

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -57,9 +57,11 @@ class Parser {
 	static const int STATUS_CODE_MAX = 599;
 
 	/* For duplicated parameter */
-	typedef std::set<std::string> DirectiveSet;
-	DirectiveSet                  server_directive_set_;
-	DirectiveSet                  location_directive_set_;
+	typedef std::set<std::string>  DirectiveSet;
+	DirectiveSet                   server_directive_set_;
+	DirectiveSet                   location_directive_set_;
+	typedef std::list<std::string> LocationUriList;
+	LocationUriList                location_uri_list_;
 
   public:
 	explicit Parser(std::list<node::Node> &);

--- a/test/common/config/error_test_files/location/location_duplicated_param.conf
+++ b/test/common/config/error_test_files/location/location_duplicated_param.conf
@@ -1,0 +1,9 @@
+server {
+	location / {
+		alias /html/;
+		index index.html;
+	}
+
+	location / {
+	}
+}

--- a/test/webserv/unit/config_parse/test_config.cpp
+++ b/test/webserv/unit/config_parse/test_config.cpp
@@ -555,6 +555,9 @@ int LocationDirectiveErrorTests() {
 	ret_code |=
 		RunErrorTest("location/location_multi_params.conf", "location/location_multi_params.conf");
 	ret_code |= RunErrorTest(
+		"location/location_duplicated_param.conf", "location/location_duplicated_param.conf"
+	);
+	ret_code |= RunErrorTest(
 		"location/location_no_end_bracket.conf", "location/location_no_end_bracket.conf"
 	);
 	ret_code |= RunErrorTest(


### PR DESCRIPTION
## ConfigParseで被っているlocationを弾くようにしました

- [x] `location /``location /`のようなlocationのuriが被っているものを弾きました(nginxでもエラー)
- [x] ついでにParserのエラーメッセージもわかりやすく修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `CustomConstIterator` クラスにインクリメントおよびデクリメントオペレーターを追加しました。
  - `Parser` クラスのエラーメッセージに文脈情報を追加し、より明確なエラー報告を実現しました。
  - 新しい型 `LocationUriList` を `Parser` クラスに追加しました。

- **バグ修正**
  - 重複パラメータの検出機能を強化し、エラーメッセージを更新しました。

- **テスト**
  - 新しいエラーテストケースを追加し、重複パラメータの検出を確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->