### PR TITLE
[update] chunked で chunk_size と chunk_str をセットで parse する

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -78,8 +78,54 @@ bool IsVString(const std::string &str) {
 	return true;
 }
 
-bool StartWith(const std::string &str, const std::string &prefix) {
-	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+typedef utils::Result<std::pair<std::string::size_type, std::string> > ChunkSizeResult;
+typedef utils::Result<std::string>                                     ChunkDataResult;
+
+ChunkSizeResult GetChunkSizeStr(const std::string &current_buf) {
+	ChunkSizeResult result;
+
+	const std::string::size_type end_of_chunk_size_pos = current_buf.find(CRLF);
+	if (end_of_chunk_size_pos == std::string::npos) {
+		result.Set(false);
+		return result;
+	}
+	const std::string chunk_size_str = current_buf.substr(0, end_of_chunk_size_pos);
+	if (!HexToDec(chunk_size_str).IsOk()) {
+		throw HttpException(
+			"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
+		);
+	}
+	result.SetValue(std::make_pair(end_of_chunk_size_pos, chunk_size_str));
+	return result;
+}
+
+ChunkDataResult GetChunkData(
+	const std::string     &current_buf,
+	std::string::size_type end_of_chunk_size_pos,
+	std::size_t            chunk_size
+) {
+	ChunkDataResult result;
+
+	// "chunk_size\r\n"の次の文字からfind
+	const std::string::size_type end_of_chunk_data_pos =
+		current_buf.find(CRLF, end_of_chunk_size_pos + CRLF.size());
+	if (end_of_chunk_data_pos == std::string::npos) {
+		// CRLFがないかつ"3\r\nXXX\rX"のようにchunk_date以降が(chunk_size+1)より多かったら早期に400
+		if (current_buf.size() > end_of_chunk_size_pos + CRLF.size() + chunk_size + 1) {
+			throw HttpException(
+				"Error: Missing or incorrect chunked transfer encoding terminator",
+				StatusCode(BAD_REQUEST)
+			);
+		}
+		result.Set(false);
+		return result;
+	}
+	const std::string chunk_data = current_buf.substr(
+		end_of_chunk_size_pos + CRLF.size(),
+		end_of_chunk_data_pos - end_of_chunk_size_pos - CRLF.size()
+	);
+	result.SetValue(chunk_data);
+	return result;
 }
 
 } // namespace
@@ -162,46 +208,44 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 		);
 	}
 
