### PR TITLE
[update] CgiResponseParseでのヘッダーフィールドのバリデーション

### DIFF
--- a/srcs/cgi/cgi.cpp
+++ b/srcs/cgi/cgi.cpp
@@ -210,8 +210,7 @@ CgiResponse Cgi::AddAndGetResponse(const std::string &read_buf) {
 	if (read_buf.empty()) {
 		is_response_complete_ = true;
 	}
-	return CgiResponse(response_body_message_, "text/plain", is_response_complete_);
-	// text/plainのみ対応
+	return CgiResponse(response_body_message_, is_response_complete_);
 }
 
 void Cgi::ReplaceNewRequest(const std::string &new_request_str) {

--- a/srcs/cgi/cgi.hpp
+++ b/srcs/cgi/cgi.hpp
@@ -9,16 +9,9 @@ namespace cgi {
 struct CgiResponse {
 	// parse等の他の処理で決まるのでstatus_codeはここにはいらない
 	std::string response;
-	std::string content_type;
 	bool        is_response_complete;
-	CgiResponse(
-		const std::string &response             = "",
-		const std::string &content_type         = "",
-		bool               is_response_complete = false
-	)
-		: response(response),
-		  content_type(content_type),
-		  is_response_complete(is_response_complete) {}
+	CgiResponse(const std::string &response = "", bool is_response_complete = false)
+		: response(response), is_response_complete(is_response_complete) {}
 };
 
 class Cgi {

--- a/srcs/cgi/cgi_response_parse/cgi_response_parse.cpp
+++ b/srcs/cgi/cgi_response_parse/cgi_response_parse.cpp
@@ -46,11 +46,8 @@ utils::Result<void> CheckValidHeaderFieldNameAndValue(
 		utils::Debug("CgiResponseParse", "Header field name has space");
 		return result;
 	}
-	if (header_field_name == "Host" && header_field_value.empty()) {
-		utils::Debug("CgiResponseParse", "Host header field is empty");
-		return result;
-	} else if (header_field_name == "Content-Length" &&
-			   !utils::ConvertStrToSize(header_field_value).IsOk()) {
+	if (header_field_name == "Content-Length" &&
+		!utils::ConvertStrToSize(header_field_value).IsOk()) {
 		utils::Debug("CgiResponseParse", "Invalid Content-Length: " + header_field_value);
 		return result;
 	}

--- a/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
+++ b/test/webserv/unit/cgi_manager/test_cgi_manager.cpp
@@ -101,14 +101,11 @@ Result RunAddAndGetResponse(
 
 	const cgi::CgiResponse cgi_response = cgi_manager.AddAndGetResponse(client_fd, read_buf);
 	if (!IsSame(cgi_response.response, expected_response.response) ||
-		!IsSame(cgi_response.content_type, expected_response.content_type) ||
 		!IsSame(cgi_response.is_response_complete, expected_response.is_response_complete)) {
 		result.is_success = false;
 		oss << "response" << std::endl;
 		oss << "- result(response)      : " << cgi_response.response << std::endl;
 		oss << "- expected(response)    : " << expected_response.response << std::endl;
-		oss << "- result(content_type)  : " << cgi_response.content_type << std::endl;
-		oss << "- expected(content_type): " << expected_response.content_type << std::endl;
 		oss << "- result(is_response_complete)  : " << cgi_response.is_response_complete
 			<< std::endl;
 		oss << "- expected(is_response_complete): " << expected_response.is_response_complete
@@ -229,7 +226,7 @@ int RunTest3() {
 	// "abc"をread()できたとしてresponseに追加
 	std::string buffer = "abc";
 	// addしてgetterを使ってresponseの保持確認
-	cgi::CgiResponse expected_cgi_response("abc", "text/plain", false);
+	cgi::CgiResponse expected_cgi_response("abc", false);
 	ret_code |=
 		Test(RunAddAndGetResponse(cgi_manager, client_fd, buffer, expected_cgi_response)); // Test4
 
@@ -237,13 +234,13 @@ int RunTest3() {
 	const std::string appended_buffer = "defgh";
 	buffer += appended_buffer;
 	ret_code |= Test(RunAddAndGetResponse(
-		cgi_manager, client_fd, appended_buffer, cgi::CgiResponse(buffer, "text/plain", false)
+		cgi_manager, client_fd, appended_buffer, cgi::CgiResponse(buffer, false)
 	)); // Test5
 
 	// 最後に""をread()したとして、responseが完成になっているか確認
-	ret_code |= Test(RunAddAndGetResponse(
-		cgi_manager, client_fd, "", cgi::CgiResponse(buffer, "text/plain", true)
-	)); // Test6
+	ret_code |=
+		Test(RunAddAndGetResponse(cgi_manager, client_fd, "", cgi::CgiResponse(buffer, true))
+		); // Test6
 
 	return ret_code;
 }

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -152,6 +152,22 @@ int TestParseNoContentLength() {
 	return HandleTestResult(CompareParsedData(expected, result.GetValue()));
 }
 
+int TestHeaderFieldWithOws() {
+	std::string response =
+		"Content-Length:    5   \r\nContent-Type: text/plain\r\n\r\nHello, world!";
+	utils::Result<CgiResponseParse::ParsedData> result = CgiResponseParse::Parse(response);
+	if (!result.IsOk()) {
+		PrintNg();
+		return EXIT_FAILURE;
+	}
+
+	CgiResponseParse::ParsedData expected;
+	expected.header_fields["Content-Length"] = "5";
+	expected.header_fields["Content-Type"]   = "text/plain";
+	expected.body                            = "Hello";
+	return HandleTestResult(CompareParsedData(expected, result.GetValue()));
+}
+
 int TestErrorResponse(const std::string &response) {
 	utils::Result<CgiResponseParse::ParsedData> result = CgiResponseParse::Parse(response);
 	if (!result.IsOk()) {
@@ -169,6 +185,7 @@ int main() {
 	ret |= TestParseHeaderOnlyResponse();
 	ret |= TestParseBodyLongerThanContentLength();
 	ret |= TestParseNoContentLength();
+	ret |= TestHeaderFieldWithOws();
 	// ヘッダーフィールドが存在しない
 	ret |= TestErrorResponse("Hello, world!");
 	ret |= TestErrorResponse("Content-Type: text/plain\r\nHello, world!");

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -152,31 +152,15 @@ int TestParseNoContentLength() {
 	return HandleTestResult(CompareParsedData(expected, result.GetValue()));
 }
 
-// todo: Error
-
-// void TestParseBodyOnlyResponse() {
-// 	CgiResponseParse             parser;
-// 	std::string                        response = "\r\n\r\nHello, world!";
-// 	CgiResponseParse::ParsedData result   = parser.Parse(response);
-
-// 	if (result.header_fields.size() == 0 && result.body == "Hello, world!") {
-// 		std::cout << "testParseBodyOnlyResponse passed\n";
-// 	} else {
-// 		std::cout << "testParseBodyOnlyResponse failed\n";
-// 	}
-// }
-
-// void TestParseInvalidResponse() {
-// 	http::CgiResponseParse             parser;
-// 	std::string                        response = "Invalid Response";
-// 	http::CgiResponseParse::ParsedData result   = parser.Parse(response);
-
-// 	if (result.header_fields.size() == 0 && result.body == "") {
-// 		std::cout << "testParseInvalidResponse passed\n";
-// 	} else {
-// 		std::cout << "testParseInvalidResponse failed\n";
-// 	}
-// }
+int TestErrorResponse(const std::string &response) {
+	utils::Result<CgiResponseParse::ParsedData> result = CgiResponseParse::Parse(response);
+	if (!result.IsOk()) {
+		PrintOk();
+		return EXIT_SUCCESS;
+	}
+	PrintNg();
+	return EXIT_FAILURE;
+}
 
 int main() {
 	int ret = EXIT_SUCCESS;
@@ -185,8 +169,22 @@ int main() {
 	ret |= TestParseHeaderOnlyResponse();
 	ret |= TestParseBodyLongerThanContentLength();
 	ret |= TestParseNoContentLength();
-	// testParseBodyOnlyResponse();
-	// testParseInvalidResponse();
+	// ヘッダーフィールドが存在しない
+	ret |= TestErrorResponse("Hello, world!");
+	ret |= TestErrorResponse("Content-Type: text/plain\r\nHello, world!");
+	ret |= TestErrorResponse("\r\n\r\nHello, world!");
+	// Content-Lengthが無効
+	ret |= TestErrorResponse("Content-Length: -1\r\n\r\nHello, world!");
+	ret |= TestErrorResponse("Content-Length: aa\r\n\r\nHello, world!");
+	// ヘッダーフィールドのヘッダー名にスペースが含まれている
+	ret |= TestErrorResponse("Content-Type   : text/plain\r\n\r\nHello, world!");
+	ret |= TestErrorResponse("  Content-Type: text/plain\r\n\r\nHello, world!");
+	// ヘッダーフィールドに可視文字でないものが含まれている
+	ret |= TestErrorResponse("Content-T\bype: text/plain\r\n\r\nHello, world!");
+	// ヘッダーフィールドのヘッダー名が空
+	ret |= TestErrorResponse(": 5\r\n\r\nHello, world!");
+	// ヘッダーフィールドのヘッダー値が空
+	ret |= TestErrorResponse("Content-Length: \r\n\r\nHello, world!");
 
 	return ret;
 }

--- a/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
+++ b/test/webserv/unit/cgi_response_parse/test_cgi_response_parse.cpp
@@ -190,6 +190,8 @@ int main() {
 	ret |= TestErrorResponse("Hello, world!");
 	ret |= TestErrorResponse("Content-Type: text/plain\r\nHello, world!");
 	ret |= TestErrorResponse("\r\n\r\nHello, world!");
+	// ヘッダーフィールドにコロンが含まれていない
+	ret |= TestErrorResponse("Content-Length 5\r\n\r\nHello, world!");
 	// Content-Lengthが無効
 	ret |= TestErrorResponse("Content-Length: -1\r\n\r\nHello, world!");
 	ret |= TestErrorResponse("Content-Length: aa\r\n\r\nHello, world!");

--- a/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
+++ b/test/webserv/unit/http/test_case/test_get_response_from_cgi.cpp
@@ -30,7 +30,7 @@ int HandleResult(const T &result, const T &expected, int number) {
 int TestGetResponseFromCgi1() {
 	const std::string &response =
 		"Content-Length: 12\r\nContent-Type: text/plain\r\n\r\nHello, world";
-	cgi::CgiResponse cgi_response(response, "text/html", true);
+	cgi::CgiResponse cgi_response(response, true);
 
 	const std::string &expected_body_message = "Hello, world";
 	HeaderFields       expected_header_fields;
@@ -52,7 +52,7 @@ int TestGetResponseFromCgi2() {
 	const std::string &response =
 		"Content-Type: text/html\r\n\r\n<!DOCTYPE "
 		"html><html><head><title>Test</title></head><body><h1>Test</h1></body></html>";
-	cgi::CgiResponse cgi_response(response, "text/plain", true);
+	cgi::CgiResponse cgi_response(response, true);
 
 	const std::string &expected_body_message =
 		"<!DOCTYPE html><html><head><title>Test</title></head><body><h1>Test</h1></body></html>";
@@ -73,7 +73,7 @@ int TestGetResponseFromCgi2() {
 // Content-Typeが無い場合 > application/octet-streamを設定
 int TestGetResponseFromCgi3() {
 	const std::string &response = "Content-Length: 12\r\n\r\nHello, world";
-	cgi::CgiResponse   cgi_response(response, "text/plain", true);
+	cgi::CgiResponse   cgi_response(response, true);
 
 	const std::string &expected_body_message = "Hello, world";
 	HeaderFields       expected_header_fields;
@@ -94,7 +94,7 @@ int TestGetResponseFromCgi3() {
 int TestGetResponseFromCgi4() {
 	const std::string &response =
 		"Content-Length: 3\r\nContent-Type: text/plain\r\n\r\nHello, world";
-	cgi::CgiResponse cgi_response(response, "text/plain", true);
+	cgi::CgiResponse cgi_response(response, true);
 
 	const std::string &expected_body_message = "Hel";
 	HeaderFields       expected_header_fields;


### PR DESCRIPTION
## CgiResponseParseでのヘッダーフィールドのバリデーションを追加しました

- [x] HttpParseから関数はそのまま引っ張ってきており、Hostのチェックだけ外しました
- [x] テストも追加しました
- [x] デバッグ出力もつけました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ヘッダーのフィールド名と値の検証機能を強化しました。
  - オプションの空白を含むヘッダー解析のテストを追加しました。
  - レスポンス構築の簡素化のため、MIMEタイプの指定を削除しました。

- **バグ修正**
  - 無効なレスポンスシナリオに対するエラーハンドリングを改善しました。

- **テスト**
  - 新しいテスト関数を追加し、テストスイートの堅牢性を向上させました。
  - レスポンス検証のロジックを簡素化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->