### PR TITLE
[add] DeleteIntegrationTestの追加

### DIFF
--- a/test/common/request/delete/2xx/204_04_delete_empty_file.txt
+++ b/test/common/request/delete/2xx/204_04_delete_empty_file.txt
@@ -1,0 +1,4 @@
+DELETE /upload/delete_file HTTP/1.1
+Host: localhost
+Connection: close
+

--- a/test/common/request/delete/2xx/204_05_delete_existing_file_keep.txt
+++ b/test/common/request/delete/2xx/204_05_delete_existing_file_keep.txt
@@ -1,0 +1,4 @@
+DELETE /upload/delete_file HTTP/1.1
+Host: localhost
+Connection: keep-alive
+

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -78,8 +78,11 @@ response_header_201_close = create_response_header(
 response_header_201_keep = create_response_header(
     201, KEEP_ALIVE, success_files_data["created_file_201_length"], TEXT_HTML
 )
-response_header_204 = create_response_header(
+response_header_204_close = create_response_header(
     204, CLOSE, success_files_data["no_content_file_204_length"], TEXT_HTML
+)
+response_header_204_keep = create_response_header(
+    204, KEEP_ALIVE, success_files_data["no_content_file_204_length"], TEXT_HTML
 )
 response_header_400 = create_response_header(
     400, CLOSE, error_files_data["bad_request_file_400_length"], TEXT_HTML
@@ -103,7 +106,10 @@ created_response_close = response_header_201_close + success_files_data[
 created_response_keep = response_header_201_keep + success_files_data[
     "created_file_201"
 ].decode("utf-8")
-no_content_response = response_header_204 + success_files_data[
+no_content_response_close = response_header_204_close + success_files_data[
+    "no_content_file_204"
+].decode("utf-8")
+no_content_response_keep = response_header_204_keep + success_files_data[
     "no_content_file_204"
 ].decode("utf-8")
 bad_request_response = response_header_400 + error_files_data[

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -10,6 +10,7 @@ STATUS = {
     201: "Created",
     204: "No Content",
     400: "Bad Request",
+    403: "Forbidden",
     404: "Not Found",
     405: "Method Not Allowed",
     408: "Request Timeout",
@@ -23,6 +24,7 @@ SUCCESS_FILES = (
 
 ERROR_FILES = (
     ("400_bad_request.txt", "bad_request_file_400", "bad_request_file_400_length"),
+    ("403_forbidden.txt", "forbidden_file_403", "forbidden_file_403_length"),
     ("404_not_found.txt", "not_found_file_404", "not_found_file_404_length"),
     (
         "405_method_not_allowed.txt",
@@ -87,6 +89,9 @@ response_header_204_keep = create_response_header(
 response_header_400 = create_response_header(
     400, CLOSE, error_files_data["bad_request_file_400_length"], TEXT_HTML
 )
+response_header_403 = create_response_header(
+    403, CLOSE, error_files_data["forbidden_file_403_length"], TEXT_HTML
+)
 response_header_404 = create_response_header(
     404, CLOSE, error_files_data["not_found_file_404_length"], TEXT_HTML
 )
@@ -114,6 +119,9 @@ no_content_response_keep = response_header_204_keep + success_files_data[
 ].decode("utf-8")
 bad_request_response = response_header_400 + error_files_data[
     "bad_request_file_400"
+].decode("utf-8")
+forbidden_response = response_header_403 + error_files_data[
+    "forbidden_file_403"
 ].decode("utf-8")
 not_found_response = response_header_404 + error_files_data[
     "not_found_file_404"

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (no_content_response_close,
-                                no_content_response_keep, not_found_response, forbidden_response)
+                                no_content_response_keep, not_found_response, forbidden_response, not_allowed_response)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
@@ -136,10 +136,16 @@ def cleanup_file_context():
             not_found_response,
             NOT_EXISTING_FILE_PATH,
         ),
+        (
+            REQUEST_DELETE_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
+            not_allowed_response,
+            "",
+        )
     ],
     ids=[
         "403_01_delete_directory",
         "404_01_delete_nonexistent_file",
+        "405_01_method_not_allowed_for_uri",
     ],
 )
 def test_post_4xx_responses(

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -39,12 +39,10 @@ def setup_file_context():
     @contextmanager
     def _setup(file_path, content=""):
         create_file(file_path, content)
-        try:
-            yield
-        finally:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-                print(f"Deleted file: {file_path}")
+        yield
+        if os.path.exists(file_path):
+            print(f"File exists: {file_path}")
+            raise AssertionError
 
     return _setup
 
@@ -141,7 +139,7 @@ def cleanup_file_context():
         (
             REQUEST_DELETE_4XX_DIR + "403_01_delete_directory.txt",
             forbidden_response,
-            None
+            None,
         ),
         (
             REQUEST_DELETE_4XX_DIR + "404_01_delete_nonexistent_file.txt",
@@ -151,7 +149,7 @@ def cleanup_file_context():
         (
             REQUEST_DELETE_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
             not_allowed_response,
-            None
+            None,
         ),
     ],
     ids=[

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (bad_request_response, no_content_response_close,
-                                no_content_response_keep)
+                                no_content_response_keep, not_found_response)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
@@ -55,9 +55,30 @@ def setup_file_context():
             DELETE_FILE_PATH,
             "Sample content for deletion",
         ),
+        (
+            REQUEST_DELETE_2XX_DIR + "204_02_delete_existing_file_with_body_message.txt",
+            no_content_response_close,
+            DELETE_FILE_PATH,
+            "Sample content for deletion",
+        ),
+        (
+            REQUEST_DELETE_2XX_DIR + "204_03_delete_existing_file_then_404_on_second_attempt.txt",
+            no_content_response_keep + not_found_response,
+            DELETE_FILE_PATH,
+            "Sample content for deletion",
+        ),
+        (
+            REQUEST_DELETE_2XX_DIR + "204_01_delete_existing_file.txt",
+            no_content_response_close,
+            DELETE_FILE_PATH,
+            "",
+        )
     ],
     ids=[
         "204_01_delete_existing_file",
+        "204_02_delete_existing_file_with_body_message",
+        "204_03_delete_existing_file_then_404_on_second_attempt",
+        "204_04_delete_empty_file",
     ],
 )
 def test_delete_responses(

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -128,7 +128,6 @@ def cleanup_file_context():
     def _cleanup(file_path):
         delete_file(file_path)
         yield
-        delete_file(file_path)
 
     return _cleanup
 

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -1,0 +1,122 @@
+import os
+import time
+
+import pytest
+from common_functions import read_file, send_request_and_assert_response
+from common_response import (bad_request_response, no_content_response_close,
+                                no_content_response_keep)
+
+REQUEST_DIR = "test/common/request/"
+REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
+REQUEST_DELETE_4XX_DIR = REQUEST_DIR + "delete/4xx/"
+
+UPLOAD_DIR = "root/upload/"
+DELETE_FILE_PATH = UPLOAD_DIR + "delete_file"
+NOT_EXISTING_FILE_PATH = UPLOAD_DIR + "non_existing_file"
+
+def create_file(file_path, content=""):
+    if file_path is None:
+        return
+
+    try:
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, 'w') as f:
+            f.write(content)
+        print(f"Created file: {file_path}")
+    except Exception as e:
+        print(f"Error creating file: {file_path}, {e}")
+        raise AssertionError
+
+
+@pytest.fixture
+def setup_file_context():
+    # コンテキストマネージャとして使用可能なフィクスチャ
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _setup(file_path, content=""):
+        create_file(file_path, content)
+        try:
+            yield
+        finally:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+                print(f"Deleted file: {file_path}")
+
+    return _setup
+
+
+@pytest.mark.parametrize(
+    "request_file, expected_response, file_path, file_content",
+    [
+        (
+            REQUEST_DELETE_2XX_DIR + "204_01_delete_existing_file.txt",
+            no_content_response_close,
+            DELETE_FILE_PATH,
+            "Sample content for deletion",
+        ),
+    ],
+    ids=[
+        "204_01_delete_existing_file",
+    ],
+)
+def test_delete_responses(
+    request_file,
+    expected_response,
+    file_path,
+    file_content,
+    setup_file_context,
+):
+    # setup_file_contextフィクスチャを使用してファイル作成を実行
+    if file_path:
+        with setup_file_context(file_path, file_content):
+            send_request_and_assert_response(request_file, expected_response)
+
+
+
+# @pytest.mark.parametrize(
+#     "request_file, expected_response, upload_file_path",
+#     [
+#         (
+#             REQUEST_POST_4XX_DIR + "400_01_duplicate_content_length.txt",
+#             bad_request_response,
+#             UPLOAD_DIR + "duplicate_content_length",
+#         ),
+        # (
+        #     REQUEST_DELETE_4XX_DIR + "400_01_delete_non_existing_file.txt",
+        #     bad_request_response,
+        #     NOT_EXISTING_FILE_PATH,
+        #     "",
+        # ),
+#         (
+#             REQUEST_POST_4XX_DIR + "400_02_transfer_encoding_and_content_length.txt",
+#             bad_request_response,
+#             UPLOAD_FILE_PATH,
+#         ),
+#         (
+#             REQUEST_POST_4XX_DIR + "408_01_shortened_body_message.txt",
+#             timeout_response,
+#             UPLOAD_DIR + "shortened_body_message",
+#         ),
+#         (
+#             REQUEST_POST_4XX_DIR + "408_02_no_body_message.txt",
+#             timeout_response,
+#             UPLOAD_DIR + "no_body_message",
+#         ),
+#     ],
+#     ids=[
+#         "400_01_duplicate_content_length",
+#         "400_02_transfer_encoding_and_content_length",
+#         "408_01_shortened_body_message",
+#         "408_02_no_body_message",
+#     ],
+# )
+# def test_post_4xx_responses(
+#     request_file,
+#     expected_response,
+#     upload_file_path,
+#     cleanup_file_context,
+# ):
+#     if upload_file_path:
+#         with cleanup_file_context(upload_file_path):
+#             send_request_and_assert_response(request_file, expected_response)

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -141,7 +141,7 @@ def cleanup_file_context():
         (
             REQUEST_DELETE_4XX_DIR + "403_01_delete_directory.txt",
             forbidden_response,
-            "",
+            None
         ),
         (
             REQUEST_DELETE_4XX_DIR + "404_01_delete_nonexistent_file.txt",
@@ -151,7 +151,7 @@ def cleanup_file_context():
         (
             REQUEST_DELETE_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
             not_allowed_response,
-            "",
+            None
         ),
     ],
     ids=[

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -5,7 +5,7 @@ import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (forbidden_response, no_content_response_close,
                              no_content_response_keep, not_allowed_response,
-                             not_found_response)
+                             not_found_response, timeout_response)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
@@ -73,10 +73,16 @@ def setup_file_context():
             "Sample content for deletion",
         ),
         (
-            REQUEST_DELETE_2XX_DIR + "204_01_delete_existing_file.txt",
+            REQUEST_DELETE_2XX_DIR + "204_04_delete_empty_file.txt",
             no_content_response_close,
             DELETE_FILE_PATH,
             "",
+        ),
+        (
+            REQUEST_DELETE_2XX_DIR + "204_05_delete_existing_file_keep.txt",
+            no_content_response_keep,
+            DELETE_FILE_PATH,
+            "Sample content for deletion",
         ),
     ],
     ids=[
@@ -84,6 +90,7 @@ def setup_file_context():
         "204_02_delete_existing_file_with_body_message",
         "204_03_delete_existing_file_then_404_on_second_attempt",
         "204_04_delete_empty_file",
+        "204_05_delete_existing_file_keep",
     ],
 )
 def test_delete_responses(

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -3,8 +3,9 @@ import time
 
 import pytest
 from common_functions import read_file, send_request_and_assert_response
-from common_response import (no_content_response_close,
-                                no_content_response_keep, not_found_response, forbidden_response, not_allowed_response)
+from common_response import (forbidden_response, no_content_response_close,
+                             no_content_response_keep, not_allowed_response,
+                             not_found_response)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
@@ -14,13 +15,14 @@ UPLOAD_DIR = "root/upload/"
 DELETE_FILE_PATH = UPLOAD_DIR + "delete_file"
 NOT_EXISTING_FILE_PATH = UPLOAD_DIR + "not_found"
 
+
 def create_file(file_path, content=""):
     if file_path is None:
         return
 
     try:
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.write(content)
         print(f"Created file: {file_path}")
     except Exception as e:
@@ -57,13 +59,15 @@ def setup_file_context():
             "Sample content for deletion",
         ),
         (
-            REQUEST_DELETE_2XX_DIR + "204_02_delete_existing_file_with_body_message.txt",
+            REQUEST_DELETE_2XX_DIR
+            + "204_02_delete_existing_file_with_body_message.txt",
             no_content_response_close,
             DELETE_FILE_PATH,
             "Sample content for deletion",
         ),
         (
-            REQUEST_DELETE_2XX_DIR + "204_03_delete_existing_file_then_404_on_second_attempt.txt",
+            REQUEST_DELETE_2XX_DIR
+            + "204_03_delete_existing_file_then_404_on_second_attempt.txt",
             no_content_response_keep + not_found_response,
             DELETE_FILE_PATH,
             "Sample content for deletion",
@@ -73,7 +77,7 @@ def setup_file_context():
             no_content_response_close,
             DELETE_FILE_PATH,
             "",
-        )
+        ),
     ],
     ids=[
         "204_01_delete_existing_file",
@@ -108,6 +112,7 @@ def delete_file(file_path):
         print(f"Error deleting file: {file_path}, {e}")
         raise AssertionError
 
+
 # ファイルがある場合に削除する関数
 @pytest.fixture
 def cleanup_file_context():
@@ -140,7 +145,7 @@ def cleanup_file_context():
             REQUEST_DELETE_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
             not_allowed_response,
             "",
-        )
+        ),
     ],
     ids=[
         "403_01_delete_directory",

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (bad_request_response, created_response_close,
-                             created_response_keep, no_content_response,
+                             created_response_keep, no_content_response_close,
                              response_header_get_root_200_close,
                              root_index_file, timeout_response)
 
@@ -74,7 +74,7 @@ def cleanup_file_context():
         ),
         (
             REQUEST_POST_2XX_DIR + "201_03_upload_file_204_same_upload_file.txt",
-            created_response_keep + no_content_response,
+            created_response_keep + no_content_response_close,
             UPLOAD_FILE_PATH,
             "first",
         ),


### PR DESCRIPTION
## DeleteIntegrationTestを追加しました

- [x] 今あるリクエストに対するテストを作成 + 2個リクエスト追加
- [x] ファイルがない場合には作成してそれを削除するテスト(BadRequestの場合は逆である場合は消す)

テストケースは順次追加して行きます(あんまり思い浮かばないが)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - HTTP DELETEリクエストのテストケースを追加しました。これにより、空のファイルや既存のファイルを削除する際の動作を確認できます。
  - 新しいHTTPステータスコード「403 Forbidden」をサポートし、関連するエラーハンドリングを強化しました。

- **バグ修正**
  - DELETEリクエストに対するレスポンス処理を改善しました。

- **テスト**
  - HTTP DELETEリクエストの統合テストを追加し、成功時とエラー時のレスポンスを検証する機能を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->