### PR TITLE
[implement] PathInfoへの対応追加

### DIFF
--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -14,15 +14,22 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 	return "";
 }
 
+bool EndWith(const std::string &str, const std::string &suffix) {
+	return str.size() >= suffix.size() &&
+		   str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 std::string
 TranslateToScriptName(const std::string &cgi_extension, const std::string &request_target) {
 	// from root path
-	const std::string::size_type extension_pos = request_target.find(cgi_extension);
-	const std::string::size_type root_pos      = request_target.find("root/cgi-bin/");
+	const std::string::size_type root_pos = request_target.find("root/cgi-bin/");
 	if (root_pos != std::string::npos) {
 		const std::string script_name = request_target.substr(root_pos);
-		if (extension_pos != std::string::npos) {
+		if (!EndWith(script_name, cgi_extension)) {
+			const std::string::size_type extension_pos = script_name.find(cgi_extension);
 			// /aa.cgi/bb の場合、/aa.cgi のみを返す
+			std::cout << "script_name: " << script_name << std::endl;
+			std::cout << script_name.substr(0, extension_pos + cgi_extension.length()) << std::endl;
 			return script_name.substr(0, extension_pos + cgi_extension.length());
 		}
 		return script_name;

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -28,8 +28,6 @@ TranslateToScriptName(const std::string &cgi_extension, const std::string &reque
 		if (!EndWith(script_name, cgi_extension)) {
 			const std::string::size_type extension_pos = script_name.find(cgi_extension);
 			// /aa.cgi/bb の場合、/aa.cgi のみを返す
-			std::cout << "script_name: " << script_name << std::endl;
-			std::cout << script_name.substr(0, extension_pos + cgi_extension.length()) << std::endl;
 			return script_name.substr(0, extension_pos + cgi_extension.length());
 		}
 		return script_name;

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -12,13 +12,13 @@
 namespace http {
 namespace {
 
-std::string GetExtension(const std::string &path) {
-	size_t pos = path.find_last_of('.');
-
-	if (pos == std::string::npos || pos == path.length() - 1) {
-		return "";
+std::string GetPathAfterRoot(const std::string &path) {
+	const std::string root = "/root";
+	size_t            pos  = path.find(root);
+	if (pos != std::string::npos) {
+		return path.substr(pos + root.length());
 	}
-	return path.substr(pos);
+	return path;
 }
 
 std::string GetCwd() {
@@ -183,9 +183,9 @@ bool HttpResponse::IsCgi(
 	if (cgi_extension.empty()) {
 		return false;
 	}
-	// pathがcgi_extensionで設定された拡張子かどうか
+	// pathにcgi_extensionで設定された拡張子が含まれているかどうか
 	// falseの場合はpathに普通のリクエストとして送られる
-	if (cgi_extension != GetExtension(path)) {
+	if (GetPathAfterRoot(path).find(cgi_extension) == std::string::npos) {
 		return false;
 	}
 	// methodがGETかPOSTかつallow_methodかどうか


### PR DESCRIPTION
## PathInfoを扱えるようになりました

- [x] http://localhost:8080/cgi-bin/print_env.pl/aa/aa のようなリクエストでは http://localhost:8080/cgi-bin/print_env.pl を実行して/aa/aaをPathInfoとして扱うように
- [x] cgi_extension終わりでないリクエストもCgiに行けるように判定修正
- [x] CgiParseの修正