### PR TITLE
[update] utilsに関数を移動

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -39,15 +39,6 @@ bool IsStringUpper(const std::string &str) {
 	return true;
 }
 
-std::string StrTrimOptionalWhitespace(const std::string &str) {
-	std::string::size_type start = str.find_first_not_of(OPTIONAL_WHITESPACE);
-	if (start == std::string::npos) {
-		return "";
-	}
-	std::string::size_type end = str.find_last_not_of(OPTIONAL_WHITESPACE);
-	return str.substr(start, end - start + 1);
-}
-
 bool IsBodyMessageReadingRequired(const HeaderFields &header_fields) {
 	if (header_fields.find(CONTENT_LENGTH) == header_fields.end() &&
 		header_fields.find(TRANSFER_ENCODING) == header_fields.end()) {
@@ -310,7 +301,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		std::size_t colon_pos          = (*it).find_first_of(':');
 		std::string header_field_name  = utils::ToLowerString((*it).substr(0, colon_pos));
 		std::string header_field_value = utils::ToLowerString((*it).substr(colon_pos + 1));
-		header_field_value             = StrTrimOptionalWhitespace(header_field_value);
+		header_field_value             = utils::Trim(header_field_value, OPTIONAL_WHITESPACE);
 		CheckValidHeaderFieldNameAndValue(header_field_name, header_field_value);
 		// todo:
 		// マルチパートを対応する場合はutils::SplitStrを使用して、セミコロン区切りのstd::vector<std::string>になる。

--- a/srcs/http/response/cgi_parse/cgi_parse.cpp
+++ b/srcs/http/response/cgi_parse/cgi_parse.cpp
@@ -15,18 +15,13 @@ std::string CreatePathInfo(const std::string &cgi_extension, const std::string &
 	return "";
 }
 
-bool EndWith(const std::string &str, const std::string &suffix) {
-	return str.size() >= suffix.size() &&
-		   str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 std::string
 TranslateToScriptName(const std::string &cgi_extension, const std::string &request_target) {
 	// from root path
 	const std::string::size_type root_pos = request_target.find("root/cgi-bin/");
 	if (root_pos != std::string::npos) {
 		const std::string script_name = request_target.substr(root_pos);
-		if (!EndWith(script_name, cgi_extension)) {
+		if (!utils::EndWith(script_name, cgi_extension)) {
 			const std::string::size_type extension_pos = script_name.find(cgi_extension);
 			// /aa.cgi/bb の場合、/aa.cgi のみを返す
 			return script_name.substr(0, extension_pos + cgi_extension.length());

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -5,6 +5,7 @@
 #include "http_response.hpp"
 #include "http_serverinfo_check.hpp"
 #include "stat.hpp"
+#include "utils.hpp"
 #include <algorithm> // std::find
 #include <cstring>
 #include <ctime>    // ctime
@@ -49,37 +50,9 @@ std::string DetermineContentType(const std::string &path) {
 	return TEXT_PLAIN;
 }
 
-// todo: utilsへ移動
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool StartWith(const std::string &str, const std::string &prefix) {
-	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
-}
-
-// ヘルパー関数: 文字列のトリム: TrimOWSにも使える
-std::string Trim(const std::string &str, const std::string &to_trim) {
-	std::size_t first = str.find_first_not_of(to_trim);
-	if (first == std::string::npos) {
-		return "";
-	}
-	std::size_t last = str.find_last_not_of(to_trim);
-	return str.substr(first, last - first + 1);
-}
-
-// std::string::front()
-char GetFrontChar(const std::string &str) {
-	return str.empty() ? '\0' : str[0];
-}
-
-// std::string::back()
-char GetBackChar(const std::string &str) {
-	return str.empty() ? '\0' : str[str.size() - 1];
-}
-
-// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
 // ヘルパー関数: 文字列のクオートを削除
 std::string RemoveQuotes(const std::string &str) {
-	if (GetFrontChar(str) == '"' && GetBackChar(str) == '"') {
+	if (utils::GetFrontChar(str) == '"' && utils::GetBackChar(str) == '"') {
 		return str.substr(1, str.size() - 2);
 	}
 	return str;
@@ -190,7 +163,7 @@ StatusCode Method::PostHandler(
 	if (upload_directory.empty()) {
 		return EchoPostHandler(request_body_message, response_body_message, response_header_fields);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
-			   StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {
+			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {
 		// Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 		// のようにContent-Typeがmultipart/form-dataの場合
 		return FileCreationHandlerForMultiPart(
@@ -504,7 +477,7 @@ std::map<std::string, std::string> Method::ParseContentDisposition(const std::st
 	std::getline(stream, part, ';'); // form-data
 	// セミコロンで分割
 	while (std::getline(stream, part, ';')) {
-		part            = Trim(part, OPTIONAL_WHITESPACE);
+		part            = utils::Trim(part, OPTIONAL_WHITESPACE);
 		std::size_t pos = part.find('=');
 		if (pos == std::string::npos) {
 			throw HttpException(
@@ -512,8 +485,8 @@ std::map<std::string, std::string> Method::ParseContentDisposition(const std::st
 			);
 		}
 		// filename="a.txt"のような形で来る
-		std::string key   = Trim(part.substr(0, pos), OPTIONAL_WHITESPACE);
-		std::string value = Trim(part.substr(pos + 1), OPTIONAL_WHITESPACE);
+		std::string key   = utils::Trim(part.substr(0, pos), OPTIONAL_WHITESPACE);
+		std::string value = utils::Trim(part.substr(pos + 1), OPTIONAL_WHITESPACE);
 		value             = RemoveQuotes(value);
 		result[key]       = value;
 	}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -29,22 +29,17 @@ std::string FileToString(const std::ifstream &file) {
 	return ss.str();
 }
 
-bool EndWith(const std::string &str, const std::string &suffix) {
-	return str.size() >= suffix.size() &&
-		   str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 // ファイルの拡張子に基づいてContent-Typeを決定する関数: デフォルトはtext/plain
 std::string DetermineContentType(const std::string &path) {
 	const std::string html_extension = ".html";
 	const std::string json_extension = ".json";
 	const std::string pdf_extension  = ".pdf";
 
-	if (EndWith(path, html_extension)) {
+	if (utils::EndWith(path, html_extension)) {
 		return http::TEXT_HTML;
-	} else if (EndWith(path, json_extension)) {
+	} else if (utils::EndWith(path, json_extension)) {
 		return "application/json";
-	} else if (EndWith(path, pdf_extension)) {
+	} else if (utils::EndWith(path, pdf_extension)) {
 		return "application/pdf";
 	}
 	return TEXT_PLAIN;
@@ -445,7 +440,7 @@ Method::Part Method::ParsePart(const std::string &part) {
 	// のboundary=----WebKitFormBoundary7MA4YWxkTrZu0gW以降の\r\nから始まる
 	std::string headers = part.substr(CRLF.length(), header_end);
 	result.body         = part.substr(header_end + CRLF.length() * 2);
-	if (!EndWith(result.body, CRLF)) { // bodyの終端はCRLFで終わっているとする
+	if (!utils::EndWith(result.body, CRLF)) { // bodyの終端はCRLFで終わっているとする
 		throw HttpException(
 			"Error: Invalid part format, body not properly terminated", StatusCode(BAD_REQUEST)
 		);

--- a/srcs/utils/end_with.cpp
+++ b/srcs/utils/end_with.cpp
@@ -1,0 +1,10 @@
+#include <string>
+
+namespace utils {
+
+bool EndWith(const std::string &str, const std::string &suffix) {
+	return str.size() >= suffix.size() &&
+		   str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+} // namespace utils

--- a/srcs/utils/get_back_char.cpp
+++ b/srcs/utils/get_back_char.cpp
@@ -1,0 +1,10 @@
+#include <string>
+
+namespace utils {
+
+// std::string::back()
+char GetBackChar(const std::string &str) {
+	return str.empty() ? '\0' : str[str.size() - 1];
+}
+
+} // namespace utils

--- a/srcs/utils/get_front_char.cpp
+++ b/srcs/utils/get_front_char.cpp
@@ -1,0 +1,10 @@
+#include <string>
+
+namespace utils {
+
+// std::string::front()
+char GetFrontChar(const std::string &str) {
+	return str.empty() ? '\0' : str[0];
+}
+
+} // namespace utils

--- a/srcs/utils/start_with.cpp
+++ b/srcs/utils/start_with.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+namespace utils {
+
+bool StartWith(const std::string &str, const std::string &prefix) {
+	return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
+} // namespace utils

--- a/srcs/utils/trim.cpp
+++ b/srcs/utils/trim.cpp
@@ -1,0 +1,14 @@
+#include <string>
+
+namespace utils {
+
+std::string Trim(const std::string &str, const std::string &to_trim) {
+	std::size_t first = str.find_first_not_of(to_trim);
+	if (first == std::string::npos) {
+		return "";
+	}
+	std::size_t last = str.find_last_not_of(to_trim);
+	return str.substr(first, last - first + 1);
+}
+
+} // namespace utils

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -51,6 +51,11 @@ std::string              ConvertUintToStr(unsigned int num);
 std::vector<std::string> SplitStr(const std::string &src, const std::string &substring);
 std::string              ToLowerString(const std::string &str);
 bool                     IsVString(const std::string &str);
+bool                     StartWith(const std::string &str, const std::string &prefix);
+bool                     EndWith(const std::string &str, const std::string &suffix);
+std::string              Trim(const std::string &str, const std::string &to_trim);
+char                     GetFrontChar(const std::string &str);
+char                     GetBackChar(const std::string &str);
 
 } // namespace utils
 

--- a/test/webserv/unit/cgi/Makefile
+++ b/test/webserv/unit/cgi/Makefile
@@ -22,6 +22,7 @@ SRCS				+=	$(WS_CGI_DIR)/cgi.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/end_with.cpp \
 						$(WS_EXCEPTION_DIR)/system_exception.cpp
 
 # 3. Add unit test files

--- a/test/webserv/unit/cgi_parse/Makefile
+++ b/test/webserv/unit/cgi_parse/Makefile
@@ -19,7 +19,8 @@ SRCS				+=	$(WS_HTTP_CGI_PARSE)/cgi_parse.cpp \
 						$(WS_CGI_DIR)/cgi_request.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
-						$(WS_UTILS_DIR)/convert_str.cpp
+						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/end_with.cpp
 
 # 3. Add unit test files
 SRCS	+=	test_cgi_parse.cpp

--- a/test/webserv/unit/http/Makefile
+++ b/test/webserv/unit/http/Makefile
@@ -26,6 +26,11 @@ SRCS				+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_UTILS_DIR)/is_vstring.cpp \
+						$(WS_UTILS_DIR)/get_front_char.cpp \
+						$(WS_UTILS_DIR)/get_back_char.cpp \
+						$(WS_UTILS_DIR)/start_with.cpp \
+						$(WS_UTILS_DIR)/end_with.cpp \
+						$(WS_UTILS_DIR)/trim.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \

--- a/test/webserv/unit/http_method/Makefile
+++ b/test/webserv/unit/http_method/Makefile
@@ -31,6 +31,7 @@ SRCS			+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 					$(WS_UTILS_DIR)/get_front_char.cpp \
 					$(WS_UTILS_DIR)/get_back_char.cpp \
 					$(WS_UTILS_DIR)/start_with.cpp \
+					$(WS_UTILS_DIR)/end_with.cpp \
 					$(WS_UTILS_DIR)/trim.cpp \
 					$(WS_HTTP_DIR)/http_message.cpp \
 					$(WS_HTTP_DIR)/status_code.cpp \

--- a/test/webserv/unit/http_method/Makefile
+++ b/test/webserv/unit/http_method/Makefile
@@ -28,6 +28,10 @@ SRCS			+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 					$(WS_UTILS_DIR)/convert_str.cpp \
 					$(WS_UTILS_DIR)/split_str.cpp \
 					$(WS_UTILS_DIR)/is_vstring.cpp \
+					$(WS_UTILS_DIR)/get_front_char.cpp \
+					$(WS_UTILS_DIR)/get_back_char.cpp \
+					$(WS_UTILS_DIR)/start_with.cpp \
+					$(WS_UTILS_DIR)/trim.cpp \
 					$(WS_HTTP_DIR)/http_message.cpp \
 					$(WS_HTTP_DIR)/status_code.cpp \
 					$(WS_HTTP_DIR)/http_exception.cpp \

--- a/test/webserv/unit/http_parse/Makefile
+++ b/test/webserv/unit/http_parse/Makefile
@@ -17,6 +17,7 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_UTILS_DIR)/is_vstring.cpp \
+						$(WS_UTILS_DIR)/trim.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp \

--- a/test/webserv/unit/http_response/Makefile
+++ b/test/webserv/unit/http_response/Makefile
@@ -29,6 +29,7 @@ SRCS			+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 					$(WS_UTILS_DIR)/get_front_char.cpp \
 					$(WS_UTILS_DIR)/get_back_char.cpp \
 					$(WS_UTILS_DIR)/start_with.cpp \
+					$(WS_UTILS_DIR)/end_with.cpp \
 					$(WS_UTILS_DIR)/trim.cpp \
 					$(WS_UTILS_DIR)/split_str.cpp \
 					$(WS_HTTP_DIR)/http_message.cpp \

--- a/test/webserv/unit/http_response/Makefile
+++ b/test/webserv/unit/http_response/Makefile
@@ -26,6 +26,10 @@ SRCS			+=	$(WS_EXCEPTION_DIR)/system_exception.cpp \
 					$(WS_UTILS_DIR)/color.cpp \
 					$(WS_UTILS_DIR)/convert_str.cpp \
 					$(WS_UTILS_DIR)/is_vstring.cpp \
+					$(WS_UTILS_DIR)/get_front_char.cpp \
+					$(WS_UTILS_DIR)/get_back_char.cpp \
+					$(WS_UTILS_DIR)/start_with.cpp \
+					$(WS_UTILS_DIR)/trim.cpp \
 					$(WS_UTILS_DIR)/split_str.cpp \
 					$(WS_HTTP_DIR)/http_message.cpp \
 					$(WS_HTTP_DIR)/status_code.cpp \

--- a/test/webserv/unit/http_storage/Makefile
+++ b/test/webserv/unit/http_storage/Makefile
@@ -18,6 +18,7 @@ SRCS				+=	$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/split_str.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
 						$(WS_UTILS_DIR)/is_vstring.cpp \
+						$(WS_UTILS_DIR)/trim.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp \


### PR DESCRIPTION
## いくつかの関数をutilsに移動しました

- StartWith
- EndWith
- GetBackChar
- GetFrontChar
- Trim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しいユーティリティ関数（`StartWith`, `EndWith`, `Trim`, `GetFrontChar`, `GetBackChar`）が追加され、文字列操作が簡素化されました。

- **バグ修正**
	- 不要な関数の削除により、コードの冗長性が削減され、メンテナンス性が向上しました。

- **ドキュメント**
	- ユーティリティ関数の宣言が追加され、利用可能な機能が拡張されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->