### PR TITLE
[update] multipartのエラーハンドリング追加

### DIFF
--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -438,6 +438,13 @@ Method::Part Method::ParsePart(const std::string &part) {
 	}
 	// ----WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name="file";
 	// のboundary=----WebKitFormBoundary7MA4YWxkTrZu0gW以降の\r\nから始まる
+	// -- + boundary + CRLF で区切られていなければならない
+	if (!utils::StartWith(part, CRLF)) {
+		throw HttpException(
+			"Error: Invalid part format, headers not properly terminated with CRLF",
+			StatusCode(BAD_REQUEST)
+		);
+	}
 	std::string headers = part.substr(CRLF.length(), header_end);
 	result.body         = part.substr(header_end + CRLF.length() * 2);
 	if (!utils::EndWith(result.body, CRLF)) { // bodyの終端はCRLFで終わっているとする

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -490,6 +490,11 @@ std::map<std::string, std::string> Method::ParseContentDisposition(const std::st
 		value             = RemoveQuotes(value);
 		result[key]       = value;
 	}
+	if (result.find("name") == result.end()) {
+		throw HttpException(
+			"Error: Content-Disposition header must contain 'name' field", StatusCode(BAD_REQUEST)
+		);
+	}
 	return result;
 }
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -470,6 +470,11 @@ std::map<std::string, std::string> Method::ParseContentDisposition(const std::st
 
 	// form-data; name="file"; filename="a.txt"
 	std::getline(stream, part, ';'); // form-data
+	if (part != "form-data") {
+		throw HttpException(
+			"Error: Content-Disposition type must be 'form-data'", StatusCode(BAD_REQUEST)
+		);
+	}
 	// セミコロンで分割
 	while (std::getline(stream, part, ';')) {
 		part            = utils::Trim(part, OPTIONAL_WHITESPACE);


### PR DESCRIPTION
## multipartのエラーハンドリングを追加しました

RFC https://datatracker.ietf.org/doc/html/rfc7578 の要件に従って以下のエラーハンドリングを追加しました
テストは統合テストで追加します

- [x] Each part MUST contain a Content-Disposition header field [RFC2183] where the disposition type is "form-data"
- [x] header field MUST also contain an additional parameter of "name"
- [x] Form parts with identical field names MUST NOT be coalesced
- [x] delimiter, constructed using CRLF, "--", and the value of the "boundary" parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- マルチパートフォームデータ処理のエラーハンドリングとバリデーションを強化しました。
- **バグ修正**
	- 不正なヘッダーの終了や重複ヘッダー名、Content-Dispositionヘッダーの不正な形式に対するチェックを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->