### PR TITLE
[fix] chunked の最後の処理

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -198,7 +198,8 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			StatusCode(BAD_REQUEST)
 		);
 	}
-
+	// 終端に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
+	data.current_buf.erase(0, CRLF.size());
 	data.is_request_format.is_body_message = true;
 }
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -78,6 +78,10 @@ bool IsVString(const std::string &str) {
 	return true;
 }
 
+bool StartWith(const std::string &str, const std::string &prefix) {
+	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
 } // namespace
 
 void HttpParse::ParseRequestLine(HttpRequestParsedData &data) {
@@ -191,14 +195,15 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 		}
 	}
 	if (data.current_buf == "\0") {
-		return;                            // is_request_format.is_body_message = false;
-	} else if (data.current_buf != CRLF) { // 終端に0\r\n\r\nの\r\nがあるはず
+		return; // is_request_format.is_body_message = false;
+	}
+	if (!StartWith(data.current_buf, CRLF)) { // 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるはず
 		throw HttpException(
 			"Error: Missing or incorrect chunked transfer encoding terminator",
 			StatusCode(BAD_REQUEST)
 		);
 	}
-	// 終端に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
+	// 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
 	data.current_buf.erase(0, CRLF.size());
 	data.is_request_format.is_body_message = true;
 }

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -369,84 +369,6 @@ int main(void) {
 	test3_body_message.request_result.request.body_message = "ab";
 	test3_body_message.current_buf                         = "abccccccccc";
 
-	// 10.Chunked Transfer-Encodingの場合
-	http::HttpRequestParsedData test4_body_message;
-	test4_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test4_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test4_body_message.is_request_format.is_request_line  = true;
-	test4_body_message.is_request_format.is_header_fields = true;
-	test4_body_message.is_request_format.is_body_message  = true;
-	test4_body_message.request_result.request.body_message =
-		"Wikipedia is a free online encyclopedia that anyone can edit.";
-	test4_body_message.current_buf = "\r\n"; // todo: "" にしたい
-
-	// 11.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
-	http::HttpRequestParsedData test5_body_message;
-	test5_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test5_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test5_body_message.is_request_format.is_request_line   = true;
-	test5_body_message.is_request_format.is_header_fields  = true;
-	test5_body_message.is_request_format.is_body_message   = false;
-	test5_body_message.request_result.request.body_message = "Wikipedia";
-	test5_body_message.current_buf                         = "0\r\n\r\n";
-
-	// 12.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
-	http::HttpRequestParsedData test6_body_message;
-	test6_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test6_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test6_body_message.is_request_format.is_request_line   = true;
-	test6_body_message.is_request_format.is_header_fields  = true;
-	test6_body_message.is_request_format.is_body_message   = false;
-	test6_body_message.request_result.request.body_message = "Wikipedia";
-	test6_body_message.current_buf                         = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
-
-	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
-	http::HttpRequestParsedData test7_body_message;
-	test7_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test7_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test7_body_message.is_request_format.is_request_line   = true;
-	test7_body_message.is_request_format.is_header_fields  = true;
-	test7_body_message.is_request_format.is_body_message   = false;
-	test7_body_message.request_result.request.body_message = "Wikipedia";
-	test7_body_message.current_buf                         = "";
-
-	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
-	http::HttpRequestParsedData test8_body_message;
-	test8_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test8_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test8_body_message.is_request_format.is_request_line   = true;
-	test8_body_message.is_request_format.is_header_fields  = true;
-	test8_body_message.is_request_format.is_body_message   = false;
-	test8_body_message.request_result.request.body_message = "Wikipedia";
-	test8_body_message.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
-
-	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
-	http::HttpRequestParsedData test9_body_message;
-	test9_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test9_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test9_body_message.is_request_format.is_request_line   = true;
-	test9_body_message.is_request_format.is_header_fields  = true;
-	test9_body_message.is_request_format.is_body_message   = false;
-	test9_body_message.request_result.request.body_message = "Wikipedia";
-	test9_body_message.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
-
-	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
-	http::HttpRequestParsedData test10_body_message;
-	test10_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test10_body_message.request_result.request.request_line =
-		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test10_body_message.is_request_format.is_request_line   = true;
-	test10_body_message.is_request_format.is_header_fields  = true;
-	test10_body_message.is_request_format.is_body_message   = false;
-	test10_body_message.request_result.request.body_message = "Wikipedia";
-	test10_body_message.current_buf                         = "";
-
 	static const TestCase test_case_http_request_body_message_format[] = {
 		TestCase(
 			"GET / HTTP/1.1\r\nHost: a\r\n\r\nContent-Length:  3\r\n\r\nabc", test1_body_message
@@ -459,48 +381,135 @@ int main(void) {
 			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: dddd\r\n\r\nabccccccccc",
 			test3_body_message
 		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0x34\r\n is a free online encyclopedia that "
-			"anyone can edit.\r\n0\r\n\r\n",
-			test4_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\n2\r\npedia\r\n0\r\n\r\n",
-			test5_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\nContent-Length: 10\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n",
-			test6_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n",
-			test7_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\nss\r\npedia\r\n",
-			test8_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\n-122\r\npedia\r\n",
-			test9_body_message
-		),
-		TestCase(
-			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
-			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
-			test10_body_message
-		),
 	};
 
 	ret_code |= RunTestCases(
 		test_case_http_request_body_message_format,
 		sizeof(test_case_http_request_body_message_format) /
 			sizeof(test_case_http_request_body_message_format[0])
+	);
+
+	// 10.Chunked Transfer-Encodingの場合
+	http::HttpRequestParsedData test1_body_message_chunked;
+	test1_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test1_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test1_body_message_chunked.is_request_format.is_request_line  = true;
+	test1_body_message_chunked.is_request_format.is_header_fields = true;
+	test1_body_message_chunked.is_request_format.is_body_message  = true;
+	test1_body_message_chunked.request_result.request.body_message =
+		"Wikipedia is a free online encyclopedia that anyone can edit.";
+	test1_body_message_chunked.current_buf = "\r\n"; // todo: "" にしたい
+
+	// 11.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
+	http::HttpRequestParsedData test2_body_message_chunked;
+	test2_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test2_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test2_body_message_chunked.is_request_format.is_request_line   = true;
+	test2_body_message_chunked.is_request_format.is_header_fields  = true;
+	test2_body_message_chunked.is_request_format.is_body_message   = false;
+	test2_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test2_body_message_chunked.current_buf                         = "0\r\n\r\n";
+
+	// 12.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
+	http::HttpRequestParsedData test3_body_message_chunked;
+	test3_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test3_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test3_body_message_chunked.is_request_format.is_request_line   = true;
+	test3_body_message_chunked.is_request_format.is_header_fields  = true;
+	test3_body_message_chunked.is_request_format.is_body_message   = false;
+	test3_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test3_body_message_chunked.current_buf = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
+
+	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
+	http::HttpRequestParsedData test4_body_message_chunked;
+	test4_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test4_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test4_body_message_chunked.is_request_format.is_request_line   = true;
+	test4_body_message_chunked.is_request_format.is_header_fields  = true;
+	test4_body_message_chunked.is_request_format.is_body_message   = false;
+	test4_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test4_body_message_chunked.current_buf                         = "";
+
+	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
+	http::HttpRequestParsedData test5_body_message_chunked;
+	test5_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test5_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test5_body_message_chunked.is_request_format.is_request_line   = true;
+	test5_body_message_chunked.is_request_format.is_header_fields  = true;
+	test5_body_message_chunked.is_request_format.is_body_message   = false;
+	test5_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test5_body_message_chunked.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
+
+	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
+	http::HttpRequestParsedData test6_body_message_chunked;
+	test6_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test6_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test6_body_message_chunked.is_request_format.is_request_line   = true;
+	test6_body_message_chunked.is_request_format.is_header_fields  = true;
+	test6_body_message_chunked.is_request_format.is_body_message   = false;
+	test6_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test6_body_message_chunked.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
+
+	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
+	http::HttpRequestParsedData test7_body_message_chunked;
+	test7_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test7_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test7_body_message_chunked.is_request_format.is_request_line   = true;
+	test7_body_message_chunked.is_request_format.is_header_fields  = true;
+	test7_body_message_chunked.is_request_format.is_body_message   = false;
+	test7_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test7_body_message_chunked.current_buf                         = "";
+
+	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0x34\r\n is a free online encyclopedia that "
+			"anyone can edit.\r\n0\r\n\r\n",
+			test1_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n2\r\npedia\r\n0\r\n\r\n",
+			test2_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\nContent-Length: 10\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n",
+			test3_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n",
+			test4_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\nss\r\npedia\r\n",
+			test5_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n-122\r\npedia\r\n",
+			test6_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
+			test7_body_message_chunked
+		),
+	};
+
+	ret_code |= RunTestCases(
+		test_case_http_request_body_message_format_with_chunked,
+		sizeof(test_case_http_request_body_message_format_with_chunked) /
+			sizeof(test_case_http_request_body_message_format_with_chunked[0])
 	);
 
 	return ret_code;

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -162,7 +162,7 @@ Result IsSameHeaderFields(const http::HeaderFields &res, http::HeaderFields expe
 	return header_fields_result;
 }
 
