### PR TITLE
[fix] client の make で object ファイルが生成される場所修正

### DIFF
--- a/test/common/client/Makefile
+++ b/test/common/client/Makefile
@@ -47,15 +47,15 @@ re: fclean all
 DEFAULT_PORT	:=	8080
 PORT			:=	$(DEFAULT_PORT)
 
-# ex) make run INFILE_PATH=../request_messages/webserver/get/200_get_sub.txt
-# ex) make run PORT=4242 INFILE_PATH=../request_messages/apache_root/get/200/connection-close.txt
+# ex) make run REQUEST=../request/get/2xx/200_01_connection_close.txt
+# ex) make run PORT=4242 REQUEST=../request/get/2xx/200_01_connection_close.txt
 .PHONY	: run
 run: all
-	@./$(NAME) $(PORT) $(INFILE_PATH)
+	@./$(NAME) $(PORT) $(REQUEST)
 
 .PHONY	: val
 val: all
-	@valgrind ./$(NAME) $(PORT) $(INFILE_PATH)
+	@valgrind ./$(NAME) $(PORT) $(REQUEST)
 
 .PHONY	: check
 check:

--- a/test/common/client/Makefile
+++ b/test/common/client/Makefile
@@ -1,14 +1,18 @@
 NAME		:=	client
 
-UTILS_DIR	:=	../../../srcs/utils
+WS_SRCS_DIR		:=	../../../srcs
+WS_UTILS_DIR	:=	$(WS_SRCS_DIR)/utils
+
 SRCS		:=	client.cpp \
 				main.cpp \
-				$(UTILS_DIR)/color.cpp
+				$(WS_UTILS_DIR)/color.cpp
 
 OBJ_DIR		:=	objs
-OBJS		:=	$(SRCS:%.cpp=$(OBJ_DIR)/%.o)
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
 
-INCLUDES	:=	-I. -I$(UTILS_DIR)/
+SRCS_DIR	:=	$(WS_UTILS_DIR)
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
 
 CXX			:=	c++
 CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
@@ -20,6 +24,7 @@ MKDIR		:=	mkdir -p
 .PHONY	: all
 all		: $(NAME)
 
+vpath %.cpp $(SRCS_DIR)
 $(OBJ_DIR)/%.o: %.cpp
 	@$(MKDIR) $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/test/common/client/main.cpp
+++ b/test/common/client/main.cpp
@@ -39,7 +39,7 @@ std::string ReadFileStr(const std::string &file_path) {
 
 } // namespace
 
-// ./client PORT INFILE_PATH
+// ./client PORT REQUEST
 int main(int argc, char **argv) {
 	if (argc != 3) {
 		PrintError("Error: invalid arguments");


### PR DESCRIPTION
変なところに `srcs/utils/color.o` が作られるのを修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
	- クライアントの`Makefile`が更新され、ソースファイルパスの整理が改善されました。
	- プログラムのコマンドライン引数が`PORT INFILE_PATH`から`PORT REQUEST`に変更され、入力要件が更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->