### PR TITLE
[fix] request_line が 3 要素ない時の valgrind error

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -244,6 +244,11 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 }
 
 void HttpParse::CheckValidRequestLine(const std::vector<std::string> &request_line_info) {
+	if (request_line_info.size() != 3) {
+		throw HttpException(
+			"Error: invalid number of status line elements", StatusCode(BAD_REQUEST)
+		);
+	}
 	CheckValidMethod(request_line_info[0]);
 	CheckValidRequestTarget(request_line_info[1]);
 	CheckValidVersion(request_line_info[2]);

--- a/test/common/request/get/4xx/400_20_too_few_status_line_elements.txt
+++ b/test/common/request/get/4xx/400_20_too_few_status_line_elements.txt
@@ -1,0 +1,4 @@
+GET /
+Host: localhost
+Connection: close
+

--- a/test/common/request/get/4xx/400_21_too_many_status_line_elements.txt
+++ b/test/common/request/get/4xx/400_21_too_many_status_line_elements.txt
@@ -1,0 +1,4 @@
+GET / HTTP/1.1 too-many-elements
+Host: localhost
+Connection: close
+

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -117,6 +117,14 @@ def send_request_and_assert_response(request_file, expected_response):
             REQUEST_GET_4XX_DIR + "400_19_non_vchr_header_field_value.txt",
             bad_request_response,
         ),