-	std::string::size_type end_of_chunk_size_pos = data.current_buf.find(CRLF);
-	std::string            chunk_size_str = data.current_buf.substr(0, end_of_chunk_size_pos);
-	data.current_buf.erase(0, chunk_size_str.size() + CRLF.size());
-	unsigned int chunk_size = HexToDec(chunk_size_str).GetValue();
-	if (HexToDec(chunk_size_str).IsOk() == false) {
-		throw HttpException(
-			"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
-		);
+	ChunkSizeResult result = GetChunkSizeStr(data.current_buf);
+	if (!result.IsOk()) {
+		return;
 	}
-	while (chunk_size > 0 && data.current_buf != "\0") {
-		std::string::size_type end_of_chunk_data_pos = data.current_buf.find(CRLF);
-		std::string            chunk_data = data.current_buf.substr(0, end_of_chunk_data_pos);
-		data.current_buf.erase(0, chunk_data.size() + CRLF.size());
+	std::string::size_type end_of_chunk_size_pos = result.GetValue().first;
+	std::string            chunk_size_str        = result.GetValue().second;
+	std::size_t            chunk_size            = HexToDec(chunk_size_str).GetValue();
+
+	while (true) {
+		const ChunkDataResult chunk_data_result =
+			GetChunkData(data.current_buf, end_of_chunk_size_pos, chunk_size);
+		if (!chunk_data_result.IsOk()) {
+			return;
+		}
+		const std::string chunk_data = chunk_data_result.GetValue();
 		if (chunk_data.size() != chunk_size) {
 			throw HttpException(
 				"Error: chunk size and chunk data size are different", StatusCode(BAD_REQUEST)
 			);
 		}
+		// sizeとdataが揃ったのでbody_messageに追加 & current_bufからまとめてerase
 		data.request_result.request.body_message += chunk_data;
-		end_of_chunk_size_pos = data.current_buf.find(CRLF);
-		chunk_size_str        = data.current_buf.substr(0, end_of_chunk_size_pos);
-		data.current_buf.erase(0, chunk_size_str.size() + CRLF.size());
-		chunk_size = HexToDec(chunk_size_str).GetValue();
-		if (HexToDec(chunk_size_str).IsOk() == false && data.current_buf != "\0") {
-			throw HttpException(
-				"Error: chunk size is not a hexadecimal number", StatusCode(BAD_REQUEST)
-			);
+		const std::size_t chunk_size_and_data_length =
+			chunk_size_str.size() + CRLF.size() + chunk_data.size() + CRLF.size();
+		data.current_buf.erase(0, chunk_size_and_data_length);
+		if (chunk_size == 0) {
+			break;
 		}
+
+		ChunkSizeResult result = GetChunkSizeStr(data.current_buf);
+		if (!result.IsOk()) {
+			return;
+		}
+		end_of_chunk_size_pos = result.GetValue().first;
+		chunk_size_str        = result.GetValue().second;
+		chunk_size            = HexToDec(chunk_size_str).GetValue();
 	}
-	if (data.current_buf == "\0") {
-		return; // is_request_format.is_body_message = false;
-	}
-	if (!StartWith(data.current_buf, CRLF)) { // 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるはず
-		throw HttpException(
-			"Error: Missing or incorrect chunked transfer encoding terminator",
-			StatusCode(BAD_REQUEST)
-		);
-	}
-	// 終端(current_bufの先頭)に0\r\n\r\nの\r\nがあるので次のリクエストの為にparse済みとして削除
-	data.current_buf.erase(0, CRLF.size());
+
 	data.is_request_format.is_body_message = true;
 }
 

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -86,6 +86,9 @@ ChunkSizeResult GetChunkSizeStr(const std::string &current_buf) {
 
 	const std::string::size_type end_of_chunk_size_pos = current_buf.find(CRLF);
 	if (end_of_chunk_size_pos == std::string::npos) {
+		if (current_buf.size() > 8) { // INT_MAX: 7FFFFFFF(8digits)
+			throw HttpException("Error: incorrect chunk size", StatusCode(BAD_REQUEST));
+		}
 		result.Set(false);
 		return result;
 	}

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -490,6 +490,51 @@ int main(void) {
 	test8_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test8_body_message_chunked.current_buf                         = "GET /";
 
+	// 19.Chunked Transfer-Encodingの場合で、0終わりの場合
+	http::HttpRequestParsedData test9_body_message_chunked;
+	test9_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test9_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test9_body_message_chunked.is_request_format.is_request_line   = true;
+	test9_body_message_chunked.is_request_format.is_header_fields  = true;
+	test9_body_message_chunked.is_request_format.is_body_message   = false;
+	test9_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test9_body_message_chunked.current_buf                         = "0";
+
+	// 20.Chunked Transfer-Encodingの場合で、0\r終わりの場合
+	http::HttpRequestParsedData test10_body_message_chunked;
+	test10_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test10_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test10_body_message_chunked.is_request_format.is_request_line   = true;
+	test10_body_message_chunked.is_request_format.is_header_fields  = true;
+	test10_body_message_chunked.is_request_format.is_body_message   = false;
+	test10_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test10_body_message_chunked.current_buf                         = "0\r";
+
+	// 21.Chunked Transfer-Encodingの場合で、
+	//    0\rの後に\nが来てない場合(大きい数字が来てる扱いでOKとした)
+	http::HttpRequestParsedData test11_body_message_chunked;
+	test11_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
+	test11_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test11_body_message_chunked.is_request_format.is_request_line   = true;
+	test11_body_message_chunked.is_request_format.is_header_fields  = true;
+	test11_body_message_chunked.is_request_format.is_body_message   = false;
+	test11_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test11_body_message_chunked.current_buf                         = "0\rGET /";
+
+	// 22.Chunked Transfer-Encodingの場合で、0\r\nの後に\r\nが来てない場合
+	http::HttpRequestParsedData test12_body_message_chunked;
+	test12_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test12_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test12_body_message_chunked.is_request_format.is_request_line   = true;
+	test12_body_message_chunked.is_request_format.is_header_fields  = true;
+	test12_body_message_chunked.is_request_format.is_body_message   = false;
+	test12_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test12_body_message_chunked.current_buf                         = "0\r\nGET /";
+
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
@@ -531,6 +576,26 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\nGET /",
 			test8_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0",
+			test9_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r",
+			test10_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\rGET /",
+			test11_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\nGET /",
+			test12_body_message_chunked
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -535,6 +535,17 @@ int main(void) {
 	test12_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test12_body_message_chunked.current_buf                         = "0\r\nGET /";
 
+	// 23.Chunked Transfer-Encodingの場合で、chunk sizeがoverflowしてる場合 / INT_MAX(7fffffff)
+	http::HttpRequestParsedData test13_body_message_chunked;
+	test13_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test13_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test13_body_message_chunked.is_request_format.is_request_line   = true;
+	test13_body_message_chunked.is_request_format.is_header_fields  = true;
+	test13_body_message_chunked.is_request_format.is_body_message   = false;
+	test13_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test13_body_message_chunked.current_buf                         = "80000000\r\naaa";
+
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
@@ -596,6 +607,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\nGET /",
 			test12_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n80000000\r\naaa",
+			test13_body_message_chunked
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -546,6 +546,17 @@ int main(void) {
 	test13_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test13_body_message_chunked.current_buf                         = "80000000\r\naaa";
 
+	// 24.Chunked Transfer-Encodingの場合で、\r\nが含まれずchunk_sizeが8桁より多い場合は早期に400
+	http::HttpRequestParsedData test14_body_message_chunked;
+	test14_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
+	test14_body_message_chunked.request_result.request.request_line =
+		CreateRequestLine("POST", "/", "HTTP/1.1");
+	test14_body_message_chunked.is_request_format.is_request_line   = true;
+	test14_body_message_chunked.is_request_format.is_header_fields  = true;
+	test14_body_message_chunked.is_request_format.is_body_message   = false;
+	test14_body_message_chunked.request_result.request.body_message = "Wikipedia";
+	test14_body_message_chunked.current_buf                         = "123456789";
+
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
@@ -612,6 +623,11 @@ int main(void) {
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
 			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n80000000\r\naaa",
 			test13_body_message_chunked
+		),
+		TestCase(
+			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: "
+			"chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n123456789",
+			test14_body_message_chunked
 		),
 	};
 

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -421,7 +421,7 @@ int main(void) {
 	test2_body_message_chunked.is_request_format.is_header_fields  = true;
 	test2_body_message_chunked.is_request_format.is_body_message   = false;
 	test2_body_message_chunked.request_result.request.body_message = "Wikipedia";
-	test2_body_message_chunked.current_buf                         = "0\r\n\r\n";
+	test2_body_message_chunked.current_buf                         = "2\r\npedia\r\n0\r\n\r\n";
 
 	// 13.Chunked Transfer-Encodingの場合で、Content-Lengthがある場合
 	http::HttpRequestParsedData test3_body_message_chunked;
@@ -454,7 +454,7 @@ int main(void) {
 	test5_body_message_chunked.is_request_format.is_header_fields  = true;
 	test5_body_message_chunked.is_request_format.is_body_message   = false;
 	test5_body_message_chunked.request_result.request.body_message = "Wikipedia";
-	test5_body_message_chunked.current_buf = "pedia\r\n"; // todo: "ss\r\npedia\r\n" にしたい
+	test5_body_message_chunked.current_buf                         = "ss\r\npedia\r\n";
 
 	// 16.Chunked Transfer-Encodingの場合で、chunk-sizeが不正な場合(負の数)
 	http::HttpRequestParsedData test6_body_message_chunked;
@@ -465,7 +465,7 @@ int main(void) {
 	test6_body_message_chunked.is_request_format.is_header_fields  = true;
 	test6_body_message_chunked.is_request_format.is_body_message   = false;
 	test6_body_message_chunked.request_result.request.body_message = "Wikipedia";
-	test6_body_message_chunked.current_buf = "pedia\r\n"; // todo: "-122\r\npedia\r\n" にしたい
+	test6_body_message_chunked.current_buf                         = "-122\r\npedia\r\n";
 
 	// 17.Chunked Transfer-Encodingの場合で、終端の0\r\n\r\nが中途半端な場合
 	http::HttpRequestParsedData test7_body_message_chunked;
@@ -476,9 +476,10 @@ int main(void) {
 	test7_body_message_chunked.is_request_format.is_header_fields  = true;
 	test7_body_message_chunked.is_request_format.is_body_message   = false;
 	test7_body_message_chunked.request_result.request.body_message = "Wikipedia";
-	test7_body_message_chunked.current_buf                         = "";
+	test7_body_message_chunked.current_buf                         = "0\r\n";
 
-	// 18.Chunked Transfer-Encodingの場合で、current_bufに次のリクエストが入っている場合正しく残るか
+	// 18.Chunked Transfer-Encodingの場合で
+	//    正常にchunk処理が終了した後、current_bufに次のリクエストが入っている場合正しく残るか
 	http::HttpRequestParsedData test8_body_message_chunked;
 	test8_body_message_chunked.request_result.status_code = http::StatusCode(http::OK);
 	test8_body_message_chunked.request_result.request.request_line =


### PR DESCRIPTION
`current_buf` が中途半端な場合や、次のリクエストが繋がって入っている場合も考慮して、chunked request の parse を見直しました

- 今まで：`chunk_size` が OK なら `erase()` -> `chunk_date` が OK なら `erase()`
-> chunk_data がまだ全部来ていなくても chunk_size 分を消してしまっていた
- 修正：`chunk_size` と `chunk_date` が両方 `current_buf` に正しくある場合のみまとめて `erase()`
-> エラー時や、まだ両方揃っていない場合は current_buf から何も消さないようにしました

ついでに追加
- `chunk_size` の位置に `7FFFFFFF` (INT_MAX) より長い文字列 (`123456789` など 8 文字より多い場合とした) が入っている場合は CRLF を待たずに分かり次第 400 
- `3\r\nXXX\rX` のような chunk_size より長いのに CRLF がない場合も分かり次第 400
- いらない気もしますが書きたくなって 2 回に分けて来た場合のテストも追加しました…

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- チャンク転送エンコーディングのHTTPリクエスト解析を改善。
	- 新しいチャンクサイズおよびデータ取得機能を追加。

- **バグ修正**
	- チャンクサイズやデータ取得のエラーハンドリングを強化。
	- 不正なチャンクサイズや形式に対するテストケースを追加。

- **テスト**
	- チャンクデータのさまざまなシナリオをカバーする新しいテストケースを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->