### PR TITLE
[add] 既存 GET request ファイルで未追加 + 新規テストを integration に追加

### DIFF
--- a/test/common/request/get/4xx/400_13_empty_host_header_value.txt
+++ b/test/common/request/get/4xx/400_13_empty_host_header_value.txt
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Host:
+Connection: close
+

--- a/test/common/request/get/4xx/400_14_transfer_encoding_and_content_length.txt
+++ b/test/common/request/get/4xx/400_14_transfer_encoding_and_content_length.txt
@@ -1,0 +1,8 @@
+GET /upload/test_upload_file HTTP/1.1
+Host: localhost
+Content-Length: 5
+Transfer-Encoding: chunked
+Connection: close
+Content-Type: text/plain
+
+abcde

--- a/test/webserv/integration/common_functions.py
+++ b/test/webserv/integration/common_functions.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+
+
+def read_file(file):
+    with open(file, "r") as f:
+        data = f.read()
+        return data, len(data)
+
+
+# \r\nをそのまま読み込む用(ヘッダー部分)
+def read_file_binary(file):
+    with open(file, "rb") as f:
+        data = f.read()
+    return data, len(data)
+
+
+def assert_response(response, expected_response):
+    assert (
+        response == expected_response
+    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+
+
+def build_client_module():
+    # client_module ディレクトリに移動
+    client_module_dir = os.path.join(os.path.dirname(__file__), "client_module")
+    # コマンドを実行
+    subprocess.run(
+        ["python3", "setup.py", "build_ext", "--inplace"],
+        cwd=client_module_dir,
+        check=True,
+    )
+
+
+try:
+    # client_module をビルド
+    build_client_module()
+    # client_module.client をインポート
+    import client_module.client as client
+except subprocess.CalledProcessError as e:
+    print(f"Build failed: {e}")
+except ImportError as e:
+    print(f"Import failed: {e}")
+
+
+def send_request_and_assert_response(request_file, expected_response):
+    client_instance = client.Client(8080)
+    request, _ = read_file_binary(request_file)
+    response = client_instance.SendRequestAndReceiveResponse(request)
+    assert_response(response, expected_response)

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -4,11 +4,20 @@ KEEP_ALIVE = "keep-alive"
 CLOSE = "close"
 TEXT_HTML = "text/html"
 
+STATUS = {
+    200: "OK",
+    400: "Bad Request",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    408: "Request Timeout",
+    501: "Not Implemented",
+}
+
 
 def create_response_header(
-    status_code, reason_phrase, connection, content_length, content_type="text/plain"
+    status_code, connection, content_length, content_type="text/plain"
 ):
-    return f"HTTP/1.1 {status_code} {reason_phrase}\r\nConnection: {connection}\r\nContent-Length: {content_length}\r\nContent-Type: {content_type}\r\nServer: webserv/1.1\r\n\r\n"
+    return f"HTTP/1.1 {status_code} {STATUS[status_code]}\r\nConnection: {connection}\r\nContent-Length: {content_length}\r\nContent-Type: {content_type}\r\nServer: webserv/1.1\r\n\r\n"
 
 
 root_index_file, root_index_file_length = read_file("root/html/index.html")
@@ -39,28 +48,28 @@ for filename, data_var, length_var in error_files:
 
 
 response_header_get_root_200_close = create_response_header(
-    200, "OK", CLOSE, root_index_file_length, TEXT_HTML
+    200, CLOSE, root_index_file_length, TEXT_HTML
 )
 response_header_get_root_200_keep = create_response_header(
-    200, "OK", KEEP_ALIVE, root_index_file_length, TEXT_HTML
+    200, KEEP_ALIVE, root_index_file_length, TEXT_HTML
 )
 response_header_get_sub_200_close = create_response_header(
-    200, "OK", CLOSE, sub_index_file_length, TEXT_HTML
+    200, CLOSE, sub_index_file_length, TEXT_HTML
 )
 response_header_400 = create_response_header(
-    400, "Bad Request", CLOSE, bad_request_file_400_length, TEXT_HTML
+    400, CLOSE, bad_request_file_400_length, TEXT_HTML
 )
 response_header_404 = create_response_header(
-    404, "Not Found", CLOSE, not_found_file_404_length, TEXT_HTML
+    404, CLOSE, not_found_file_404_length, TEXT_HTML
 )
 response_header_405 = create_response_header(
-    405, "Method Not Allowed", CLOSE, not_allowed_file_405_length, TEXT_HTML
+    405, CLOSE, not_allowed_file_405_length, TEXT_HTML
 )
 response_header_408 = create_response_header(
-    408, "Request Timeout", CLOSE, timeout_file_408_length, TEXT_HTML
+    408, CLOSE, timeout_file_408_length, TEXT_HTML
 )
 response_header_501 = create_response_header(
-    501, "Not Implemented", CLOSE, not_implemented_file_501_length, TEXT_HTML
+    501, CLOSE, not_implemented_file_501_length, TEXT_HTML
 )
 
 bad_request_response = response_header_400 + bad_request_file_400.decode("utf-8")

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -1,20 +1,8 @@
-def read_file(file):
-    with open(file, "r") as f:
-        data = f.read()
-        return data, len(data)
+from common_functions import read_file, read_file_binary
 
-
-# \r\nをそのまま読み込む用(ヘッダー部分)
-def read_file_binary(file):
-    with open(file, "rb") as f:
-        data = f.read()
-    return data, len(data)
-
-
-def assert_response(response, expected_response):
-    assert (
-        response == expected_response
-    ), f"Expected response\n\n {repr(expected_response)}, but got\n\n {repr(response)}"
+KEEP_ALIVE = "keep-alive"
+CLOSE = "close"
+TEXT_HTML = "text/html"
 
 
 def create_response_header(
@@ -49,15 +37,6 @@ for filename, data_var, length_var in error_files:
     globals()[data_var] = data
     globals()[length_var] = length
 
-
-REQUEST_DIR = "test/common/request/"
-REQUEST_GET_2XX_DIR = REQUEST_DIR + "get/2xx/"
-REQUEST_GET_4XX_DIR = REQUEST_DIR + "get/4xx/"
-REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
-
-KEEP_ALIVE = "keep-alive"
-CLOSE = "close"
-TEXT_HTML = "text/html"
 
 response_header_get_root_200_close = create_response_header(
     200, "OK", CLOSE, root_index_file_length, TEXT_HTML

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -14,16 +14,6 @@ STATUS = {
     501: "Not Implemented",
 }
 
-
-def create_response_header(
-    status_code, connection, content_length, content_type=TEXT_PLAIN
-):
-    return f"HTTP/1.1 {status_code} {STATUS[status_code]}\r\nConnection: {connection}\r\nContent-Length: {content_length}\r\nContent-Type: {content_type}\r\nServer: webserv/1.1\r\n\r\n"
-
-
-root_index_file, root_index_file_length = read_file("root/html/index.html")
-sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
-
 ERROR_FILES = (
     ("400_bad_request.txt", "bad_request_file_400", "bad_request_file_400_length"),
     ("404_not_found.txt", "not_found_file_404", "not_found_file_404_length"),
@@ -47,6 +37,16 @@ for filename, data_var, length_var in ERROR_FILES:
     )
     globals()[data_var] = data
     globals()[length_var] = length
+
+
+def create_response_header(
+    status_code, connection, content_length, content_type=TEXT_PLAIN
+):
+    return f"HTTP/1.1 {status_code} {STATUS[status_code]}\r\nConnection: {connection}\r\nContent-Length: {content_length}\r\nContent-Type: {content_type}\r\nServer: webserv/1.1\r\n\r\n"
+
+
+root_index_file, root_index_file_length = read_file("root/html/index.html")
+sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
 
 response_header_get_root_200_close = create_response_header(

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -24,7 +24,7 @@ def create_response_header(
 root_index_file, root_index_file_length = read_file("root/html/index.html")
 sub_index_file, sub_index_file_length = read_file("root/html/sub/index.html")
 
-error_files = [
+ERROR_FILES = (
     ("400_bad_request.txt", "bad_request_file_400", "bad_request_file_400_length"),
     ("404_not_found.txt", "not_found_file_404", "not_found_file_404_length"),
     (
@@ -38,9 +38,10 @@ error_files = [
         "not_implemented_file_501",
         "not_implemented_file_501_length",
     ),
-]
+)
 
-for filename, data_var, length_var in error_files:
+
+for filename, data_var, length_var in ERROR_FILES:
     data, length = read_file_binary(
         f"test/webserv/expected_response/default_body_message/{filename}"
     )

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -2,6 +2,7 @@ from common_functions import read_file, read_file_binary
 
 KEEP_ALIVE = "keep-alive"
 CLOSE = "close"
+TEXT_PLAIN = "text/plain"
 TEXT_HTML = "text/html"
 
 STATUS = {
@@ -15,7 +16,7 @@ STATUS = {
 
 
 def create_response_header(
-    status_code, connection, content_length, content_type="text/plain"
+    status_code, connection, content_length, content_type=TEXT_PLAIN
 ):
     return f"HTTP/1.1 {status_code} {STATUS[status_code]}\r\nConnection: {connection}\r\nContent-Length: {content_length}\r\nContent-Type: {content_type}\r\nServer: webserv/1.1\r\n\r\n"
 

--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -2,8 +2,9 @@ import socket
 from http.client import HTTPConnection, HTTPException
 from typing import Optional
 
-from common import (assert_response, response_header_get_root_200_keep,
-                    root_index_file, timeout_response)
+from common_functions import assert_response
+from common_response import (response_header_get_root_200_keep,
+                             root_index_file, timeout_response)
 
 # serverのtimeout+αを設定する
 TIMEOUT = 4.0

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -109,6 +109,10 @@ REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
             bad_request_response,
         ),
         (
+            REQUEST_GET_4XX_DIR + "400_13_empty_host_header_value.txt",
+            bad_request_response,
+        ),
+        (
             REQUEST_GET_4XX_DIR + "400_15_space_in_header_field_name.txt",
             bad_request_response,
         ),
@@ -172,6 +176,7 @@ REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
         "400_10_duplicate_host",
         "400_11_no_header_field_colon",
         "400_12_no_connection_name",
+        "400_13_empty_host_header_value",
         "400_15_space_in_header_field_name",
         "400_16_header_field_name_space_colon",
         "400_17_space_header_field_name",

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -113,6 +113,10 @@ REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
             bad_request_response,
         ),
         (
+            REQUEST_GET_4XX_DIR + "400_14_transfer_encoding_and_content_length.txt",
+            bad_request_response,
+        ),
+        (
             REQUEST_GET_4XX_DIR + "400_15_space_in_header_field_name.txt",
             bad_request_response,
         ),
@@ -177,6 +181,7 @@ REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
         "400_11_no_header_field_colon",
         "400_12_no_connection_name",
         "400_13_empty_host_header_value",
+        "400_14_transfer_encoding_and_content_length.txt",
         "400_15_space_in_header_field_name",
         "400_16_header_field_name_space_colon",
         "400_17_space_header_field_name",

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -1,37 +1,11 @@
-import os
-import subprocess
-
 import pytest
-from common import *
+from common_functions import send_request_and_assert_response
+from common_response import *
 
-
-def build_client_module():
-    # client_module ディレクトリに移動
-    client_module_dir = os.path.join(os.path.dirname(__file__), "client_module")
-    # コマンドを実行
-    subprocess.run(
-        ["python3", "setup.py", "build_ext", "--inplace"],
-        cwd=client_module_dir,
-        check=True,
-    )
-
-
-try:
-    # client_module をビルド
-    build_client_module()
-    # client_module.client をインポート
-    import client_module.client as client
-except subprocess.CalledProcessError as e:
-    print(f"Build failed: {e}")
-except ImportError as e:
-    print(f"Import failed: {e}")
-
-
-def send_request_and_assert_response(request_file, expected_response):
-    client_instance = client.Client(8080)
-    request, _ = read_file_binary(request_file)
-    response = client_instance.SendRequestAndReceiveResponse(request)
-    assert_response(response, expected_response)
+REQUEST_DIR = "test/common/request/"
+REQUEST_GET_2XX_DIR = REQUEST_DIR + "get/2xx/"
+REQUEST_GET_4XX_DIR = REQUEST_DIR + "get/4xx/"
+REQUEST_GET_5XX_DIR = REQUEST_DIR + "get/5xx/"
 
 
 @pytest.mark.parametrize(

--- a/test/webserv/integration/test_integration.py
+++ b/test/webserv/integration/test_integration.py
@@ -50,6 +50,27 @@ def send_request_and_assert_response(request_file, expected_response):
             response_header_get_sub_200_close + sub_index_file,
         ),
         (
+            REQUEST_GET_2XX_DIR
+            + "200_04_connection_keep_alive_and_200_connection_keep_alive.txt",
+            response_header_get_root_200_keep
+            + root_index_file
+            + response_header_get_root_200_keep
+            + root_index_file,
+        ),
+        (
+            REQUEST_GET_2XX_DIR
+            + "200_05_connection_close_and_200_connection_close.txt",
+            response_header_get_root_200_close + root_index_file,
+        ),
+        (
+            REQUEST_GET_2XX_DIR
+            + "200_06_connection_keep_alive_and_200_connection_close.txt",
+            response_header_get_root_200_keep
+            + root_index_file
+            + response_header_get_root_200_close
+            + root_index_file,
+        ),
+        (
             REQUEST_GET_2XX_DIR + "200_07_no_connection_value.txt",
             response_header_get_root_200_keep + root_index_file,
         ),
@@ -76,6 +97,10 @@ def send_request_and_assert_response(request_file, expected_response):
         (
             REQUEST_GET_2XX_DIR + "200_17_not_exist_header_field.txt",
             response_header_get_root_200_close + root_index_file,
+        ),
+        (
+            REQUEST_GET_2XX_DIR + "200_21_no_connection.txt",
+            response_header_get_root_200_keep + root_index_file,
         ),
         (REQUEST_GET_4XX_DIR + "400_02_lower_method.txt", bad_request_response),
         (
@@ -151,6 +176,9 @@ def send_request_and_assert_response(request_file, expected_response):
         "200_01_connection_close",
         "200_02_connection_keep",
         "200_03_sub_connection_close",
+        "200_04_connection_keep_alive_and_200_connection_keep_alive",
+        "200_05_connection_close_and_200_connection_close",
+        "200_06_connection_keep_alive_and_200_connection_close",
         "200_07_no_connection_value",
         "200_08_wrong_connection_value",
         "200_12_header_field_value_space",
@@ -158,6 +186,7 @@ def send_request_and_assert_response(request_file, expected_response):
         "200_14_extra_request",
         "200_15_body_message_default",
         "200_17_not_exist_header_field",
+        "200_21_no_connection",
         "400_02_lower_method",
         "400_03_no_ascii_method",
         "400_04_no_root",


### PR DESCRIPTION
以下のケースを追加しました

get
- 200_04 : keep -> keep と連続で来る
- 200_05 : close -> close と連続で来る
- 200_06 : keep -> close と連続で来る
- 200_21 : Connection がない
- 400_13 : Host の field name が空
- 400_14 : Content-Length と Transfer-Encoding が両方ある

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいHTTPリクエストテストケースを追加（空のHostヘッダーやTransfer-Encodingを含むリクエスト）。
  - リクエストファイルの構造を整理し、パラメータ化テストを導入。

- **バグ修正**
  - HTTPレスポンスの処理を改善し、状態メッセージの管理を強化。

- **ドキュメント**
  - テストケースの構造を簡素化し、可読性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->