### PR TITLE
[fix] get/400_09 : Host header-field は必須にする

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -82,6 +82,12 @@ bool StartWith(const std::string &str, const std::string &prefix) {
 	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
 }
 
+void ThrowMissingHostHeaderField(const HeaderFields &header_fields) {
+	if (header_fields.count(HOST) == 0) {
+		throw HttpException("Error: missing Host header field.", StatusCode(BAD_REQUEST));
+	}
+}
+
 } // namespace
 
 void HttpParse::ParseRequestLine(HttpRequestParsedData &data) {
@@ -240,6 +246,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 			);
 		}
 	}
+	ThrowMissingHostHeaderField(header_fields);
 	return header_fields;
 }
 

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -88,6 +88,10 @@ def send_request_and_assert_response(request_file, expected_response):
             REQUEST_GET_4XX_DIR + "400_08_wrong_http_version.txt",
             bad_request_response,
         ),
+        (
+            REQUEST_GET_4XX_DIR + "400_09_no_host.txt",
+            bad_request_response,
+        ),
         (REQUEST_GET_4XX_DIR + "400_10_duplicate_host.txt", bad_request_response),
         (
             REQUEST_GET_4XX_DIR + "400_11_no_header_field_colon.txt",

--- a/test/webserv/unit/http/test_http.cpp
+++ b/test/webserv/unit/http/test_http.cpp
@@ -75,8 +75,7 @@ int  main(void) {
     ret_code |= test::TestGetBadRequest6LowerHttpVersion(server_infos);
     ret_code |= test::TestGetBadRequest7WrongHttpName(server_infos);
     ret_code |= test::TestGetBadRequest8WrongHttpVersion(server_infos);
-    // todo: Fix: std::out_of_range: map::at:  key not found
-    // ret_code |= test::TestGetBadRequest9NoHost(server_infos);
+    ret_code |= test::TestGetBadRequest9NoHost(server_infos);
     ret_code |= test::TestGetBadRequest10DuplicateHost(server_infos);
     ret_code |= test::TestGetBadRequest11NoHeaderFieldColon(server_infos);
     ret_code |= test::TestGetBadRequest12NoConnectionName(server_infos);


### PR DESCRIPTION
`Host` の header field が送られてこなかった場合に 400 を投げるようにしました

- どこで throw するか迷ったのですが、header field を parse して全部セットし終わったら、にしてみました
- 該当する `get/400_09` のテストが通るようになりました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTPリクエストの`Host`ヘッダーが欠如している場合に例外をスローする機能を追加しました。
  
- **バグ修正**
  - `Host`ヘッダーがないリクエストに対するテストケースを追加し、400エラーの応答を確認するようにしました。
  
- **テスト**
  - `TestGetBadRequest9NoHost`テストケースをメインテストルーチンに統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->