+        (
+            REQUEST_GET_4XX_DIR + "400_20_too_few_status_line_elements.txt",
+            bad_request_response,
+        ),
+        (
+            REQUEST_GET_4XX_DIR + "400_21_too_many_status_line_elements.txt",
+            bad_request_response,
+        ),
         (REQUEST_GET_4XX_DIR + "404_01_not_exist_path.txt", not_found_response),
         (
             REQUEST_GET_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",

--- a/test/webserv/unit/http/test_case/get/test_4xx.cpp
+++ b/test/webserv/unit/http/test_case/get/test_4xx.cpp
@@ -331,6 +331,45 @@ int TestGetBadRequest19NonVchrHeaderFieldValue(const server::VirtualServerAddrLi
 	return HandleHttpResult(client_infos, server_infos, expected, "400-19");
 }
 
+int TestGetBadRequest20TooFewStatusLineElements(const server::VirtualServerAddrList &server_infos) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_20_TOO_FEW_STATUS_LINE_ELEMENTS);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
+	expected_header_fields[http::CONNECTION]     = http::CLOSE;
+	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
+	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
+	const std::string &expected_response         = CreateHttpResponseFormat(
+        expected_status_line, expected_header_fields, expected_body_message
+    );
+	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
+	http::HttpResult   expected =
+		CreateHttpResult(true, false, expected_request_buffer, expected_response);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-20");
+}
+
+int TestGetBadRequest21TooManyStatusLineElements(const server::VirtualServerAddrList &server_infos
+) {
+	http::ClientInfos client_infos =
+		CreateClientInfos(request::GET_400_21_TOO_MANY_STATUS_LINE_ELEMENTS);
+	std::string  expected_status_line  = EXPECTED_STATUS_LINE_BAD_REQUEST;
+	std::string  expected_body_message = EXPECTED_BODY_MESSAGE_BAD_REQUEST;
+	HeaderFields expected_header_fields;
+	expected_header_fields[http::CONNECTION]     = http::CLOSE;
+	expected_header_fields[http::CONTENT_LENGTH] = utils::ToString(expected_body_message.length());
+	expected_header_fields[http::CONTENT_TYPE]   = http::TEXT_HTML;
+	expected_header_fields[http::SERVER]         = http::SERVER_VERSION;
+	const std::string &expected_response         = CreateHttpResponseFormat(
+        expected_status_line, expected_header_fields, expected_body_message
+    );
+	const std::string &expected_request_buffer = "Host: localhost\r\nConnection: close\r\n\r\n";
+	http::HttpResult   expected =
+		CreateHttpResult(true, false, expected_request_buffer, expected_response);
+	return HandleHttpResult(client_infos, server_infos, expected, "400-21");
+}
+
 int TestGetNotFound1NotExistFile(const server::VirtualServerAddrList &server_infos) {
 	http::ClientInfos client_infos =
 		CreateClientInfos(request::GET_404_1_NOT_EXIST_PATH_CONNECTION_CLOSE);

--- a/test/webserv/unit/http/test_case/test_case.hpp
+++ b/test/webserv/unit/http/test_case/test_case.hpp
@@ -48,6 +48,8 @@ int TestGetBadRequest16HeaderFieldNameSpaceColon(const server::VirtualServerAddr
 int TestGetBadRequest17SpaceHeaderFieldName(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest18NonVchrHeaderFieldName(const server::VirtualServerAddrList &server_infos);
 int TestGetBadRequest19NonVchrHeaderFieldValue(const server::VirtualServerAddrList &server_infos);
+int TestGetBadRequest20TooFewStatusLineElements(const server::VirtualServerAddrList &server_infos);
+int TestGetBadRequest21TooManyStatusLineElements(const server::VirtualServerAddrList &server_infos);
 
 int TestGetNotFound1NotExistFile(const server::VirtualServerAddrList &server_infos);
 int TestGetMethodNotAllowed(const server::VirtualServerAddrList &server_infos);

--- a/test/webserv/unit/http/test_case/test_case.hpp
+++ b/test/webserv/unit/http/test_case/test_case.hpp
@@ -20,10 +20,6 @@ int TestGetOk4ConnectionKeepAndOkConnectionKeep(const server::VirtualServerAddrL
 int TestGetOk5ConnectionCloseAndOkConnectionClose(const server::VirtualServerAddrList &server_infos
 );
 int TestGetOk6ConnectionKeepAndOkConnectionClose(const server::VirtualServerAddrList &server_infos);
-int TestGetOk7DuplicateConnectionKeep(const server::VirtualServerAddrList &server_infos);
-int TestGetOk8DuplicateConnectionClose(const server::VirtualServerAddrList &server_infos);
-int TestGetOk9ConnectionKeepAndClose(const server::VirtualServerAddrList &server_infos);
-int TestGetOk10ConnectionCloseAndKeep(const server::VirtualServerAddrList &server_infos);
 int TestGetOk11UpperAndLowerHeaderFields(const server::VirtualServerAddrList &server_infos);
 int TestGetOk12HeaderFieldValueSpace(const server::VirtualServerAddrList &server_infos);
 int TestGetOk13SpaceHeaderFieldValue(const server::VirtualServerAddrList &server_infos);

--- a/test/webserv/unit/http/test_case/test_request.hpp
+++ b/test/webserv/unit/http/test_case/test_request.hpp
@@ -83,6 +83,10 @@ static const std::string &GET_400_18_NON_VCHR_HEADER_FIELD_NAME =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_18_non_vchr_header_field_name.txt");
 static const std::string &GET_400_19_NON_VCHR_HEADER_FIELD_VALUE =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_19_non_vchr_header_field_value.txt");
+static const std::string &GET_400_20_TOO_FEW_STATUS_LINE_ELEMENTS =
+	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_20_too_few_status_line_elements.txt");
+static const std::string &GET_400_21_TOO_MANY_STATUS_LINE_ELEMENTS =
+	LoadFileContent(REQUEST_GET + ROOT_4XX + "/400_21_too_many_status_line_elements.txt");
 
 static const std::string &GET_404_1_NOT_EXIST_PATH_CONNECTION_CLOSE =
 	LoadFileContent(REQUEST_GET + ROOT_4XX + "/404_01_not_exist_path.txt");

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -89,6 +89,8 @@ int  main(void) {
     ret_code |= test::TestGetBadRequest17SpaceHeaderFieldName(server_infos);
     ret_code |= test::TestGetBadRequest18NonVchrHeaderFieldName(server_infos);
     ret_code |= test::TestGetBadRequest19NonVchrHeaderFieldValue(server_infos);
+    ret_code |= test::TestGetBadRequest20TooFewStatusLineElements(server_infos);
+    ret_code |= test::TestGetBadRequest21TooManyStatusLineElements(server_infos);
 
     ret_code |= test::TestGetNotFound1NotExistFile(server_infos);
     ret_code |= test::TestGetMethodNotAllowed(server_infos);


### PR DESCRIPTION
`get/400_20`, `get/400_21` のような、`StatusLine` の要素数が 3 ではないケースで 400 を返すようにしました
これで valgrind でのエラーも出なくなりました

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTPリクエストのステータスラインに対する新しいバリデーションチェックを追加しました。これにより、リクエストラインが正しい形式であることが保証されます。

- **バグ修正**
  - 不正なリクエストに対して適切なエラーレスポンスを返すテストケースを追加しました。

- **テスト**
  - ステータスライン要素が不足または過剰なHTTPリクエストを検証する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->