### PR TITLE
[fix] integration / test_timeout_keep_alive() がたまに actions で失敗する

### DIFF
--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -14,9 +14,17 @@ BUFFER_SIZE = 10240
 def receive_with_timeout(sock) -> Optional[str]:
     # timeoutを設定
     sock.settimeout(TIMEOUT)
+
+    # timeout秒までに受信したデータをためておく
+    received_data = []
     try:
-        # timeout秒までに何かを受信したらその時点で返す
-        return sock.recv(BUFFER_SIZE).decode("utf-8")
+        # 一度で全てrecvできない場合用にwhile
+        while True:
+            data = sock.recv(BUFFER_SIZE).decode("utf-8")
+            if not data:
+                # 受信データを繋げてstrにして返す
+                return "".join(received_data)
+            received_data.append(data)
     except socket.timeout:
         # timeout秒待っても何も送られてこなかった場合
         return None

--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -8,7 +8,7 @@ from common_response import (response_header_get_root_200_keep,
 
 # serverのtimeout+αを設定する
 TIMEOUT = 4.0
-BUFFER_SIZE = 10240
+BUFFER_SIZE = 1024
 
 
 def receive_with_timeout(sock) -> Optional[str]:


### PR DESCRIPTION
たまに actions でだけ落ちる integration の出力を見たところ、index.html を全部 `recv()` できていなかったです
一度で `revc()` できない場合の為に、while 文で `recv()` するよう変更しました
これで大丈夫になってくれるはず…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- データ受信のロジックを改善し、複数のパケットに分かれる大きなレスポンスを正しく処理できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->