### PR TITLE
[update] SERVER_PORTを定数にしました

### DIFF
--- a/srcs/http/http_message.cpp
+++ b/srcs/http/http_message.cpp
@@ -36,16 +36,17 @@ const std::string CHUNKED                  = "chunked";
 const std::string LOCATION                 = "location";
 const std::string AUTHORIZATION            = "authorization";
 const std::string REQUEST_HEADER_FIELDS[]  = {
-	 HOST,
-	 USER_AGENT,
-	 ACCEPT,
-	 ACCEPT_ENCODING,
-	 CONNECTION,
-	 CONTENT_TYPE,
-	 CONTENT_LENGTH,
-	 TRANSFER_ENCODING,
-	 LOCATION,
-	 AUTHORIZATION};
+    HOST,
+    USER_AGENT,
+    ACCEPT,
+    ACCEPT_ENCODING,
+    CONNECTION,
+    CONTENT_TYPE,
+    CONTENT_LENGTH,
+    TRANSFER_ENCODING,
+    LOCATION,
+    AUTHORIZATION
+};
 const std::size_t REQUEST_HEADER_FIELDS_SIZE =
 	sizeof(REQUEST_HEADER_FIELDS) / sizeof(REQUEST_HEADER_FIELDS[0]);
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -348,8 +348,7 @@ void Server::HandleTimeoutMessages() {
 			continue;
 		}
 
-		const http::HttpResult http_result =
-			http_.GetErrorResponse(client_fd, http::TIMEOUT);
+		const http::HttpResult http_result = http_.GetErrorResponse(client_fd, http::TIMEOUT);
 		message_manager_.AddPrimaryResponse(client_fd, message::CLOSE, http_result.response);
 		ReplaceEvent(client_fd, event::EVENT_WRITE);
 		utils::Debug("server", "timeout client", client_fd);
@@ -363,8 +362,7 @@ void Server::SetInternalServerError(int client_fd) {
 		cgi_manager_.DeleteCgi(client_fd);
 	}
 
-	const http::HttpResult http_result =
-		http_.GetErrorResponse(client_fd, http::INTERNAL_ERROR);
+	const http::HttpResult http_result = http_.GetErrorResponse(client_fd, http::INTERNAL_ERROR);
 	message_manager_.AddPrimaryResponse(client_fd, message::CLOSE, http_result.response);
 	ReplaceEvent(client_fd, event::EVENT_WRITE);
 	utils::Debug("server", "internal server error to client", client_fd);

--- a/srcs/utils/convert_str.cpp
+++ b/srcs/utils/convert_str.cpp
@@ -27,7 +27,7 @@ Result<unsigned int> ConvertStrToUint(const std::string &str) {
 		return convert_result;
 	}
 
-	char			*end;
+	char            *end;
 	static const int BASE   = 10;
 	errno                   = 0;
 	const unsigned long num = std::strtoul(str.c_str(), &end, BASE);
@@ -50,7 +50,7 @@ Result<std::size_t> ConvertStrToSize(const std::string &str) {
 		return convert_result;
 	}
 
-	char			*end;
+	char            *end;
 	static const int BASE   = 10;
 	errno                   = 0;
 	const unsigned long num = std::strtoul(str.c_str(), &end, BASE);

--- a/test/webserv/integration/common_functions.py
+++ b/test/webserv/integration/common_functions.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+SERVER_PORT = 8080
+
 
 def read_file(file):
     with open(file, "r") as f:
@@ -46,7 +48,7 @@ except ImportError as e:
 
 
 def send_request_and_assert_response(request_file, expected_response):
-    client_instance = client.Client(8080)
+    client_instance = client.Client(SERVER_PORT)
     request, _ = read_file_binary(request_file)
     response = client_instance.SendRequestAndReceiveResponse(request)
     assert_response(response, expected_response)

--- a/test/webserv/integration/test_cgi.py
+++ b/test/webserv/integration/test_cgi.py
@@ -2,6 +2,7 @@ import unittest
 from http import HTTPStatus
 from http.client import HTTPConnection, HTTPException
 
+from common_functions import SERVER_PORT
 from http_module.assert_http_response import (assert_body, assert_header,
                                               assert_status_line)
 