-Result IsSameBodyMessage(const std::string &res, const std::string expected) {
+Result IsSameBodyMessage(const std::string &res, const std::string &expected) {
 	Result             body_message_result;
 	std::ostringstream error_log;
 	if (res != expected) {
@@ -234,7 +234,7 @@ int Run(const std::string &read_buf, const http::HttpRequestParsedData &expected
 }
 
 int RunTestCases(const TestCase test_cases[], std::size_t num_test_cases) {
-	int ret_code = 0;
+	int ret_code = EXIT_SUCCESS;
 
 	for (std::size_t i = 0; i < num_test_cases; i++) {
 		const TestCase test_case = test_cases[i];
@@ -246,7 +246,7 @@ int RunTestCases(const TestCase test_cases[], std::size_t num_test_cases) {
 } // namespace
 
 int main(void) {
-	int ret_code = 0;
+	int ret_code = EXIT_SUCCESS;
 
 	// todo: http/http_response/test_http_request.cpp HttpRequestParsedData関数のテストケース
 
@@ -260,7 +260,7 @@ int main(void) {
 	test2_request_line.request_result.status_code        = http::StatusCode(http::BAD_REQUEST);
 	test2_request_line.is_request_format.is_request_line = false;
 
-	// 3.CRLNがない場合
+	// 3.CRLFがない場合
 	http::HttpRequestParsedData test3_request_line;
 	// 本来のステータスコードはRequest Timeout
 	test3_request_line.request_result.status_code        = http::StatusCode(http::OK);

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -399,7 +399,7 @@ int main(void) {
 	test1_body_message_chunked.is_request_format.is_body_message  = true;
 	test1_body_message_chunked.request_result.request.body_message =
 		"Wikipedia is a free online encyclopedia that anyone can edit.";
-	test1_body_message_chunked.current_buf = "\r\n"; // todo: "" にしたい
+	test1_body_message_chunked.current_buf = "";
 
 	// 11.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
 	http::HttpRequestParsedData test2_body_message_chunked;

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -287,11 +287,11 @@ int main(void) {
 	test1_header_fields.is_request_format.is_body_message  = true;
 
 	// 5.ヘッダフィールドの書式が正しくない場合
-	// http::HttpRequestParsedData test2_header_fields;
-	// test2_header_fields.request_result.status_code         = http::StatusCode(http::BAD_REQUEST);
-	// test2_header_fields.is_request_format.is_request_line  = true;
-	// test2_header_fields.is_request_format.is_header_fields = false;
-	// test2_header_fields.is_request_format.is_body_message  = false;
+	http::HttpRequestParsedData test2_header_fields;
+	test2_header_fields.request_result.status_code         = http::StatusCode(http::BAD_REQUEST);
+	test2_header_fields.is_request_format.is_request_line  = true;
+	test2_header_fields.is_request_format.is_header_fields = false;
+	test2_header_fields.is_request_format.is_body_message  = false;
 
 	// 6.ヘッダフィールドにContent-Lengthがあるがボディメッセージがない場合
 	http::HttpRequestParsedData test3_header_fields;
@@ -305,7 +305,7 @@ int main(void) {
 
 	static const TestCase test_case_http_request_header_fields_format[] = {
 		TestCase("GET / HTTP/1.1\r\nHost: a\r\n\r\n", test1_header_fields),
-		// TestCase("GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fields),
+		TestCase("GET / HTTP/1.1\r\nHost :\r\n\r\n", test2_header_fields),
 		TestCase("GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\n", test3_header_fields),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -467,6 +467,17 @@ int main(void) {
 	test7_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test7_body_message_chunked.current_buf                         = "";
 
+	// 17.Chunked Transfer-Encodingの場合で、current_bufに次のリクエストが入っている場合正しく残るか
+	http::HttpRequestParsedData test8_body_message_chunked;
+	test8_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test8_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test8_body_message_chunked.is_request_format.is_request_line   = true;
+	test8_body_message_chunked.is_request_format.is_header_fields  = true;
+	test8_body_message_chunked.is_request_format.is_body_message   = true;
+	test8_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test8_body_message_chunked.current_buf                         = "GET /";
+
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
@@ -503,6 +514,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
 			test7_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\nGET /",
+			test8_body_message_chunked
 		),
 	};
 


### PR DESCRIPTION
### `unit/test_http_parse` の修正
- `Parse()` 後に残った `current_buf` も比較するようにしました
- それにより test case 10, 14, 15 が未対応と分かったので修正

### `http_parse.cpp` 修正
- chunked の parse に成功したらまだ `current_buf` に `CRLF` が残っていたのを消すだけをしました -> test 10 が通るように
- `current_buf` に次の request がくっついている場合もあるので、最後の終端判定を `current_buf` の先頭だけ見るように変更 -> 新規 test 17 追加


多くなりそうだったので test 14, 15 に対応する実装は別 Issue (->#587 )

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- チャンク転送エンコーディングの処理を改善し、HTTPリクエストのパース機能を強化しました。
	- 新しいユーティリティ関数「StartWith」を追加し、文字列の先頭を検証します。

- **バグ修正**
	- チャンクデータの終端処理に関するロジックを明確化し、エラー処理を強化しました。

- **テスト**
	- チャンク転送エンコーディングに関するテストケースを拡張し、エッジケースをカバーしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->