### PR TITLE
[fix] server / pipe_fd に EPOLLHUP が起きても read の返り値が 0 になるまでは終了としない

### DIFF
--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -161,7 +161,7 @@ void Server::HandleExistingConnection(const event::Event &event) {
 		return;
 	}
 	if (event.type & event::EVENT_HANGUP) {
-		HandleHangUpEvent(event.fd);
+		HandleHangUpEvent(event);
 		return;
 	}
 	if (event.type & event::EVENT_READ) {
@@ -197,20 +197,21 @@ void Server::HandleErrorEvent(int fd) {
 	SetInternalServerError(client_fd);
 }
 
-void Server::HandleHangUpEvent(int fd) {
+void Server::HandleHangUpEvent(const event::Event &event) {
+	const int fd = event.fd;
 	if (!IsMessageExist(fd)) {
 		return;
 	}
 	if (IsCgi(fd)) {
-		const int client_fd = cgi_manager_.GetClientFd(fd);
-		// todo: EPOLL errorだからといってread pipeが空とは限らないのかもしれない？
-		const CgiResponseResult cgi_response_result = AddAndGetCgiResponse(client_fd, "");
-		if (!cgi_response_result.IsOk()) {
-			throw std::logic_error("HandleErrorEvent: Invalid result from cgi response");
+		const int                     client_fd      = cgi_manager_.GetClientFd(fd);
+		const CgiManager::GetFdResult read_fd_result = cgi_manager_.GetReadFd(client_fd);
+		// except on read_fd
+		if (!read_fd_result.IsOk() || read_fd_result.GetValue() != fd) {
+			SetInternalServerError(client_fd);
+			return;
 		}
-		// Explicitly delete from cgi_manager
-		cgi_manager_.DeleteCgi(client_fd);
-		GetHttpResponseFromCgiResponse(client_fd, cgi_response_result.GetValue());
+		// If it's read_fd, keep reading until read returns 0
+		HandleReadEvent(event);
 		return;
 	}
 	// fd == client_fd

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -42,7 +42,7 @@ class Server {
 	PortIpMap CreatePortIpMap(const VirtualServerList &virtual_server_list);
 	void      Listen(const HostPortPair &host_port);
 	void      HandleErrorEvent(int fd);
-	void      HandleHangUpEvent(int fd);
+	void      HandleHangUpEvent(const event::Event &event);
 	void      HandleEvent(const event::Event &event);
 	void      HandleNewConnection(int server_fd);
 	void      HandleExistingConnection(const event::Event &event);

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -42,6 +42,7 @@ class Server {
 	PortIpMap CreatePortIpMap(const VirtualServerList &virtual_server_list);
 	void      Listen(const HostPortPair &host_port);
 	void      HandleErrorEvent(int fd);
+	void      HandleHangUpEvent(int fd);
 	void      HandleEvent(const event::Event &event);
 	void      HandleNewConnection(int server_fd);
 	void      HandleExistingConnection(const event::Event &event);


### PR DESCRIPTION
たまに `cgi_response` を全部 `Read()` する前に `EPOLLHUP` が起きて途中までしか client に返せていなかった (5～10 回に 1 回くらい)

`pipe_fd` の場合はもう一方が `close()` されていると HUP が起こる可能性があるらしく、`close()` のタイミングを変えればうまくいくかと思ったのですがうまくいかず…、

man poll
> POLLHUP
Hang up (only returned in revents; ignored in events). Note that when reading from a channel such as a pipe or a stream socket, this event merely indicates that the peer closed its end of the channel. Subsequent reads from the channel will return 0 (end of file) only after all outstanding data in the channel has been consumed.

そもそも `Read()` の結果が 0 byte になったら response の終了とするのが自然のようで、HUP が起きても最後まで `Read()` し、0 byte が返った時に初めて response の終了と判定するようにしました

これにより今までたまに途中までしか client に返せていなかったのが毎回全 response を返せるようになりました

### 実行
```sh
# server
make run

# client
make run REQUEST=../request/cgi/get/200_05_print_env.pl_close.txt
```

これも動きます
`cgi/get/` : 200_5, 200_6
`cgi/post/` : 200_1, 200_2, 200_3

よりシンプルなはずの `cgi/get/200_01` が動かない… 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - クライアントのハングアップイベントを処理する新しいメソッド「HandleHangUpEvent」を追加しました。
  - 既存の接続に関連するイベント処理が改善され、エラーハンドリングが強化されました。

- **バグ修正**
  - メッセージが存在しないファイルディスクリプタに対するエラーハンドリングを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->