@@ -9,7 +10,7 @@ from http_module.assert_http_response import (assert_body, assert_header,
 class TestCGI(unittest.TestCase):
     def setUp(self):
         # 各テストの前に実行される(unittestの機能)
-        self.con = HTTPConnection("localhost", 8080)
+        self.con = HTTPConnection("localhost", SERVER_PORT)
 
     def tearDown(self):
         # 各テストの後に実行される(unittestの機能)

--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -2,7 +2,7 @@ import socket
 from http.client import HTTPConnection, HTTPException
 from typing import Optional
 
-from common_functions import assert_response
+from common_functions import SERVER_PORT, assert_response
 from common_response import (response_header_get_root_200_keep,
                              root_index_file, timeout_response)
 
@@ -26,7 +26,7 @@ def receive_with_timeout(sock) -> Optional[str]:
 # 通常のkeep-aliveを送信(各関数の説明付き)
 def test_timeout_keep_alive() -> None:
     try:
-        con = HTTPConnection("localhost", 8080)
+        con = HTTPConnection("localhost", SERVER_PORT)
         # serverに接続
         con.connect()
 
@@ -65,7 +65,7 @@ def test_timeout_keep_alive() -> None:
 
 def test_timeout_incomplete_request() -> None:
     try:
-        con = HTTPConnection("localhost", 8080)
+        con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
 
         # 完全ではないrequestを送信
@@ -88,7 +88,7 @@ def test_timeout_incomplete_request() -> None:
 
 def test_timeout_no_request() -> None:
     try:
-        con = HTTPConnection("localhost", 8080)
+        con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
 
         # requestを何も送らない
@@ -111,7 +111,7 @@ def test_timeout_no_request() -> None:
 # serverがその後も正常に動いていればOK
 def test_incomplete_request_disconnect() -> None:
     try:
-        con = HTTPConnection("localhost", 8080)
+        con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
 
         # 完全ではないrequestを送信
@@ -131,7 +131,7 @@ def test_incomplete_request_disconnect() -> None:
 # serverがその後も正常に動いていればOK
 def test_timeout_no_request_disconnect() -> None:
     try:
-        con = HTTPConnection("localhost", 8080)
+        con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
 
         # requestを何も送らない

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -375,7 +375,8 @@ int main(void) {
 	static const TestCase test_case_http_request_line_format[] = {
 		TestCase("GET / HTTP/1.1\r\n", test1_request_line),
 		TestCase("GET / HTTP/1.\r\n", test2_request_line),
-		TestCase("GET / HTTP/1.1", test3_request_line)};
+		TestCase("GET / HTTP/1.1", test3_request_line)
+	};
 
 	ret_code |= RunTestCases(
 		test_case_http_request_line_format,

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -42,14 +42,14 @@ int HandleResult(const T &result, const T &expected) {
 }
 
 server::Location BuildLocation(
-	const std::string						  &request_uri,
-	const std::string						  &alias,
-	const std::string						  &index,
+	const std::string                          &request_uri,
+	const std::string                          &alias,
+	const std::string                          &index,
 	bool                                        autoindex,
 	const std::list<std::string>               &allowed_methods,
 	const std::pair<unsigned int, std::string> &redirect,
-	const std::string						  &cgi_extension    = "",
-	const std::string						  &upload_directory = ""
+	const std::string                          &cgi_extension    = "",
+	const std::string                          &upload_directory = ""
 ) {
 	server::Location loc;
 	loc.request_uri      = request_uri;

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -11,14 +11,14 @@ namespace {
 using namespace http;
 
 server::Location BuildLocation(
-	const std::string						  &request_uri,
-	const std::string						  &alias,
-	const std::string						  &index,
+	const std::string                          &request_uri,
+	const std::string                          &alias,
+	const std::string                          &index,
 	bool                                        autoindex,
 	const std::list<std::string>               &allowed_methods,
 	const std::pair<unsigned int, std::string> &redirect,
-	const std::string						  &cgi_extension    = "",
-	const std::string						  &upload_directory = ""
+	const std::string                          &cgi_extension    = "",
+	const std::string                          &upload_directory = ""
 ) {
 	server::Location loc;
 	loc.request_uri      = request_uri;
@@ -212,7 +212,7 @@ int Test1() {
 int Test2() {
 	// request
 	HttpRequestFormat request;
-	request.request_line        = CreateRequestLine("GET", "/www/test.html", "HTTP/1.1");
+	request.request_line = CreateRequestLine("GET", "/www/test.html", "HTTP/1.1");
 	request.header_fields[HOST] = "host10"; // hostが見つからない場合がデフォルト(host1)に
 	request.header_fields[CONNECTION] = KEEP_ALIVE;
 


### PR DESCRIPTION
ついでにformatterも

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- HTTPリクエストとレスポンスのエラーハンドリングを強化しました。
	- テストで使用するサーバーポートを定数`SERVER_PORT`に置き換え、設定の柔軟性を向上させました。

- **バグ修正**
	- タイムアウトや内部サーバーエラーの処理を改善しました。

- **文書化**
	- コードの整形や可読性の向上を目的とした変更を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->