### PR TITLE
[fix] python-devのバージョンを更新

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     git=1:2.34.1-1ubuntu1.11 \
     python3=3.10.6-1~22.04.1 \
     python3-pip=22.0.2+dfsg-1ubuntu0.4 \
+    python3.10-dev=3.10.12-1~22.04.6 \
     build-essential=12.9ubuntu3 \
     curl=7.81.0-1ubuntu1.18 \
     vim=2:8.2.3995-1ubuntu2.19 \
@@ -19,9 +20,6 @@ RUN apt-get update && \
     strace=5.16-0ubuntu3 \
     net-tools=1.60+git20181103.0eebece-1ubuntu5 \
     iputils-ping=3:20211215-1 --no-install-recommends
-
-# ここでないとできない
-RUN apt-get update && apt-get install -y python3.8-dev
 
 WORKDIR /workspaces/webserv
 


### PR DESCRIPTION
DevContainerの中でmake e2eで失敗しており、buildの以下のようなエラーが出たのでpython-devのバージョンを更新しました

```
/usr/local/lib/python3.10/dist-packages/pybind11/include/pybind11/detail/common.h:274:10: fatal error: Python.h: No such file or directory
  274 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
Build failed: Command '['python3', 'setup.py', 'build_ext', '--inplace']' returned non-zero exit status 1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 開発環境において、Python 3.10の開発パッケージが追加されました。
- **変更点**
	- Python 3.8の開発パッケージが削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->