### PR TITLE
[fix] CgiParseの修正

### DIFF
--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -74,25 +74,19 @@ cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	return request_meta_variables;
 }
 
-utils::Result<cgi::CgiRequest> CgiParse::Parse(
+cgi::CgiRequest CgiParse::Parse(
 	const http::HttpRequestFormat &request,
 	const std::string             &cgi_script,
 	const std::string             &cgi_extension,
 	const std::string             &server_port,
 	const std::string             &client_ip
 ) {
-	cgi::CgiRequest                cgi_request;
-	utils::Result<cgi::CgiRequest> result;
+	cgi::CgiRequest cgi_request;
 
-	try {
-		cgi_request.meta_variables =
-			CreateRequestMetaVariables(request, cgi_script, cgi_extension, server_port, client_ip);
-		cgi_request.body_message = request.body_message;
-		result.SetValue(cgi_request);
-	} catch (const std::exception &e) {
-		result.Set(false); // atで例外が投げられる
-	}
-	return result;
+	cgi_request.meta_variables =
+		CreateRequestMetaVariables(request, cgi_script, cgi_extension, server_port, client_ip);
+	cgi_request.body_message = request.body_message;
+	return cgi_request;
 }
 
 } // namespace http

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -16,7 +16,7 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 
 std::string
 TranslateToScriptName(const std::string &cgi_extension, const std::string &request_target) {
-	// from cgi_parse dir to cgi dir
+	// from root path
 	const std::string::size_type extension_pos = request_target.find(cgi_extension);
 	const std::string::size_type root_pos      = request_target.find("root/cgi-bin/");
 	const std::string            script_name   = request_target.substr(root_pos);
@@ -28,7 +28,7 @@ TranslateToScriptName(const std::string &cgi_extension, const std::string &reque
 }
 
 std::string TranslatePathInfo(const std::string &request_target) {
-	// from cgi_parse dir to root dir
+	// from root path
 	if (request_target.empty()) {
 		return "";
 	}

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -15,7 +15,7 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 }
 
 std::string
-TranslateToCgiPath(const std::string &cgi_extension, const std::string &request_target) {
+TranslateToScriptName(const std::string &cgi_extension, const std::string &request_target) {
 	// from cgi_parse dir to cgi dir
 	const std::string::size_type extension_pos = request_target.find(cgi_extension);
 	const std::string::size_type root_pos      = request_target.find("root/cgi-bin/");
@@ -26,9 +26,12 @@ TranslateToCgiPath(const std::string &cgi_extension, const std::string &request_
 	return script_name;
 }
 
-std::string TranslateToHtmlPath(const std::string &request_target) {
-	// from cgi_parse dir to html dir
-	return "../../../../html" + request_target;
+std::string TranslatePathInfo(const std::string &request_target) {
+	// from cgi_parse dir to root dir
+	if (request_target.empty()) {
+		return "";
+	}
+	return "root" + request_target;
 }
 
 std::string FindValueFromMap(const cgi::MetaMap &map, const std::string &key) {
@@ -58,18 +61,15 @@ cgi::MetaMap CgiParse::CreateRequestMetaVariables(
 	} // bodyがない場合はunset
 	request_meta_variables[cgi::GATEWAY_INTERFACE] = "CGI/1.1";
 	request_meta_variables[cgi::PATH_INFO]         = CreatePathInfo(cgi_extension, cgi_script);
-	std::cout << "PATH_INFO: " << request_meta_variables["PATH_INFO"] << std::endl;
 	request_meta_variables[cgi::PATH_TRANSLATED] =
-		TranslateToHtmlPath(request_meta_variables["PATH_INFO"]);
-	std::cout << "PATH_TRANSLATED: " << request_meta_variables["PATH_TRANSLATED"] << std::endl;
-	request_meta_variables[cgi::QUERY_STRING]   = "";
-	request_meta_variables[cgi::REMOTE_ADDR]    = client_ip;
-	request_meta_variables[cgi::REMOTE_HOST]    = "";
-	request_meta_variables[cgi::REMOTE_IDENT]   = "";
-	request_meta_variables[cgi::REMOTE_USER]    = "";
-	request_meta_variables[cgi::REQUEST_METHOD] = request.request_line.method;
-	request_meta_variables[cgi::SCRIPT_NAME]    = TranslateToCgiPath(cgi_extension, cgi_script);
-	std::cout << "SCRIPT_NAME: " << request_meta_variables["SCRIPT_NAME"] << std::endl;
+		TranslatePathInfo(request_meta_variables["PATH_INFO"]);
+	request_meta_variables[cgi::QUERY_STRING]    = "";
+	request_meta_variables[cgi::REMOTE_ADDR]     = client_ip;
+	request_meta_variables[cgi::REMOTE_HOST]     = "";
+	request_meta_variables[cgi::REMOTE_IDENT]    = "";
+	request_meta_variables[cgi::REMOTE_USER]     = "";
+	request_meta_variables[cgi::REQUEST_METHOD]  = request.request_line.method;
+	request_meta_variables[cgi::SCRIPT_NAME]     = TranslateToScriptName(cgi_extension, cgi_script);
 	request_meta_variables[cgi::SERVER_NAME]     = FindValueFromMap(request.header_fields, "Host");
 	request_meta_variables[cgi::SERVER_PORT]     = server_port;
 	request_meta_variables[cgi::SERVER_PROTOCOL] = request.request_line.version;

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -19,12 +19,17 @@ TranslateToScriptName(const std::string &cgi_extension, const std::string &reque
 	// from root path
 	const std::string::size_type extension_pos = request_target.find(cgi_extension);
 	const std::string::size_type root_pos      = request_target.find("root/cgi-bin/");
-	const std::string            script_name   = request_target.substr(root_pos);
-	if (extension_pos != std::string::npos &&
-		root_pos != std::string::npos) { // for /aa.cgi/bb only return /aa.cgi
-		return script_name.substr(0, extension_pos + cgi_extension.length());
+	if (root_pos != std::string::npos) {
+		const std::string script_name = request_target.substr(root_pos);
+		if (extension_pos != std::string::npos) {
+			// /aa.cgi/bb の場合、/aa.cgi のみを返す
+			return script_name.substr(0, extension_pos + cgi_extension.length());
+		}
+		return script_name;
+	} else {
+		// root_pos が見つからない場合は request_target をそのまま返す
+		return request_target;
 	}
-	return script_name;
 }
 
 std::string TranslatePathInfo(const std::string &request_target) {

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -20,7 +20,8 @@ TranslateToScriptName(const std::string &cgi_extension, const std::string &reque
 	const std::string::size_type extension_pos = request_target.find(cgi_extension);
 	const std::string::size_type root_pos      = request_target.find("root/cgi-bin/");
 	const std::string            script_name   = request_target.substr(root_pos);
-	if (extension_pos != std::string::npos) { // for /aa.cgi/bb only return /aa.cgi
+	if (extension_pos != std::string::npos &&
+		root_pos != std::string::npos) { // for /aa.cgi/bb only return /aa.cgi
 		return script_name.substr(0, extension_pos + cgi_extension.length());
 	}
 	return script_name;

--- a/srcs/http/response/cgi_parse/cgi_parse.hpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.hpp
@@ -12,7 +12,7 @@ struct HttpRequestFormat;
 
 class CgiParse {
   public:
-	static utils::Result<cgi::CgiRequest> Parse(
+	static cgi::CgiRequest Parse(
 		const http::HttpRequestFormat &request,
 		const std::string             &cgi_script,
 		const std::string             &cgi_extension,

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -61,18 +61,15 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				server_info_result.allowed_methods
 			)) {
 			// これはパースした結果
-			utils::Result<cgi::CgiRequest> cgi_parse_result = CgiParse::Parse(
+			cgi::CgiRequest cgi_request = CgiParse::Parse(
 				request_info.request,
 				server_info_result.path,
 				server_info_result.cgi_extension,
 				utils::ToString(client_info.listen_server_port),
 				client_info.ip
 			);
-			if (!cgi_parse_result.IsOk()) { // parserが直でthrowするように変更か
-				throw HttpException("CGI Parse Error", StatusCode(BAD_REQUEST));
-			}
 			cgi_result.is_cgi      = true;
-			cgi_result.cgi_request = cgi_parse_result.GetValue();
+			cgi_result.cgi_request = cgi_request;
 		} else {
 			status_code = Method::Handler(
 				server_info_result.path,

--- a/test/webserv/unit/cgi/Makefile
+++ b/test/webserv/unit/cgi/Makefile
@@ -21,6 +21,8 @@ SRCS				+=	$(WS_CGI_DIR)/cgi.cpp \
 						$(WS_HTTP_CGI_PARSE_DIR)/cgi_parse.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp \
 						$(WS_EXCEPTION_DIR)/system_exception.cpp
 
 # 3. Add unit test files

--- a/test/webserv/unit/cgi_parse/Makefile
+++ b/test/webserv/unit/cgi_parse/Makefile
@@ -18,7 +18,9 @@ WS_HTTP_CGI_PARSE		:=	$(WS_HTTP_RESPONSE_DIR)/cgi_parse
 SRCS				+=	$(WS_HTTP_CGI_PARSE)/cgi_parse.cpp \
 						$(WS_CGI_DIR)/cgi_request.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
-						$(WS_UTILS_DIR)/color.cpp
+						$(WS_UTILS_DIR)/color.cpp \
+						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/isdigit.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_cgi_parse.cpp

--- a/test/webserv/unit/cgi_parse/test_cgi_parse.cpp
+++ b/test/webserv/unit/cgi_parse/test_cgi_parse.cpp
@@ -53,89 +53,104 @@ InputIt Next(InputIt it, typename std::iterator_traits<InputIt>::difference_type
 
 // ================================================= //
 
-// cgi_parseから見た相対パス
-const std::string html_dir_path    = "../../../../html";
-const std::string cgi_bin_dir_path = "../../../../cgi-bin";
+// ホームから見たディレクトリパス
+const std::string root_dir_path    = "root";
+const std::string cgi_bin_dir_path = root_dir_path + "/cgi-bin";
 
-// todo: TranslateToCgiPath()アップデートしてから
-/*
+// GETのテスト
 int Test1() {
 	// request
 	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
 	HttpRequestFormat request;
-	request.request_line                  = request_line;
-	request.header_fields[HOST]           = "host1";
-	request.header_fields[CONTENT_LENGTH] = "0";
-	request.header_fields[CONTENT_TYPE]   = "text/plain";
+	request.request_line        = request_line;
+	request.body_message        = "";
+	request.header_fields[HOST] = "host";
 
-	std::string cgi_script    = "/test.cgi";
-	std::string cgi_path_info = "/aa/b";
-	std::string cgi_extension = ".cgi";
-	std::string server_port   = "8080";
-	std::string client_ip     = "127.0.0.1";
-
-	utils::Result<cgi::CgiRequest> parse_result =
-		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port, client_ip);
-	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
-
-	try {
-		COMPARE(meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH));
-		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
-		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
-		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
-		COMPARE(meta_variables.at(cgi::REMOTE_ADDR), client_ip);
-		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
-		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
-		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
-		COMPARE(meta_variables.at(cgi::SERVER_PORT), server_port);
-		COMPARE(meta_variables.at(cgi::SERVER_PROTOCOL), request_line.version);
-	} catch (const std::exception &e) {
-		PrintNg();
-		std::cerr << e.what() << '\n';
-		return EXIT_FAILURE;
-	}
-	PrintOk();
-	return EXIT_SUCCESS;
-}
-*/
-
-/* 不足しているフィールドがある場合 */
-int Test2() {
-	// request
-	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
-	HttpRequestFormat request;
-	request.request_line                  = request_line;
-	request.header_fields[CONTENT_LENGTH] = "0";
-	request.header_fields[CONTENT_TYPE]   = "text/plain";
-
-	std::string cgi_script    = "/test.cgi";
+	std::string cgi_script    = "root/cgi-bin/test.cgi";
 	std::string cgi_path_info = "/aa/b";
 	std::string cgi_extension = ".cgi";
 	std::string server_port   = "8080";
 	std::string client_ip     = "127.0.0.2";
+	std::string server_name   = "host";
 
-	utils::Result<cgi::CgiRequest> parse_result =
+	cgi::CgiRequest cgi_request =
 		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port, client_ip);
-	cgi::MetaMap meta_variables = parse_result.GetValue().meta_variables;
-
+	cgi::MetaMap meta_variables = cgi_request.meta_variables;
 	try {
-		COMPARE(meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH));
-		COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
+		if (!request.body_message.empty()) {
+			COMPARE(
+				meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH)
+			);
+			COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
+		}
 		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
-		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), html_dir_path + cgi_path_info);
+		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), root_dir_path + cgi_path_info);
 		COMPARE(meta_variables.at(cgi::REMOTE_ADDR), client_ip);
 		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
-		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_bin_dir_path + cgi_script);
+		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_script);
 		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
 		COMPARE(meta_variables.at(cgi::SERVER_PORT), server_port);
 		COMPARE(meta_variables.at(cgi::SERVER_PROTOCOL), request_line.version);
+		COMPARE(cgi_request.body_message, request.body_message);
 	} catch (const std::exception &e) {
-		PrintOk();
-		utils::Debug("Test2", e.what());
-		return EXIT_SUCCESS;
+		PrintNg();
+		utils::Debug("Test1", e.what());
+		return EXIT_FAILURE;
 	}
-	PrintNg();
-	return EXIT_FAILURE;
+	PrintOk();
+	utils::Debug("PATH_INFO", meta_variables.at(cgi::PATH_INFO));
+	utils::Debug("PATH_TRANSLATED", meta_variables.at(cgi::PATH_TRANSLATED));
+	utils::Debug("SCRIPT_NAME", meta_variables.at(cgi::SCRIPT_NAME));
+	return EXIT_SUCCESS;
+}
+
+// POSTのテスト
+int Test2() {
+	// request
+	const RequestLine request_line = {"POST", "/", "HTTP/1.1"};
+	HttpRequestFormat request;
+	request.request_line                  = request_line;
+	request.body_message                  = "test";
+	request.header_fields[CONTENT_LENGTH] = "4";
+	request.header_fields[CONTENT_TYPE]   = "text/plain";
+	request.header_fields[HOST]           = "host";
+
+	std::string cgi_script    = "root/cgi-bin/test2.cgi";
+	std::string cgi_path_info = "";
+	std::string cgi_extension = ".cgi";
+	std::string server_port   = "8080";
+	std::string client_ip     = "127.0.0.1";
+	std::string server_name   = "host";
+
+	cgi::CgiRequest cgi_request =
+		CgiParse::Parse(request, cgi_script + cgi_path_info, cgi_extension, server_port, client_ip);
+	cgi::MetaMap meta_variables = cgi_request.meta_variables;
+	try {
+		if (!request.body_message.empty()) {
+			COMPARE(
+				meta_variables.at(cgi::CONTENT_LENGTH), request.header_fields.at(CONTENT_LENGTH)
+			);
+			COMPARE(meta_variables.at(cgi::CONTENT_TYPE), request.header_fields.at(CONTENT_TYPE));
+		}
+		COMPARE(meta_variables.at(cgi::PATH_INFO), cgi_path_info);
+		COMPARE(meta_variables.at(cgi::PATH_TRANSLATED), cgi_path_info);
+		COMPARE(meta_variables.at(cgi::REMOTE_ADDR), client_ip);
+		COMPARE(meta_variables.at(cgi::REQUEST_METHOD), request_line.method);
+		COMPARE(meta_variables.at(cgi::SCRIPT_NAME), cgi_script);
+		COMPARE(meta_variables.at(cgi::SERVER_NAME), request.header_fields.at(HOST));
+		COMPARE(meta_variables.at(cgi::SERVER_PORT), server_port);
+		COMPARE(meta_variables.at(cgi::SERVER_PROTOCOL), request_line.version);
+		COMPARE(cgi_request.body_message, request.body_message);
+	} catch (const std::exception &e) {
+		PrintNg();
+		utils::Debug("Test2", e.what());
+		return EXIT_FAILURE;
+	}
+	PrintOk();
+	utils::Debug("PATH_INFO", meta_variables.at(cgi::PATH_INFO));
+	utils::Debug("PATH_TRANSLATED", meta_variables.at(cgi::PATH_TRANSLATED));
+	utils::Debug("SCRIPT_NAME", meta_variables.at(cgi::SCRIPT_NAME));
+	return EXIT_SUCCESS;
 }
 
 } // namespace
@@ -143,7 +158,7 @@ int Test2() {
 int main() {
 	int ret = EXIT_SUCCESS;
 
-	// ret |= Test1();
+	ret |= Test1();
 	ret |= Test2();
 
 	return ret;


### PR DESCRIPTION
## CgiParseを修正しました

- [x] CgiParseのmap.atをなくすことで値が未セットでもthrowされないように
- [x] 返り値もCgiResultからCgiRequestに変更
- [x] 諸々のパス修正
- [x] テストも修正(POSTも追加)

これでページにあった http://localhost:8080/cgi-bin/print_env.pl が動くようになりました

## TODO
- [ ] http://localhost:8080/cgi-bin/print_env.pl/aa のようなリクエストでは/aaをPATH_INFOにしてCGIリクエストとして扱わないといけないが、他のところで弾かれているので要修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - CGIパースロジックの改善により、スクリプト名の取得方法が更新されました。
  - ヘッダー値の取得を強化する新しいユーティリティ関数が追加されました。

- **バグ修正**
  - リダイレクト処理のロジックが明確化され、適切な例外処理が追加されました。

- **テスト**
  - テストケースのディレクトリパスが新しいルートディレクトリに更新され、GETおよびPOSTメソッドのリクエスト処理が調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->