### PR TITLE
[add] POSTの場合でContent-Typeがない場合, Content-LengthまたはTransfer-Encodingがない場合 の integration 追加

### DIFF
--- a/test/common/request/post/4xx/400_03_no_content_type.txt
+++ b/test/common/request/post/4xx/400_03_no_content_type.txt
@@ -1,0 +1,6 @@
+POST /upload/test_upload_file HTTP/1.1
+Host: localhost
+Connection: close
+Content-Length: 3
+
+aaa

--- a/test/common/request/post/4xx/400_04_no_content_length_and_no_transfer_encoding.txt
+++ b/test/common/request/post/4xx/400_04_no_content_length_and_no_transfer_encoding.txt
@@ -1,0 +1,11 @@
+POST /upload/test_upload_file HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: text/plain
+
+4
+Wiki
+5
+pedia
+0
+

--- a/test/common/request/post/4xx/400_05_no_content_length_and_not_chunked_transfer_encoding.txt
+++ b/test/common/request/post/4xx/400_05_no_content_length_and_not_chunked_transfer_encoding.txt
@@ -1,0 +1,12 @@
+POST /upload/chunked_request_file HTTP/1.1
+Host: localhost
+Connection: keep-alive
+Content-Type: text/plain
+Transfer-Encoding: not-chunked
+
+4
+Wiki
+5
+pedia
+0
+

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -135,6 +135,12 @@ def test_post_upload_responses(
             UPLOAD_FILE_PATH,
         ),
         (
+            REQUEST_POST_4XX_DIR
+            + "400_04_no_content_length_and_no_transfer_encoding.txt",
+            bad_request_response,
+            UPLOAD_FILE_PATH,
+        ),
+        (
             REQUEST_POST_4XX_DIR + "408_01_shortened_body_message.txt",
             timeout_response,
             UPLOAD_DIR + "shortened_body_message",
@@ -149,6 +155,7 @@ def test_post_upload_responses(
         "400_01_duplicate_content_length",
         "400_02_transfer_encoding_and_content_length",
         "400_03_no_content_type",
+        "400_04_no_content_length_and_no_transfer_encoding",
         "408_01_shortened_body_message",
         "408_02_no_body_message",
     ],

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -130,6 +130,11 @@ def test_post_upload_responses(
             UPLOAD_FILE_PATH,
         ),
         (
+            REQUEST_POST_4XX_DIR + "400_03_no_content_type.txt",
+            bad_request_response,
+            UPLOAD_FILE_PATH,
+        ),
+        (
             REQUEST_POST_4XX_DIR + "408_01_shortened_body_message.txt",
             timeout_response,
             UPLOAD_DIR + "shortened_body_message",
@@ -143,6 +148,7 @@ def test_post_upload_responses(
     ids=[
         "400_01_duplicate_content_length",
         "400_02_transfer_encoding_and_content_length",
+        "400_03_no_content_type",
         "408_01_shortened_body_message",
         "408_02_no_body_message",
     ],

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -141,6 +141,12 @@ def test_post_upload_responses(
             UPLOAD_FILE_PATH,
         ),
         (
+            REQUEST_POST_4XX_DIR
+            + "400_05_no_content_length_and_not_chunked_transfer_encoding.txt",
+            bad_request_response,
+            CHUNKED_FILE_PATH,
+        ),
+        (
             REQUEST_POST_4XX_DIR + "408_01_shortened_body_message.txt",
             timeout_response,
             UPLOAD_DIR + "shortened_body_message",
@@ -156,6 +162,7 @@ def test_post_upload_responses(
         "400_02_transfer_encoding_and_content_length",
         "400_03_no_content_type",
         "400_04_no_content_length_and_no_transfer_encoding",
+        "400_05_no_content_length_and_not_chunked_transfer_encoding",
         "408_01_shortened_body_message",
         "408_02_no_body_message",
     ],


### PR DESCRIPTION
以下 3 つの integration test を追加しました
- `post/400_03` : POST, content-type がない
- `post/400_04` : POST, content-length がないかつ transfer-encoding がない
- `post/400_05` : POST, content-length がなく, transfer-encoding はあるが, chunked ではない value

POST のテスト追加はこの branch から切ろうと思います

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいHTTP POSTリクエストが`/upload/test_upload_file`エンドポイントに追加されました。
  
- **テスト**
  - HTTP 4XXエラーに対する新しいテストケースが追加され、`Content-Type`ヘッダーが欠如している場合や、`Content-Length`および`Transfer-Encoding`ヘッダーが欠如している場合のシナリオを検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->