### PR TITLE
[update] chunked の最後の処理修正

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -78,6 +78,10 @@ bool IsVString(const std::string &str) {
 	return true;
 }
 
+bool StartWith(const std::string &str, const std::string &prefix) {
+	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
 } // namespace
 
 void HttpParse::ParseRequestLine(HttpRequestParsedData &data) {
@@ -188,14 +192,15 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 		}
 	}
 	if (data.current_buf == "\0") {
-		return;                            // is_request_format.is_body_message = false;
-	} else if (data.current_buf != CRLF) { // 終端に0\r\n\r\nの\r\nがあるはず
+		return; // is_request_format.is_body_message = false;
+	}
+	if (!StartWith(data.current_buf, CRLF)) { // 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるはず
 		throw HttpException(
 			"Error: Missing or incorrect chunked transfer encoding terminator",
 			StatusCode(BAD_REQUEST)
 		);
 	}
-	// 終端に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
+	// 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
 	data.current_buf.erase(0, CRLF.size());
 	data.is_request_format.is_body_message = true;
 }

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -195,7 +195,8 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			StatusCode(BAD_REQUEST)
 		);
 	}
-
+	// 終端に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
+	data.current_buf.erase(0, CRLF.size());
 	data.is_request_format.is_body_message = true;
 }
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -478,6 +478,17 @@ int main(void) {
 	test7_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test7_body_message_chunked.current_buf                         = "";
 
+	// 18.Chunked Transfer-Encodingの場合で、current_bufに次のリクエストが入っている場合正しく残るか
+	http::HttpRequestParsedData test8_body_message_chunked;
+	test8_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test8_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test8_body_message_chunked.is_request_format.is_request_line   = true;
+	test8_body_message_chunked.is_request_format.is_header_fields  = true;
+	test8_body_message_chunked.is_request_format.is_body_message   = true;
+	test8_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test8_body_message_chunked.current_buf                         = "GET /";
+
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
@@ -514,6 +525,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
 			test7_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\nGET /",
+			test8_body_message_chunked
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -370,16 +370,16 @@ int main(void) {
 	test3_body_message.request_result.request.body_message = "ab";
 	test3_body_message.current_buf                         = "abccccccccc";
 
-	// 17.前後にOWSがある場合
-	http::HttpRequestParsedData test11_body_message;
-	test11_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test11_body_message.request_result.request.request_line =
+	// 10.前後にOWSがある場合
+	http::HttpRequestParsedData test4_body_message;
+	test4_body_message.request_result.status_code = http::StatusCode(http::OK);
+	test4_body_message.request_result.request.request_line =
 		CreateRequestLine("GET", "/", "HTTP/1.1");
-	test11_body_message.is_request_format.is_request_line                = true;
-	test11_body_message.is_request_format.is_header_fields               = true;
-	test11_body_message.is_request_format.is_body_message                = true;
-	test11_body_message.request_result.request.header_fields[http::HOST] = "host";
-	test11_body_message.current_buf                                      = "";
+	test4_body_message.is_request_format.is_request_line                = true;
+	test4_body_message.is_request_format.is_header_fields               = true;
+	test4_body_message.is_request_format.is_body_message                = true;
+	test4_body_message.request_result.request.header_fields[http::HOST] = "host";
+	test4_body_message.current_buf                                      = "";
 
 	static const TestCase test_case_http_request_body_message_format[] = {
 		TestCase("GET / HTTP/1.1\r\nHost: a\r\nContent-Length:  3\r\n\r\nabc", test1_body_message),
@@ -391,7 +391,7 @@ int main(void) {
 			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: dddd\r\n\r\nabccccccccc",
 			test3_body_message
 		),
-		TestCase("GET / HTTP/1.1\r\nHost:    host    \r\n\r\n", test11_body_message),
+		TestCase("GET / HTTP/1.1\r\nHost:    host    \r\n\r\n", test4_body_message),
 	};
 
 	ret_code |= RunTestCases(
@@ -400,120 +400,120 @@ int main(void) {
 			sizeof(test_case_http_request_body_message_format[0])
 	);
 
-	// 10.Chunked Transfer-Encodingの場合
-	http::HttpRequestParsedData test4_body_message;
-	test4_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test4_body_message.request_result.request.request_line =
+	// 11.Chunked Transfer-Encodingの場合
+	http::HttpRequestParsedData test1_body_message_chunked;
+	test1_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test1_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test4_body_message.is_request_format.is_request_line  = true;
-	test4_body_message.is_request_format.is_header_fields = true;
-	test4_body_message.is_request_format.is_body_message  = true;
-	test4_body_message.request_result.request.body_message =
+	test1_body_message_chunked.is_request_format.is_request_line  = true;
+	test1_body_message_chunked.is_request_format.is_header_fields = true;
+	test1_body_message_chunked.is_request_format.is_body_message  = true;
+	test1_body_message_chunked.request_result.request.body_message =
 		"Wikipedia is a free online encyclopedia that anyone can edit.";
-	test4_body_message.current_buf = "\r\n"; // todo: "" にしたい
+	test1_body_message_chunked.current_buf = "\r\n"; // todo: "" にしたい
 
-	// 11.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
-	http::HttpRequestParsedData test5_body_message;
-	test5_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test5_body_message.request_result.request.request_line =
+	// 12.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
+	http::HttpRequestParsedData test2_body_message_chunked;
+	test2_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test2_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test5_body_message.is_request_format.is_request_line   = true;
-	test5_body_message.is_request_format.is_header_fields  = true;
-	test5_body_message.is_request_format.is_body_message   = false;
-	test5_body_message.request_result.request.body_message = "Wikipedia";
-	test5_body_message.current_buf                         = "0\r\n\r\n";
+	test2_body_message_chunked.is_request_format.is_request_line   = true;
+	test2_body_message_chunked.is_request_format.is_header_fields  = true;
+	test2_body_message_chunked.is_request_format.is_body_message   = false;
+	test2_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test2_body_message_chunked.current_buf                         = "0\r\n\r\n";
 
-	// 12.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
-	http::HttpRequestParsedData test6_body_message;
-	test6_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test6_body_message.request_result.request.request_line =
+	// 13.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
+	http::HttpRequestParsedData test3_chunked_body_message;
+	test3_chunked_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test3_chunked_body_message.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test6_body_message.is_request_format.is_request_line   = true;
-	test6_body_message.is_request_format.is_header_fields  = true;
-	test6_body_message.is_request_format.is_body_message   = false;
-	test6_body_message.request_result.request.body_message = "Wikipedia";
-	test6_body_message.current_buf                         = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
+	test3_chunked_body_message.is_request_format.is_request_line   = true;
+	test3_chunked_body_message.is_request_format.is_header_fields  = true;
+	test3_chunked_body_message.is_request_format.is_body_message   = false;
+	test3_chunked_body_message.request_result.request.body_message = "Wikipedia";
+	test3_chunked_body_message.current_buf = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
 
-	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
-	http::HttpRequestParsedData test7_body_message;
-	test7_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test7_body_message.request_result.request.request_line =
+	// 14.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
+	http::HttpRequestParsedData test4_body_message_chunked;
+	test4_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test4_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test7_body_message.is_request_format.is_request_line   = true;
-	test7_body_message.is_request_format.is_header_fields  = true;
-	test7_body_message.is_request_format.is_body_message   = false;
-	test7_body_message.request_result.request.body_message = "Wikipedia";
-	test7_body_message.current_buf                         = "";
+	test4_body_message_chunked.is_request_format.is_request_line   = true;
+	test4_body_message_chunked.is_request_format.is_header_fields  = true;
+	test4_body_message_chunked.is_request_format.is_body_message   = false;
+	test4_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test4_body_message_chunked.current_buf                         = "";
 
-	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
-	http::HttpRequestParsedData test8_body_message;
-	test8_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test8_body_message.request_result.request.request_line =
+	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
+	http::HttpRequestParsedData test5_body_message_chunked;
+	test5_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test5_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test8_body_message.is_request_format.is_request_line   = true;
-	test8_body_message.is_request_format.is_header_fields  = true;
-	test8_body_message.is_request_format.is_body_message   = false;
-	test8_body_message.request_result.request.body_message = "Wikipedia";
-	test8_body_message.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
+	test5_body_message_chunked.is_request_format.is_request_line   = true;
+	test5_body_message_chunked.is_request_format.is_header_fields  = true;
+	test5_body_message_chunked.is_request_format.is_body_message   = false;
+	test5_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test5_body_message_chunked.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
 
-	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
-	http::HttpRequestParsedData test9_body_message;
-	test9_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test9_body_message.request_result.request.request_line =
+	// 16.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
+	http::HttpRequestParsedData test6_body_message_chunked;
+	test6_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test6_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test9_body_message.is_request_format.is_request_line   = true;
-	test9_body_message.is_request_format.is_header_fields  = true;
-	test9_body_message.is_request_format.is_body_message   = false;
-	test9_body_message.request_result.request.body_message = "Wikipedia";
-	test9_body_message.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
+	test6_body_message_chunked.is_request_format.is_request_line   = true;
+	test6_body_message_chunked.is_request_format.is_header_fields  = true;
+	test6_body_message_chunked.is_request_format.is_body_message   = false;
+	test6_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test6_body_message_chunked.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
 
-	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
-	http::HttpRequestParsedData test10_body_message;
-	test10_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test10_body_message.request_result.request.request_line =
+	// 17.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
+	http::HttpRequestParsedData test7_body_message_chunked;
+	test7_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test7_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test10_body_message.is_request_format.is_request_line   = true;
-	test10_body_message.is_request_format.is_header_fields  = true;
-	test10_body_message.is_request_format.is_body_message   = false;
-	test10_body_message.request_result.request.body_message = "Wikipedia";
-	test10_body_message.current_buf                         = "";
+	test7_body_message_chunked.is_request_format.is_request_line   = true;
+	test7_body_message_chunked.is_request_format.is_header_fields  = true;
+	test7_body_message_chunked.is_request_format.is_body_message   = false;
+	test7_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test7_body_message_chunked.current_buf                         = "";
 
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0x34\r\n is a free online encyclopedia that "
 			"anyone can edit.\r\n0\r\n\r\n",
-			test4_body_message
+			test1_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n2\r\npedia\r\n0\r\n\r\n",
-			test5_body_message
+			test2_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\nContent-Length: 10\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n",
-			test6_body_message
+			test3_chunked_body_message
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n",
-			test7_body_message
+			test4_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\nss\r\npedia\r\n",
-			test8_body_message
+			test5_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n-122\r\npedia\r\n",
-			test9_body_message
+			test6_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
-			test10_body_message
+			test7_body_message_chunked
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -370,6 +370,36 @@ int main(void) {
 	test3_body_message.request_result.request.body_message = "ab";
 	test3_body_message.current_buf                         = "abccccccccc";
 
+	// 17.前後にOWSがある場合
+	http::HttpRequestParsedData test11_body_message;
+	test11_body_message.request_result.status_code = http::StatusCode(http::OK);
+	test11_body_message.request_result.request.request_line =
+		CreateRequestLine("GET", "/", "HTTP/1.1");
+	test11_body_message.is_request_format.is_request_line                = true;
+	test11_body_message.is_request_format.is_header_fields               = true;
+	test11_body_message.is_request_format.is_body_message                = true;
+	test11_body_message.request_result.request.header_fields[http::HOST] = "host";
+	test11_body_message.current_buf                                      = "";
+
+	static const TestCase test_case_http_request_body_message_format[] = {
+		TestCase("GET / HTTP/1.1\r\nHost: a\r\nContent-Length:  3\r\n\r\nabc", test1_body_message),
+		TestCase(
+			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\nabccccccccc",
+			test2_body_message
+		),
+		TestCase(
+			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: dddd\r\n\r\nabccccccccc",
+			test3_body_message
+		),
+		TestCase("GET / HTTP/1.1\r\nHost:    host    \r\n\r\n", test11_body_message),
+	};
+
+	ret_code |= RunTestCases(
+		test_case_http_request_body_message_format,
+		sizeof(test_case_http_request_body_message_format) /
+			sizeof(test_case_http_request_body_message_format[0])
+	);
+
 	// 10.Chunked Transfer-Encodingの場合
 	http::HttpRequestParsedData test4_body_message;
 	test4_body_message.request_result.status_code = http::StatusCode(http::OK);
@@ -448,27 +478,7 @@ int main(void) {
 	test10_body_message.request_result.request.body_message = "Wikipedia";
 	test10_body_message.current_buf                         = "";
 
-	// 17.前後にOWSがある場合
-	http::HttpRequestParsedData test11_body_message;
-	test11_body_message.request_result.status_code = http::StatusCode(http::OK);
-	test11_body_message.request_result.request.request_line =
-		CreateRequestLine("GET", "/", "HTTP/1.1");
-	test11_body_message.is_request_format.is_request_line                = true;
-	test11_body_message.is_request_format.is_header_fields               = true;
-	test11_body_message.is_request_format.is_body_message                = true;
-	test11_body_message.request_result.request.header_fields[http::HOST] = "host";
-	test11_body_message.current_buf                                      = "";
-
-	static const TestCase test_case_http_request_body_message_format[] = {
-		TestCase("GET / HTTP/1.1\r\nHost: a\r\nContent-Length:  3\r\n\r\nabc", test1_body_message),
-		TestCase(
-			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 2\r\n\r\nabccccccccc",
-			test2_body_message
-		),
-		TestCase(
-			"GET / HTTP/1.1\r\nHost: test\r\nContent-Length: dddd\r\n\r\nabccccccccc",
-			test3_body_message
-		),
+	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0x34\r\n is a free online encyclopedia that "
@@ -505,13 +515,12 @@ int main(void) {
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n",
 			test10_body_message
 		),
-		TestCase("GET / HTTP/1.1\r\nHost:    host    \r\n\r\n", test11_body_message),
 	};
 
 	ret_code |= RunTestCases(
-		test_case_http_request_body_message_format,
-		sizeof(test_case_http_request_body_message_format) /
-			sizeof(test_case_http_request_body_message_format[0])
+		test_case_http_request_body_message_format_with_chunked,
+		sizeof(test_case_http_request_body_message_format_with_chunked) /
+			sizeof(test_case_http_request_body_message_format_with_chunked[0])
 	);
 
 	return ret_code;

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -424,15 +424,15 @@ int main(void) {
 	test2_body_message_chunked.current_buf                         = "0\r\n\r\n";
 
 	// 13.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
-	http::HttpRequestParsedData test3_chunked_body_message;
-	test3_chunked_body_message.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
-	test3_chunked_body_message.request_result.request.request_line =
+	http::HttpRequestParsedData test3_body_message_chunked;
+	test3_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test3_body_message_chunked.request_result.request.request_line =
 		CreateRequestLine("POST", "/", "HTTP/1.1");
-	test3_chunked_body_message.is_request_format.is_request_line   = true;
-	test3_chunked_body_message.is_request_format.is_header_fields  = true;
-	test3_chunked_body_message.is_request_format.is_body_message   = false;
-	test3_chunked_body_message.request_result.request.body_message = "Wikipedia";
-	test3_chunked_body_message.current_buf = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
+	test3_body_message_chunked.is_request_format.is_request_line   = true;
+	test3_body_message_chunked.is_request_format.is_header_fields  = true;
+	test3_body_message_chunked.is_request_format.is_body_message   = false;
+	test3_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test3_body_message_chunked.current_buf = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
 
 	// 14.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
 	http::HttpRequestParsedData test4_body_message_chunked;
@@ -504,7 +504,7 @@ int main(void) {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\nContent-Length: 10\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n",
-			test3_chunked_body_message
+			test3_body_message_chunked
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -163,7 +163,7 @@ Result IsSameHeaderFields(const http::HeaderFields &res, http::HeaderFields expe
 	return header_fields_result;
 }
 
-Result IsSameBodyMessage(const std::string &res, const std::string expected) {
+Result IsSameBodyMessage(const std::string &res, const std::string &expected) {
 	Result             body_message_result;
 	std::ostringstream error_log;
 	if (res != expected) {
@@ -235,7 +235,7 @@ int Run(const std::string &read_buf, const http::HttpRequestParsedData &expected
 }
 
 int RunTestCases(const TestCase test_cases[], std::size_t num_test_cases) {
-	int ret_code = 0;
+	int ret_code = EXIT_SUCCESS;
 
 	for (std::size_t i = 0; i < num_test_cases; i++) {
 		const TestCase test_case = test_cases[i];
@@ -247,7 +247,7 @@ int RunTestCases(const TestCase test_cases[], std::size_t num_test_cases) {
 } // namespace
 
 int main(void) {
-	int ret_code = 0;
+	int ret_code = EXIT_SUCCESS;
 
 	// todo: http/http_response/test_http_request.cpp HttpRequestParsedData関数のテストケース
 
@@ -261,7 +261,7 @@ int main(void) {
 	test2_request_line.request_result.status_code        = http::StatusCode(http::BAD_REQUEST);
 	test2_request_line.is_request_format.is_request_line = false;
 
-	// 3.CRLNがない場合
+	// 3.CRLFがない場合
 	http::HttpRequestParsedData test3_request_line;
 	// 本来のステータスコードはRequest Timeout
 	test3_request_line.request_result.status_code        = http::StatusCode(http::OK);

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -410,7 +410,7 @@ int main(void) {
 	test1_body_message_chunked.is_request_format.is_body_message  = true;
 	test1_body_message_chunked.request_result.request.body_message =
 		"Wikipedia is a free online encyclopedia that anyone can edit.";
-	test1_body_message_chunked.current_buf = "\r\n"; // todo: "" にしたい
+	test1_body_message_chunked.current_buf = "";
 
 	// 12.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
 	http::HttpRequestParsedData test2_body_message_chunked;

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -194,6 +194,19 @@ IsSameHttpRequest(const http::HttpRequestFormat &res, const http::HttpRequestFor
 	return http_request_result;
 }
 
+Result IsSameCurrentBuf(const std::string &current_buf, const std::string &expected_current_buf) {
+	Result             current_buf_result;
+	std::ostringstream error_log;
+	if (current_buf != expected_current_buf) {
+		error_log << "Error: current_buf\n";
+		error_log << "- Expected: [" << expected_current_buf << "]\n";
+		error_log << "- Result  : [" << current_buf << "]\n";
+		current_buf_result.is_success = false;
+	}
+	current_buf_result.error_log = error_log.str();
+	return current_buf_result;
+}
+
 Result IsSameHttpRequestParsedData(
 	const http::HttpRequestParsedData &result, const http::HttpRequestParsedData &expected
 ) {
@@ -214,8 +227,12 @@ Result IsSameHttpRequestParsedData(
 	if (is_response_complete) {
 		http_request_result =
 			IsSameHttpRequest(result.request_result.request, expected.request_result.request);
+		if (!http_request_result.is_success) {
+			return http_request_result;
+		}
 	}
-	return http_request_result;
+	Result current_buf_result = IsSameCurrentBuf(result.current_buf, expected.current_buf);
+	return current_buf_result;
 }
 
 http::HttpRequestParsedData ParseHttpRequestFormat(const std::string &read_buf) {
@@ -255,17 +272,20 @@ int main(void) {
 	http::HttpRequestParsedData test1_request_line;
 	test1_request_line.request_result.status_code        = http::StatusCode(http::OK);
 	test1_request_line.is_request_format.is_request_line = true;
+	test1_request_line.current_buf                       = "";
 
 	// 2.リクエストラインの書式が正しいくない場合
 	http::HttpRequestParsedData test2_request_line;
 	test2_request_line.request_result.status_code        = http::StatusCode(http::BAD_REQUEST);
 	test2_request_line.is_request_format.is_request_line = false;
+	test2_request_line.current_buf                       = "";
 
 	// 3.CRLFがない場合
 	http::HttpRequestParsedData test3_request_line;
 	// 本来のステータスコードはRequest Timeout
 	test3_request_line.request_result.status_code        = http::StatusCode(http::OK);
 	test3_request_line.is_request_format.is_request_line = false;
+	test3_request_line.current_buf                       = "GET / HTTP/1.1";
 
 	static const TestCase test_case_http_request_line_format[] = {
 		TestCase("GET / HTTP/1.1\r\n", test1_request_line),
@@ -286,6 +306,7 @@ int main(void) {
 	test1_header_fields.is_request_format.is_request_line  = true;
 	test1_header_fields.is_request_format.is_header_fields = true;
 	test1_header_fields.is_request_format.is_body_message  = true;
+	test1_header_fields.current_buf                        = "";
 
 	// 5.ヘッダフィールドの書式が正しくない場合
 	http::HttpRequestParsedData test2_header_fields;
@@ -293,6 +314,7 @@ int main(void) {
 	test2_header_fields.is_request_format.is_request_line  = true;
 	test2_header_fields.is_request_format.is_header_fields = false;
 	test2_header_fields.is_request_format.is_body_message  = false;
+	test2_header_fields.current_buf                        = "";
 
 	// 6.ヘッダフィールドにContent-Lengthがあるがボディメッセージがない場合
 	http::HttpRequestParsedData test3_header_fields;
@@ -303,6 +325,7 @@ int main(void) {
 	test3_header_fields.is_request_format.is_request_line  = true;
 	test3_header_fields.is_request_format.is_header_fields = true;
 	test3_header_fields.is_request_format.is_body_message  = false;
+	test3_header_fields.current_buf                        = "";
 
 	static const TestCase test_case_http_request_header_fields_format[] = {
 		TestCase("GET / HTTP/1.1\r\nHost: a\r\n\r\n", test1_header_fields),
@@ -325,6 +348,7 @@ int main(void) {
 	test1_body_message.is_request_format.is_header_fields  = true;
 	test1_body_message.is_request_format.is_body_message   = true;
 	test1_body_message.request_result.request.body_message = "abc";
+	test1_body_message.current_buf                         = "";
 
 	// 8.Content-Lengthの数値以上にボディメッセージがある場合
 	http::HttpRequestParsedData test2_body_message;
@@ -335,6 +359,7 @@ int main(void) {
 	test2_body_message.is_request_format.is_header_fields  = true;
 	test2_body_message.is_request_format.is_body_message   = true;
 	test2_body_message.request_result.request.body_message = "ab";
+	test2_body_message.current_buf                         = "ccccccccc";
 
 	// 9.Content-Lengthの値の書式が間違ってる場合
 	http::HttpRequestParsedData test3_body_message;
@@ -343,6 +368,7 @@ int main(void) {
 	test3_body_message.is_request_format.is_header_fields  = false;
 	test3_body_message.is_request_format.is_body_message   = false;
 	test3_body_message.request_result.request.body_message = "ab";
+	test3_body_message.current_buf                         = "abccccccccc";
 
 	// 10.Chunked Transfer-Encodingの場合
 	http::HttpRequestParsedData test4_body_message;
@@ -354,6 +380,7 @@ int main(void) {
 	test4_body_message.is_request_format.is_body_message  = true;
 	test4_body_message.request_result.request.body_message =
 		"Wikipedia is a free online encyclopedia that anyone can edit.";
+	test4_body_message.current_buf = "\r\n"; // todo: "" にしたい
 
 	// 11.Chunked Transfer-Encodingの場合で、chunk-sizeとchunk-dataの大きさが一致していない場合
 	http::HttpRequestParsedData test5_body_message;
@@ -364,6 +391,7 @@ int main(void) {
 	test5_body_message.is_request_format.is_header_fields  = true;
 	test5_body_message.is_request_format.is_body_message   = false;
 	test5_body_message.request_result.request.body_message = "Wikipedia";
+	test5_body_message.current_buf                         = "0\r\n\r\n";
 
 	// 12.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
 	http::HttpRequestParsedData test6_body_message;
@@ -374,6 +402,7 @@ int main(void) {
 	test6_body_message.is_request_format.is_header_fields  = true;
 	test6_body_message.is_request_format.is_body_message   = false;
 	test6_body_message.request_result.request.body_message = "Wikipedia";
+	test6_body_message.current_buf                         = "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
 
 	// 13.Chunked Transfer-Encodingの場合で、終端に0\r\n\r\nがない場合
 	http::HttpRequestParsedData test7_body_message;
@@ -384,6 +413,7 @@ int main(void) {
 	test7_body_message.is_request_format.is_header_fields  = true;
 	test7_body_message.is_request_format.is_body_message   = false;
 	test7_body_message.request_result.request.body_message = "Wikipedia";
+	test7_body_message.current_buf                         = "";
 
 	// 14.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(無効な文字)
 	http::HttpRequestParsedData test8_body_message;
@@ -394,6 +424,7 @@ int main(void) {
 	test8_body_message.is_request_format.is_header_fields  = true;
 	test8_body_message.is_request_format.is_body_message   = false;
 	test8_body_message.request_result.request.body_message = "Wikipedia";
+	test8_body_message.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
 
 	// 15.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
 	http::HttpRequestParsedData test9_body_message;
@@ -404,6 +435,7 @@ int main(void) {
 	test9_body_message.is_request_format.is_header_fields  = true;
 	test9_body_message.is_request_format.is_body_message   = false;
 	test9_body_message.request_result.request.body_message = "Wikipedia";
+	test9_body_message.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
 
 	// 16.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
 	http::HttpRequestParsedData test10_body_message;
@@ -414,6 +446,7 @@ int main(void) {
 	test10_body_message.is_request_format.is_header_fields  = true;
 	test10_body_message.is_request_format.is_body_message   = false;
 	test10_body_message.request_result.request.body_message = "Wikipedia";
+	test10_body_message.current_buf                         = "";
 
 	// 17.前後にOWSがある場合
 	http::HttpRequestParsedData test11_body_message;
@@ -424,6 +457,7 @@ int main(void) {
 	test11_body_message.is_request_format.is_header_fields               = true;
 	test11_body_message.is_request_format.is_body_message                = true;
 	test11_body_message.request_result.request.header_fields[http::HOST] = "host";
+	test11_body_message.current_buf                                      = "";
 
 	static const TestCase test_case_http_request_body_message_format[] = {
 		TestCase("GET / HTTP/1.1\r\nHost: a\r\nContent-Length:  3\r\n\r\nabc", test1_body_message),


### PR DESCRIPTION
(test がだいぶ同じ所を編集してたので main じゃないところから切ってます)

### `unit/test_http_parse` の修正
- `Parse()` 後に残った `current_buf` も比較するようにしました
- それにより test case 11, 15, 16 が未対応と分かったので修正

### `http_parse.cpp` 修正
- chunked の parse に成功したらまだ `current_buf` に `CRLF` が残っていたのを消すだけをしました -> test 11 が通るように
- `current_buf` に次の request がくっついている場合もあるので、最後の終端判定を `current_buf` の先頭だけ見るように変更 -> 新規 test 18 追加


多くなりそうだったので test 15, 16 に対応する実装は別 Issue (->#587 )

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - HTTPリクエストの解析における新しい関数`StartWith`を追加し、文字列のプレフィックスをチェックする機能を強化しました。

- **テスト**
  - HTTPリクエスト解析のテストフレームワークを強化し、新しいテストケースを追加しました。特に、チャンク転送エンコーディングやヘッダー周りのオプションのホワイトスペース処理を含むさまざまなシナリオを網羅しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->