### PR TITLE
[update] ヘッダーの値チェックを追加、前後のOWSを切り取るように

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -300,6 +300,17 @@ void HttpParse::CheckValidHeaderFieldNameAndValue(
 			"Error: the name of Header field has a space.", StatusCode(BAD_REQUEST)
 		);
 	}
+	if (header_field_name == "Host" && header_field_value.empty()) {
+		throw HttpException(
+			"Error: the value of Host header field is empty.", StatusCode(BAD_REQUEST)
+		);
+	} else if (header_field_name == "Content-Length" &&
+			   !utils::ConvertStrToSize(header_field_value).IsOk()) {
+		throw HttpException(
+			"Error: the value of Content-Length header field is not a number.",
+			StatusCode(BAD_REQUEST)
+		);
+	}
 }
 
 // status_line && header

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -32,7 +32,7 @@ bool IsStringUpper(const std::string &str) {
 	return true;
 }
 
-std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
+std::string StrTrimOptionalWhitespace(const std::string &str) {
 	std::string::size_type start = str.find_first_not_of(OPTIONAL_WHITESPACE);
 	if (start == std::string::npos) {
 		return "";
@@ -221,7 +221,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		std::size_t colon_pos          = (*it).find_first_of(':');
 		std::string header_field_name  = (*it).substr(0, colon_pos);
 		std::string header_field_value = (*it).substr(colon_pos + 1);
-		header_field_value             = StrTrimLeadingOptionalWhitespace(header_field_value);
+		header_field_value             = StrTrimOptionalWhitespace(header_field_value);
 		CheckValidHeaderFieldNameAndValue(header_field_name, header_field_value);
 		// todo:
 		// マルチパートを対応する場合はutils::SplitStrを使用して、セミコロン区切りのstd::vector<std::string>になる。

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -133,13 +133,10 @@ void HttpParse::ParseBodyMessage(HttpRequestParsedData &data) {
 	}
 	// todo: HttpRequestParsedDataクラスでcontent_lengthを保持？
 	// why: ParseBodyMessageが呼ばれるたびにcontent_lengthを変換するのを避けるため
-	const utils::Result<std::size_t> convert_result =
-		utils::ConvertStrToSize(data.request_result.request.header_fields[CONTENT_LENGTH]);
-	if (!convert_result.IsOk()) {
-		throw HttpException("Error: wrong Content-Length number", StatusCode(BAD_REQUEST));
-	}
-	const size_t content_length = convert_result.GetValue();
-	size_t       readable_content_length =
+	const size_t content_length =
+		utils::ConvertStrToSize(data.request_result.request.header_fields[CONTENT_LENGTH])
+			.GetValue();
+	size_t readable_content_length =
 		content_length - data.request_result.request.body_message.size();
 	if (data.current_buf.size() >= readable_content_length) {
 		data.request_result.request.body_message +=

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -33,12 +33,12 @@ bool IsStringUpper(const std::string &str) {
 }
 
 std::string StrTrimLeadingOptionalWhitespace(const std::string &str) {
-	std::string::size_type pos = str.find_first_not_of(OPTIONAL_WHITESPACE);
-	if (pos != std::string::npos) {
-		return str.substr(pos);
-	} else {
+	std::string::size_type start = str.find_first_not_of(OPTIONAL_WHITESPACE);
+	if (start == std::string::npos) {
 		return "";
 	}
+	std::string::size_type end = str.find_last_not_of(OPTIONAL_WHITESPACE);
+	return str.substr(start, end - start + 1);
 }
 
 bool IsBodyMessageReadingRequired(const HeaderFields &header_fields) {

--- a/srcs/http/request/parse/http_parse.hpp
+++ b/srcs/http/request/parse/http_parse.hpp
@@ -55,7 +55,6 @@ class HttpParse {
 	static void CheckValidHeaderFieldNameAndValue(
 		const std::string &header_field_name, const std::string &header_field_value
 	);
-	static bool HasConnectionKeepInHeaderFields(const HeaderFields &header_fields);
 };
 
 } // namespace http

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -117,11 +117,10 @@ not_implemented_response = response_header_501 + not_implemented_file_501.decode
             REQUEST_GET_2XX_DIR + "200_03_sub_connection_close.txt",
             response_header_get_sub_200_close + sub_index_file,
         ),
-        # todo
-        # (
-        #     REQUEST_GET_2XX_DIR + "200_12_header_field_value_space.txt",
-        #     response_header_get_root_200_close + root_index_file,
-        # ),
+        (
+            REQUEST_GET_2XX_DIR + "200_12_header_field_value_space.txt",
+            response_header_get_root_200_close + root_index_file,
+        ),
         (
             REQUEST_GET_2XX_DIR + "200_13_space_header_field_value.txt",
             response_header_get_root_200_close + root_index_file,

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -269,8 +269,7 @@ int main(void) {
 	static const TestCase test_case_http_request_line_format[] = {
 		TestCase("GET / HTTP/1.1\r\n", test1_request_line),
 		TestCase("GET / HTTP/1.\r\n", test2_request_line),
-		TestCase("GET / HTTP/1.1", test3_request_line)
-	};
+		TestCase("GET / HTTP/1.1", test3_request_line)};
 
 	ret_code |= RunTestCases(
 		test_case_http_request_line_format,
@@ -287,11 +286,11 @@ int main(void) {
 	test1_header_fields.is_request_format.is_body_message  = true;
 
 	// 5.ヘッダフィールドの書式が正しくない場合
-	// http::HttpRequestParsedData test2_header_fields;
-	// test2_header_fields.request_result.status_code         = http::StatusCode(http::BAD_REQUEST);
-	// test2_header_fields.is_request_format.is_request_line  = true;
-	// test2_header_fields.is_request_format.is_header_fields = false;
-	// test2_header_fields.is_request_format.is_body_message  = false;
+	http::HttpRequestParsedData test2_header_fields;
+	test2_header_fields.request_result.status_code         = http::StatusCode(http::BAD_REQUEST);
+	test2_header_fields.is_request_format.is_request_line  = true;
+	test2_header_fields.is_request_format.is_header_fields = false;
+	test2_header_fields.is_request_format.is_body_message  = false;
 
 	// 6.ヘッダフィールドにContent-Lengthがあるがボディメッセージがない場合
 	http::HttpRequestParsedData test3_header_fields;
@@ -305,7 +304,7 @@ int main(void) {
 
 	static const TestCase test_case_http_request_header_fields_format[] = {
 		TestCase("GET / HTTP/1.1\r\nHost: a\r\n\r\n", test1_header_fields),
-		// TestCase("GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fields),
+		TestCase("GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fields),
 		TestCase("GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\n", test3_header_fields),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -1,3 +1,4 @@
+#include "http_message.hpp"
 #include "http_parse.hpp"
 #include "utils.hpp"
 #include <cstdlib>
@@ -269,7 +270,8 @@ int main(void) {
 	static const TestCase test_case_http_request_line_format[] = {
 		TestCase("GET / HTTP/1.1\r\n", test1_request_line),
 		TestCase("GET / HTTP/1.\r\n", test2_request_line),
-		TestCase("GET / HTTP/1.1", test3_request_line)};
+		TestCase("GET / HTTP/1.1", test3_request_line)
+	};
 
 	ret_code |= RunTestCases(
 		test_case_http_request_line_format,
@@ -319,9 +321,10 @@ int main(void) {
 	test1_body_message.request_result.status_code = http::StatusCode(http::OK);
 	test1_body_message.request_result.request.request_line =
 		CreateRequestLine("GET", "/", "HTTP/1.1");
-	test1_body_message.is_request_format.is_request_line  = true;
-	test1_body_message.is_request_format.is_header_fields = true;
-	test1_body_message.is_request_format.is_body_message  = true;
+	test1_body_message.is_request_format.is_request_line   = true;
+	test1_body_message.is_request_format.is_header_fields  = true;
+	test1_body_message.is_request_format.is_body_message   = true;
+	test1_body_message.request_result.request.body_message = "abc";
 
 	// 8.Content-Lengthの数値以上にボディメッセージがある場合
 	http::HttpRequestParsedData test2_body_message;
@@ -337,7 +340,7 @@ int main(void) {
 	http::HttpRequestParsedData test3_body_message;
 	test3_body_message.request_result.status_code          = http::StatusCode(http::BAD_REQUEST);
 	test3_body_message.is_request_format.is_request_line   = true;
-	test3_body_message.is_request_format.is_header_fields  = true;
+	test3_body_message.is_request_format.is_header_fields  = false;
 	test3_body_message.is_request_format.is_body_message   = false;
 	test3_body_message.request_result.request.body_message = "ab";
 
@@ -412,10 +415,18 @@ int main(void) {
 	test10_body_message.is_request_format.is_body_message   = false;
 	test10_body_message.request_result.request.body_message = "Wikipedia";
 
+	// 17.前後にOWSがある場合
+	http::HttpRequestParsedData test11_body_message;
+	test11_body_message.request_result.status_code = http::StatusCode(http::OK);
+	test11_body_message.request_result.request.request_line =
+		CreateRequestLine("GET", "/", "HTTP/1.1");
+	test11_body_message.is_request_format.is_request_line                = true;
+	test11_body_message.is_request_format.is_header_fields               = true;
+	test11_body_message.is_request_format.is_body_message                = true;
+	test11_body_message.request_result.request.header_fields[http::HOST] = "host";
+
 	static const TestCase test_case_http_request_body_message_format[] = {
-		TestCase(
-			"GET / HTTP/1.1\r\nHost: a\r\n\r\nContent-Length:  3\r\n\r\nabc", test1_body_message
-		),
+		TestCase("GET / HTTP/1.1\r\nHost: a\r\nContent-Length:  3\r\n\r\nabc", test1_body_message),
 		TestCase(
 			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\nabccccccccc",
 			test2_body_message
@@ -460,6 +471,7 @@ int main(void) {
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
 			test10_body_message
 		),
+		TestCase("GET / HTTP/1.1\r\nHost:    host    \r\n\r\n", test11_body_message),
 	};
 
 	ret_code |= RunTestCases(


### PR DESCRIPTION
## ヘッダーの値チェックを追加、前後のOWSを切り取るようにしました

- [x] ヘッダーの値をチェックする関数を追加(HostとContent-Length)
- [x] 今までにあった似たような処理を削除(Content-Lengthのチェックは元々あった)
- [x] ヘッダーの値の前後のOWSを切り取るように
- [x] テストの追加

思ったよりチェックが少なかったです。CheckHeaderFieldValueを作るという話もありましたが、ヘッダーフィールドの名前によってチェックの種類が変わるので、nameとvalueを同時に渡す今までと同じ関数にしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- HTTPリクエストの解析ロジックが改善され、重要なヘッダーの検証が強化されました。

- **バグ修正**
	- 空の「Host」ヘッダーや無効な「Content-Length」ヘッダーに対する例外処理が追加されました。

- **テスト**
	- 新しいテストケースが追加され、既存のテストケースが修正され、HTTPリクエスト解析の堅牢性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->