### PR TITLE
ubutu_tester用にdevコンテナのDockerfile修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,24 @@
-FROM ubuntu:20.04
+FROM --platform=linux/x86_64 ubuntu:22.04
 
 # 非対話的モードを設定
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
-    git=1:2.25.1-1ubuntu3.13 \
-    python3=3.8.2-0ubuntu2 \
-    python3-pip=20.0.2-5ubuntu1.10 \
-    build-essential \
-    curl=7.68.0-1ubuntu2.24 \
-    vim=2:8.1.2269-1ubuntu5.24 \
-    clang-format=1:10.0-50~exp1 \
-    valgrind=1:3.15.0-1ubuntu9 \
-    cppcheck=1.90-4build1 \
-    tzdata=2024a-0ubuntu0.20.04 \
-    siege=4.0.4-1build1 \
-    strace=5.5-3ubuntu1 \
-    net-tools=1.60+git20180626.aebd88e-1ubuntu1 \
-    iputils-ping=3:20190709-3ubuntu1 --no-install-recommends
+    git=1:2.34.1-1ubuntu1.11 \
+    python3=3.10.6-1~22.04.1 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
+    build-essential=12.9ubuntu3 \
+    curl=7.81.0-1ubuntu1.18 \
+    vim=2:8.2.3995-1ubuntu2.19 \
+    clang-format=1:14.0-55~exp2 \
+    valgrind=1:3.18.1-1ubuntu2 \
+    cppcheck=2.7-1 \
+    tzdata=2024a-0ubuntu0.22.04.1 \
+    siege=4.0.7-1build3 \
+    strace=5.16-0ubuntu3 \
+    net-tools=1.60+git20181103.0eebece-1ubuntu5 \
+    iputils-ping=3:20211215-1 --no-install-recommends
 
 # ここでないとできない
 RUN apt-get update && apt-get install -y python3.8-dev


### PR DESCRIPTION
変更点
* aarch64からx86-64に変更
-> ubuntu_testerはx86-64で実行することを期待しているため
```
./test/webserv/ubuntu_tester 
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
 Trace/breakpoint trap
```


* `ubuntu:20.04`から`ubuntu:22.04`
-> ubuntu_testerは`GLIBC_2.34'以上を必要とするため
```
 ./test/webserv/ubuntu_tester 
./test/webserv/ubuntu_tester: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./test/webserv/ubuntu_tester)
./test/webserv/ubuntu_tester: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./test/webserv/ubuntu_tester)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- DockerfileがUbuntu 22.04に更新され、パッケージのバージョンが最新のものに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->