### PR TITLE
[update] CgiのResponseをパースする部分の追加

### DIFF
--- a/srcs/http/IHttp.hpp
+++ b/srcs/http/IHttp.hpp
@@ -36,7 +36,7 @@ class IHttp {
 	Run(const ClientInfos &client_infos, const server::VirtualServerAddrList &virtual_servers) = 0;
 
 	// Generates an error HTTP response.
-	virtual HttpResult GetErrorResponse(const ClientInfos &client_info, ErrorState state) = 0;
+	virtual HttpResult GetErrorResponse(int client_fd, ErrorState state) = 0;
 
 	// Generates a HTTP response based on the CGI response.
 	virtual HttpResult GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response) = 0;

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -18,7 +18,7 @@ Http::Run(const ClientInfos &client_info, const server::VirtualServerAddrList &s
 	utils::Result<void> parsed_result =
 		ParseHttpRequestFormat(client_info.fd, client_info.request_buf);
 	if (!parsed_result.IsOk()) {
-		return CreateBadRequestResponse(client_info);
+		return CreateBadRequestResponse(client_info.fd);
 	}
 	if (IsHttpRequestFormatComplete(client_info.fd)) {
 		result = CreateHttpResponse(client_info, server_info);
@@ -90,14 +90,14 @@ HttpResult Http::GetErrorResponse(int client_fd, ErrorState state) {
 	return result;
 }
 
-HttpResult Http::CreateBadRequestResponse(const ClientInfos &client_info) {
+HttpResult Http::CreateBadRequestResponse(int client_fd) {
 	HttpResult            result;
-	HttpRequestParsedData data  = storage_.GetClientSaveData(client_info.fd);
+	HttpRequestParsedData data  = storage_.GetClientSaveData(client_fd);
 	result.is_response_complete = true;
 	result.is_connection_keep   = false;
 	result.request_buf          = data.current_buf;
 	result.response             = HttpResponse::CreateErrorResponse(StatusCode(BAD_REQUEST));
-	storage_.DeleteClientSaveData(client_info.fd);
+	storage_.DeleteClientSaveData(client_fd);
 	return result;
 }
 

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -70,9 +70,9 @@ HttpResult Http::CreateHttpResponse(
 	return result;
 }
 
-HttpResult Http::GetErrorResponse(const ClientInfos &client_info, ErrorState state) {
+HttpResult Http::GetErrorResponse(int client_fd, ErrorState state) {
 	HttpResult            result;
-	HttpRequestParsedData data  = storage_.GetClientSaveData(client_info.fd);
+	HttpRequestParsedData data  = storage_.GetClientSaveData(client_fd);
 	result.is_response_complete = true;
 	result.is_connection_keep   = false;
 	result.request_buf          = data.current_buf;
@@ -86,7 +86,7 @@ HttpResult Http::GetErrorResponse(const ClientInfos &client_info, ErrorState sta
 	default:
 		break;
 	}
-	storage_.DeleteClientSaveData(client_info.fd);
+	storage_.DeleteClientSaveData(client_fd);
 	return result;
 }
 

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -29,7 +29,7 @@ class Http : public IHttp {
 	HttpResult          CreateHttpResponse(
 				 const ClientInfos &client_info, const server::VirtualServerAddrList &server_info
 			 );
-	HttpResult            CreateBadRequestResponse(const ClientInfos &client_info);
+	HttpResult            CreateBadRequestResponse(int client_fd);
 	bool                  IsHttpRequestFormatComplete(int client_fd);
 	HttpRequestParsedData GetClientData(int client_fd);
 };

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -18,7 +18,7 @@ class Http : public IHttp {
 	~Http();
 	HttpResult
 	Run(const ClientInfos &client_info, const server::VirtualServerAddrList &server_info);
-	HttpResult GetErrorResponse(const ClientInfos &client_info, ErrorState state);
+	HttpResult GetErrorResponse(int client_fd, ErrorState state);
 	HttpResult GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_response);
 
   private:

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -1,0 +1,61 @@
+#include "cgi_response_parse.hpp"
+#include "utils.hpp"
+
+namespace http {
+
+const std::string CgiResponseParse::CRLF              = "\r\n";
+const std::string CgiResponseParse::HEADER_FIELDS_END = CRLF + CRLF;
+
+CgiResponseParse::CgiResponseParse() {}
+
+CgiResponseParse::~CgiResponseParse() {}
+
+CgiResponseParse::ParsedData CgiResponseParse::Parse(const std::string &response) {
+	parsed_data_.header_fields.clear();
+	parsed_data_.body.clear();
+	size_t pos = response.find(HEADER_FIELDS_END);
+	if (pos == std::string::npos) {
+		return parsed_data_;
+	}
+	std::string header = response.substr(0, pos);
+	ParseHeaderFields(header);
+	ParseBody(response.substr(pos + HEADER_FIELDS_END.size()));
+	return parsed_data_;
+}
+
+void CgiResponseParse::ParseHeaderFields(const std::string &header) {
+	std::string::size_type pos = 0;
+	// todo: err でthrow
+	while (pos < header.size()) {
+		std::string::size_type end_of_line = header.find(CRLF, pos);
+		if (end_of_line == std::string::npos) {
+			break;
+		}
+		std::string line                 = header.substr(pos, end_of_line - pos);
+		pos                              = end_of_line + CRLF.size();
+		std::string::size_type colon_pos = line.find(":");
+		if (colon_pos == std::string::npos) {
+			continue;
+		}
+		std::string key   = line.substr(0, colon_pos);
+		std::string value = line.substr(colon_pos + 1);
+		// todo: validation and trim
+		parsed_data_.header_fields[key] = value;
+	}
+}
+
+void CgiResponseParse::ParseBody(const std::string &body) {
+	HeaderFields::iterator it = parsed_data_.header_fields.find("Content-Length");
+	if (it != parsed_data_.header_fields.end()) {
+		std::string::size_type content_length = utils::ConvertStrToSize(it->second).GetValue();
+		// todo: ConvertStrToSize is Not Ok
+		if (content_length > body.size()) {
+			parsed_data_.body = body;
+			return;
+		}
+		parsed_data_.body = body.substr(0, content_length);
+		return;
+	}
+}
+
+} // namespace http

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -1,7 +1,7 @@
 #include "cgi_response_parse.hpp"
 #include "utils.hpp"
 
-namespace http {
+namespace cgi {
 
 const std::string CgiResponseParse::CRLF              = "\r\n";
 const std::string CgiResponseParse::HEADER_FIELDS_END = CRLF + CRLF;
@@ -81,4 +81,4 @@ std::string &CgiResponseParse::TrimOws(std::string &s) {
 	return s;
 }
 
-} // namespace http
+} // namespace cgi

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -40,7 +40,7 @@ void CgiResponseParse::ParseHeaderFields(const std::string &header, ParsedData &
 		}
 		std::string key   = line.substr(0, colon_pos);
 		std::string value = line.substr(colon_pos + 1);
-		value             = TrimOWS(value);
+		value             = TrimOws(value);
 		// todo: validation(HttpParseの処理をそのまま使う)
 		parsed_data.header_fields[key] = value;
 	}
@@ -63,7 +63,7 @@ void CgiResponseParse::ParseBody(const std::string &body, ParsedData &parsed_dat
 	return;
 }
 
-std::string &CgiResponseParse::TrimOWS(std::string &s) {
+std::string &CgiResponseParse::TrimOws(std::string &s) {
 	// 先頭のスペースとタブを削除
 	std::string::iterator it = s.begin();
 	while (it != s.end() && CgiResponseParse::OWS.find(*it) != std::string::npos) {

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -5,6 +5,7 @@ namespace http {
 
 const std::string CgiResponseParse::CRLF              = "\r\n";
 const std::string CgiResponseParse::HEADER_FIELDS_END = CRLF + CRLF;
+const std::string CgiResponseParse::OWS               = " \t";
 
 CgiResponseParse::CgiResponseParse() {}
 
@@ -17,7 +18,7 @@ CgiResponseParse::ParsedData CgiResponseParse::Parse(const std::string &response
 	if (pos == std::string::npos) {
 		return parsed_data_;
 	}
-	std::string header = response.substr(0, pos);
+	std::string header = response.substr(0, pos + CRLF.size()); // CRLFも含めたいため
 	ParseHeaderFields(header);
 	ParseBody(response.substr(pos + HEADER_FIELDS_END.size()));
 	return parsed_data_;
@@ -39,7 +40,8 @@ void CgiResponseParse::ParseHeaderFields(const std::string &header) {
 		}
 		std::string key   = line.substr(0, colon_pos);
 		std::string value = line.substr(colon_pos + 1);
-		// todo: validation and trim
+		value             = TrimOWS(value);
+		// todo: validation(HttpParseの処理をそのまま使う)
 		parsed_data_.header_fields[key] = value;
 	}
 }
@@ -56,6 +58,24 @@ void CgiResponseParse::ParseBody(const std::string &body) {
 		parsed_data_.body = body.substr(0, content_length);
 		return;
 	}
+}
+
+std::string &CgiResponseParse::TrimOWS(std::string &s) {
+	// 先頭のスペースとタブを削除
+	std::string::iterator it = s.begin();
+	while (it != s.end() && CgiResponseParse::OWS.find(*it) != std::string::npos) {
+		++it;
+	}
+	s.erase(s.begin(), it);
+
+	// 末尾のスペースとタブを削除
+	std::string::reverse_iterator rit = s.rbegin();
+	while (rit != s.rend() && CgiResponseParse::OWS.find(*rit) != std::string::npos) {
+		++rit;
+	}
+	s.erase(rit.base(), s.end());
+
+	return s;
 }
 
 } // namespace http

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -58,6 +58,9 @@ void CgiResponseParse::ParseBody(const std::string &body, ParsedData &parsed_dat
 		parsed_data.body = body.substr(0, content_length);
 		return;
 	}
+	// Content-Lengthがない場合は全てのbodyを格納
+	parsed_data.body = body;
+	return;
 }
 
 std::string &CgiResponseParse::TrimOWS(std::string &s) {

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.cpp
@@ -19,12 +19,12 @@ CgiResponseParse::ParsedData CgiResponseParse::Parse(const std::string &response
 		return parsed_data;
 	}
 	std::string header = response.substr(0, pos + CRLF.size()); // CRLFも含めたいため
-	ParseHeaderFields(header, parsed_data);
+	ParseHeaderFields(header, parsed_data.header_fields);
 	ParseBody(response.substr(pos + HEADER_FIELDS_END.size()), parsed_data);
 	return parsed_data;
 }
 
-void CgiResponseParse::ParseHeaderFields(const std::string &header, ParsedData &parsed_data) {
+void CgiResponseParse::ParseHeaderFields(const std::string &header, HeaderFields &header_fields) {
 	std::string::size_type pos = 0;
 	// todo: err でthrow
 	while (pos < header.size()) {
@@ -42,7 +42,7 @@ void CgiResponseParse::ParseHeaderFields(const std::string &header, ParsedData &
 		std::string value = line.substr(colon_pos + 1);
 		value             = TrimOws(value);
 		// todo: validation(HttpParseの処理をそのまま使う)
-		parsed_data.header_fields[key] = value;
+		header_fields[key] = value;
 	}
 }
 

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -1,0 +1,36 @@
+#ifndef CGI_RESPONSE_PARSE_HPP_
+#define CGI_RESPONSE_PARSE_HPP_
+
+#include <map>
+#include <string>
+
+namespace http {
+
+class CgiResponseParse {
+	typedef std::map<std::string, std::string> HeaderFields;
+	struct ParsedData {
+		HeaderFields header_fields;
+		std::string  body;
+	};
+
+  public:
+	CgiResponseParse();
+	~CgiResponseParse();
+	ParsedData Parse(const std::string &response);
+
+  private:
+	CgiResponseParse(const CgiResponseParse &other);
+	CgiResponseParse &operator=(const CgiResponseParse &other);
+
+	void ParseHeaderFields(const std::string &header);
+	void ParseBody(const std::string &body);
+
+	ParsedData parsed_data_;
+
+	static const std::string CRLF;
+	static const std::string HEADER_FIELDS_END;
+};
+
+} // namespace http
+
+#endif

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -7,13 +7,13 @@
 namespace http {
 
 class CgiResponseParse {
+  public:
 	typedef std::map<std::string, std::string> HeaderFields;
 	struct ParsedData {
 		HeaderFields header_fields;
 		std::string  body;
 	};
 
-  public:
 	CgiResponseParse();
 	~CgiResponseParse();
 	ParsedData Parse(const std::string &response);
@@ -22,13 +22,15 @@ class CgiResponseParse {
 	CgiResponseParse(const CgiResponseParse &other);
 	CgiResponseParse &operator=(const CgiResponseParse &other);
 
-	void ParseHeaderFields(const std::string &header);
-	void ParseBody(const std::string &body);
+	void         ParseHeaderFields(const std::string &header);
+	void         ParseBody(const std::string &body);
+	std::string &TrimOWS(std::string &s);
 
 	ParsedData parsed_data_;
 
 	static const std::string CRLF;
 	static const std::string HEADER_FIELDS_END;
+	static const std::string OWS;
 };
 
 } // namespace http

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -22,7 +22,7 @@ class CgiResponseParse {
 
 	static void         ParseHeaderFields(const std::string &header, ParsedData &parsed_data);
 	static void         ParseBody(const std::string &body, ParsedData &parsed_data);
-	static std::string &TrimOWS(std::string &s);
+	static std::string &TrimOws(std::string &s);
 
 	static const std::string CRLF;
 	static const std::string HEADER_FIELDS_END;

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -20,7 +20,7 @@ class CgiResponseParse {
 	CgiResponseParse();
 	~CgiResponseParse();
 
-	static void         ParseHeaderFields(const std::string &header, ParsedData &parsed_data);
+	static void         ParseHeaderFields(const std::string &header, HeaderFields &header_fields);
 	static void         ParseBody(const std::string &body, ParsedData &parsed_data);
 	static std::string &TrimOws(std::string &s);
 

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -14,19 +14,15 @@ class CgiResponseParse {
 		std::string  body;
 	};
 
-	CgiResponseParse();
-	~CgiResponseParse();
-	ParsedData Parse(const std::string &response);
+	static ParsedData Parse(const std::string &response);
 
   private:
-	CgiResponseParse(const CgiResponseParse &other);
-	CgiResponseParse &operator=(const CgiResponseParse &other);
+	CgiResponseParse();
+	~CgiResponseParse();
 
-	void         ParseHeaderFields(const std::string &header);
-	void         ParseBody(const std::string &body);
-	std::string &TrimOWS(std::string &s);
-
-	ParsedData parsed_data_;
+	static void         ParseHeaderFields(const std::string &header, ParsedData &parsed_data);
+	static void         ParseBody(const std::string &body, ParsedData &parsed_data);
+	static std::string &TrimOWS(std::string &s);
 
 	static const std::string CRLF;
 	static const std::string HEADER_FIELDS_END;

--- a/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
+++ b/srcs/http/response/cgi_response_parse/cgi_response_parse.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 
-namespace http {
+namespace cgi {
 
 class CgiResponseParse {
   public:
@@ -29,6 +29,6 @@ class CgiResponseParse {
 	static const std::string OWS;
 };
 
-} // namespace http
+} // namespace cgi
 
 #endif

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -336,7 +336,7 @@ void Server::HandleTimeoutMessages() {
 		}
 
 		const http::HttpResult http_result =
-			http_.GetErrorResponse(GetClientInfos(client_fd), http::TIMEOUT);
+			http_.GetErrorResponse(client_fd, http::TIMEOUT);
 		message_manager_.AddPrimaryResponse(client_fd, message::CLOSE, http_result.response);
 		ReplaceEvent(client_fd, event::EVENT_WRITE);
 		utils::Debug("server", "timeout client", client_fd);
@@ -351,7 +351,7 @@ void Server::SetInternalServerError(int client_fd) {
 	}
 
 	const http::HttpResult http_result =
-		http_.GetErrorResponse(GetClientInfos(client_fd), http::INTERNAL_ERROR);
+		http_.GetErrorResponse(client_fd, http::INTERNAL_ERROR);
 	message_manager_.AddPrimaryResponse(client_fd, message::CLOSE, http_result.response);
 	ReplaceEvent(client_fd, event::EVENT_WRITE);
 	utils::Debug("server", "internal server error to client", client_fd);
@@ -370,7 +370,7 @@ void Server::Disconnect(int client_fd) {
 	}
 	// todo: client_save_dataがない場合に呼ばれても大丈夫な作りになってるか確認
 	// HttpResult is not used.
-	http_.GetErrorResponse(GetClientInfos(client_fd), http::INTERNAL_ERROR);
+	http_.GetErrorResponse(client_fd, http::INTERNAL_ERROR);
 	event_monitor_.Delete(client_fd);
 	message_manager_.DeleteMessage(client_fd);
 	context_.DeleteClientInfo(client_fd);

--- a/test/webserv/unit/Makefile
+++ b/test/webserv/unit/Makefile
@@ -10,6 +10,7 @@ TEST_DIRS	:=	convert_str \
 				http_serverinfo_check \
 				cgi_parse \
 				cgi \
+				cgi_response_parse \
 				cgi_manager \
 				sock_context \
 				split_str \

--- a/test/webserv/unit/cgi_response_parse/Makefile
+++ b/test/webserv/unit/cgi_response_parse/Makefile
@@ -1,0 +1,82 @@
+NAME			:=	a.out
+
+# 1. Set each directory name
+TEST_DIR		:=	cgi_response_parse
+
+LOG_DIR			:=	log
+LOG_FILE_NAME	:=	$(TEST_DIR).log
+LOG_FILE_PATH	:=	$(LOG_DIR)/$(LOG_FILE_NAME)
+
+# 2. Add target webserv files
+WS_SRCS_DIR						:=	../../../../srcs
+WS_UTILS_DIR					:= $(WS_SRCS_DIR)/utils
+WS_HTTP_DIR						:=	$(WS_SRCS_DIR)/http
+WS_HTTP_RESPONSE_DIR			:=	$(WS_HTTP_DIR)/response
+WS_HTTP_CGI_RESPONSE_PARSE		:=	$(WS_HTTP_RESPONSE_DIR)/cgi_response_parse
+
+SRCS				+=	$(WS_HTTP_CGI_RESPONSE_PARSE)/cgi_response_parse.cpp \
+						$(WS_UTILS_DIR)/color.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp
+
+# 3. Add unit test files
+SRCS	+=	test_cgi_response_parse.cpp
+
+# 4. Add directory for INCLUDE
+SRCS_DIR	:=	$(WS_UTILS_DIR) \
+				$(WS_HTTP_DIR) \
+				$(WS_HTTP_RESPONSE_DIR) \
+				$(WS_HTTP_CGI_RESPONSE_PARSE)
+
+#--------------------------------------------
+OBJ_DIR		:=	objs
+OBJS		:=	$(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRCS)))
+
+INCLUDES	:=	$(addprefix -I, $(SRCS_DIR))
+
+CXX			:=	c++
+CXXFLAGS	:=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
+
+DEPS		:=	$(OBJS:.o=.d)
+MKDIR		:=	mkdir -p
+
+.PHONY	: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) -o $@ $^
+
+vpath %.cpp $(SRCS_DIR)
+$(OBJ_DIR)/%.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+.PHONY	: clean
+clean:
+	$(RM) -r $(OBJ_DIR)
+
+.PHONY	: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY	: re
+re: fclean all
+
+#--------------------------------------------
+# PIPESTATUSがbash固有のため
+SHELL=/bin/bash
+
+.PHONY	: run
+run: all
+	@$(MKDIR) $(dir $(LOG_FILE_PATH))
+	@./$(NAME) 2>&1 | tee $(LOG_FILE_PATH); \
+	status=$${PIPESTATUS[0]}; \
+	echo -e "\nunit test's log =>" $(LOG_FILE_PATH); \
+	exit $$status;
+
+.PHONY	: val
+val: all
+	@valgrind ./$(NAME)
+
+#--------------------------------------------
+-include $(DEPS)

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -91,9 +91,8 @@ int HandleTestResult(const Result &result) {
 }
 
 int TestParseValidResponse() {
-	CgiResponseParse parser;
 	std::string response = "Content-Length: 13\r\nContent-Type: text/plain\r\n\r\nHello, world!";
-	CgiResponseParse::ParsedData result = parser.Parse(response);
+	CgiResponseParse::ParsedData result = CgiResponseParse::Parse(response);
 
 	CgiResponseParse::ParsedData expected;
 	expected.header_fields["Content-Length"] = "13";
@@ -103,9 +102,8 @@ int TestParseValidResponse() {
 }
 
 int TestParseHeaderOnlyResponse() {
-	CgiResponseParse             parser;
 	std::string                  response = "Content-Length: 0\r\nContent-Type: text/plain\r\n\r\n";
-	CgiResponseParse::ParsedData result   = parser.Parse(response);
+	CgiResponseParse::ParsedData result   = CgiResponseParse::Parse(response);
 
 	CgiResponseParse::ParsedData expected;
 	expected.header_fields["Content-Length"] = "0";
@@ -115,9 +113,8 @@ int TestParseHeaderOnlyResponse() {
 }
 
 int TestParseBodyLongerThanContentLength() {
-	CgiResponseParse parser;
 	std::string response = "Content-Length: 5\r\nContent-Type: text/plain\r\n\r\nHello, world!";
-	CgiResponseParse::ParsedData result = parser.Parse(response);
+	CgiResponseParse::ParsedData result = CgiResponseParse::Parse(response);
 
 	CgiResponseParse::ParsedData expected;
 	expected.header_fields["Content-Length"] = "5";

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <string>
 
-using namespace http;
+using namespace cgi;
 
 // ==================== Test汎用 ==================== //
 namespace {

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -1,5 +1,6 @@
 #include "cgi_response_parse.hpp"
 #include "utils.hpp"
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <string>

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -1,0 +1,164 @@
+#include "cgi_response_parse.hpp"
+#include "utils.hpp"
+#include <iostream>
+#include <map>
+#include <string>
+
+using namespace http;
+
+// ==================== Test汎用 ==================== //
+namespace {
+
+struct Result {
+	Result() : is_success(true) {}
+	bool        is_success;
+	std::string error_log;
+};
+
+int GetTestCaseNum() {
+	static int test_case_num = 0;
+	++test_case_num;
+	return test_case_num;
+}
+
+void PrintOk() {
+	std::cout << utils::color::GREEN << GetTestCaseNum() << ".[OK]" << utils::color::RESET
+			  << std::endl;
+}
+
+void PrintNg() {
+	std::cerr << utils::color::RED << GetTestCaseNum() << ".[NG] " << utils::color::RESET
+			  << std::endl;
+}
+
+} // namespace
+
+// ================================================= //
+
+typedef CgiResponseParse::ParsedData   ParsedData;
+typedef CgiResponseParse::HeaderFields HeaderFields;
+
+Result CompareHeaderFields(const HeaderFields &expected, const HeaderFields &actual) {
+	Result result;
+	if (expected.size() != actual.size()) {
+		result.is_success = false;
+		result.error_log  = "The number of header fields is different.";
+		return result;
+	}
+	for (HeaderFields::const_iterator it = expected.begin(); it != expected.end(); ++it) {
+		HeaderFields::const_iterator actual_it = actual.find(it->first);
+		if (actual_it == actual.end()) {
+			result.is_success = false;
+			result.error_log  = "The key does not exist.";
+			return result;
+		}
+		if (it->second != actual_it->second) {
+			result.is_success = false;
+			result.error_log  = "The value is different.";
+			result.error_log += " key: " + it->first + ", expected: " + it->second +
+								", actual: " + actual_it->second;
+			return result;
+		}
+	}
+	return result;
+}
+
+Result CompareParsedData(const ParsedData &expected, const ParsedData &actual) {
+	Result result;
+	Result header_fields_result = CompareHeaderFields(expected.header_fields, actual.header_fields);
+	if (!header_fields_result.is_success) {
+		result.is_success = false;
+		result.error_log  = header_fields_result.error_log;
+		return result;
+	}
+	if (expected.body != actual.body) {
+		result.is_success = false;
+		result.error_log  = "The body is different.";
+		return result;
+	}
+	return result;
+}
+
+int HandleTestResult(const Result &result) {
+	if (result.is_success) {
+		PrintOk();
+		return EXIT_SUCCESS;
+	}
+	PrintNg();
+	std::cerr << result.error_log << std::endl;
+	return EXIT_FAILURE;
+}
+
+int TestParseValidResponse() {
+	CgiResponseParse parser;
+	std::string response = "Content-Length: 13\r\nContent-Type: text/plain\r\n\r\nHello, world!";
+	CgiResponseParse::ParsedData result = parser.Parse(response);
+
+	CgiResponseParse::ParsedData expected;
+	expected.header_fields["Content-Length"] = "13";
+	expected.header_fields["Content-Type"]   = "text/plain";
+	expected.body                            = "Hello, world!";
+	return HandleTestResult(CompareParsedData(expected, result));
+}
+
+int TestParseHeaderOnlyResponse() {
+	CgiResponseParse             parser;
+	std::string                  response = "Content-Length: 0\r\nContent-Type: text/plain\r\n\r\n";
+	CgiResponseParse::ParsedData result   = parser.Parse(response);
+
+	CgiResponseParse::ParsedData expected;
+	expected.header_fields["Content-Length"] = "0";
+	expected.header_fields["Content-Type"]   = "text/plain";
+	expected.body                            = "";
+	return HandleTestResult(CompareParsedData(expected, result));
+}
+
+int TestParseBodyLongerThanContentLength() {
+	CgiResponseParse parser;
+	std::string response = "Content-Length: 5\r\nContent-Type: text/plain\r\n\r\nHello, world!";
+	CgiResponseParse::ParsedData result = parser.Parse(response);
+
+	CgiResponseParse::ParsedData expected;
+	expected.header_fields["Content-Length"] = "5";
+	expected.header_fields["Content-Type"]   = "text/plain";
+	expected.body                            = "Hello";
+	return HandleTestResult(CompareParsedData(expected, result));
+}
+
+// todo: Error
+
+// void TestParseBodyOnlyResponse() {
+// 	CgiResponseParse             parser;
+// 	std::string                        response = "\r\n\r\nHello, world!";
+// 	CgiResponseParse::ParsedData result   = parser.Parse(response);
+
+// 	if (result.header_fields.size() == 0 && result.body == "Hello, world!") {
+// 		std::cout << "testParseBodyOnlyResponse passed\n";
+// 	} else {
+// 		std::cout << "testParseBodyOnlyResponse failed\n";
+// 	}
+// }
+
+// void TestParseInvalidResponse() {
+// 	http::CgiResponseParse             parser;
+// 	std::string                        response = "Invalid Response";
+// 	http::CgiResponseParse::ParsedData result   = parser.Parse(response);
+
+// 	if (result.header_fields.size() == 0 && result.body == "") {
+// 		std::cout << "testParseInvalidResponse passed\n";
+// 	} else {
+// 		std::cout << "testParseInvalidResponse failed\n";
+// 	}
+// }
+
+int main() {
+	int ret = EXIT_SUCCESS;
+
+	ret |= TestParseValidResponse();
+	ret |= TestParseHeaderOnlyResponse();
+	ret |= TestParseBodyLongerThanContentLength();
+	// testParseBodyOnlyResponse();
+	// testParseInvalidResponse();
+
+	return ret;
+}

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -43,14 +43,16 @@ Result CompareHeaderFields(const HeaderFields &expected, const HeaderFields &act
 	Result result;
 	if (expected.size() != actual.size()) {
 		result.is_success = false;
-		result.error_log  = "The number of header fields is different.";
+		result.error_log  = "The number of header fields is different, expected: " +
+						   utils::ToString(expected.size()) +
+						   ", actual: " + utils::ToString(actual.size());
 		return result;
 	}
 	for (HeaderFields::const_iterator it = expected.begin(); it != expected.end(); ++it) {
 		HeaderFields::const_iterator actual_it = actual.find(it->first);
 		if (actual_it == actual.end()) {
 			result.is_success = false;
-			result.error_log  = "The key does not exist.";
+			result.error_log  = "The key does not exist: " + it->first;
 			return result;
 		}
 		if (it->second != actual_it->second) {

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -123,6 +123,16 @@ int TestParseBodyLongerThanContentLength() {
 	return HandleTestResult(CompareParsedData(expected, result));
 }
 
+int TestParseNoContentLength() {
+	std::string                  response = "Content-Type: text/plain\r\n\r\nHello, world!";
+	CgiResponseParse::ParsedData result   = CgiResponseParse::Parse(response);
+
+	CgiResponseParse::ParsedData expected;
+	expected.header_fields["Content-Type"] = "text/plain";
+	expected.body                          = "Hello, world!";
+	return HandleTestResult(CompareParsedData(expected, result));
+}
+
 // todo: Error
 
 // void TestParseBodyOnlyResponse() {
@@ -155,6 +165,7 @@ int main() {
 	ret |= TestParseValidResponse();
 	ret |= TestParseHeaderOnlyResponse();
 	ret |= TestParseBodyLongerThanContentLength();
+	ret |= TestParseNoContentLength();
 	// testParseBodyOnlyResponse();
 	// testParseInvalidResponse();
 

--- a/test/webserv/unit/http/test_case/test_get_error_response.cpp
+++ b/test/webserv/unit/http/test_case/test_get_error_response.cpp
@@ -37,7 +37,7 @@ int TestRequestTimeoutResponse() {
     );
 
 	http::Http       http;
-	http::HttpResult result = http.GetErrorResponse(client_infos, http::TIMEOUT);
+	http::HttpResult result = http.GetErrorResponse(client_infos.fd, http::TIMEOUT);
 	return HandleGetErrorResponseError(result.response, expected_response, 1);
 }
 
@@ -55,7 +55,7 @@ int TestInternalServerErrorResponse() {
     );
 
 	http::Http       http;
-	http::HttpResult result = http.GetErrorResponse(client_infos, http::INTERNAL_ERROR);
+	http::HttpResult result = http.GetErrorResponse(client_infos.fd, http::INTERNAL_ERROR);
 	return HandleGetErrorResponseError(result.response, expected_response, 2);
 }
 


### PR DESCRIPTION
## CgiのResponseをパースするクラスを作成しました

- apacheではレスポンスのフォーマットが正しくない場合は内部的に500を返しているのでそれを再現したい
- そこで、Cgiの実行から読み取ったものをパースする部分を作成
- GetResponseFromCgiに組み込み、エラーの場合にはInternalServerErrorを返す想定
- 正常であればパースのデータを元にレスポンスを作成

Content-Length分だけを読み取り、ない場合は全て読むという作業も追加してあります。
ヘッダーのエラー処理はHttpのが完成したらそれを取り入れるつもりです。
ついでにClientInfoを渡しているのにclient_fdしか使っていない部分を修正しました(ClientInfoを持っていないGetResponseFromCgiでも使いたいため)

## Further
- [ ] ヘッダーのエラー処理
- [ ] GetResponseFromCgiに組み込む(ParserDataをCreateCgiResponseに渡さす)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - CGIレスポンスを解析する新しいクラス`CgiResponseParse`を追加しました。

- **変更**
  - エラーレスポンス処理の方法を改善し、クライアントのファイルディスクリプタを直接使用するように変更しました。

- **テスト**
  - `CgiResponseParse`クラスのユニットテストを追加しました。
  - エラーレスポンスのテスト方法を更新しました。
  - `CgiResponseParse`に関連するテストを新たに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->