### PR TITLE
[update] client_max_body_sizeに上限を設けた

### DIFF
--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -172,6 +172,10 @@ void Parser::HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr 
 	utils::Result<std::size_t> body_max_size = utils::ConvertStrToSize((*it).token);
 	if (!body_max_size.IsOk()) { // check range?
 		throw std::runtime_error("invalid client_max_body_size: " + (*it).token);
+	} else if (body_max_size.GetValue() < BODY_SIZE_MIN ||
+			   body_max_size.GetValue() > BODY_SIZE_MAX) {
+		// 8MB以上はアップロードに時間がかかりすぎる
+		throw std::runtime_error("client_max_body_size should be greater than 0 and less than 8MB");
 	}
 	if (IsDuplicateDirectiveName(server_directive_set_, CLIENT_MAX_BODY_SIZE)) {
 		throw std::runtime_error("'client_max_body_size' directive is duplicated");

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -170,7 +170,7 @@ void Parser::HandleClientMaxBodySize(std::size_t &client_max_body_size, NodeItr 
 		);
 	}
 	utils::Result<std::size_t> body_max_size = utils::ConvertStrToSize((*it).token);
-	if (!body_max_size.IsOk()) { // check range?
+	if (!body_max_size.IsOk()) {
 		throw std::runtime_error("invalid client_max_body_size: " + (*it).token);
 	} else if (body_max_size.GetValue() < BODY_SIZE_MIN ||
 			   body_max_size.GetValue() > BODY_SIZE_MAX) {

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -55,6 +55,8 @@ class Parser {
 	static const int PORT_MAX        = 65535;
 	static const int STATUS_CODE_MIN = 300;
 	static const int STATUS_CODE_MAX = 599;
+	static const int BODY_SIZE_MIN   = 1;       // 1B
+	static const int BODY_SIZE_MAX   = 8388608; // 8MB
 
 	/* For duplicated parameter */
 	typedef std::set<std::string>  DirectiveSet;

--- a/test/common/config/error_test_files/client_max_body_size/client_max_body_size_out_of_lower_range.conf
+++ b/test/common/config/error_test_files/client_max_body_size/client_max_body_size_out_of_lower_range.conf
@@ -1,0 +1,9 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 0;
+	error_page 404 /error_pages/404-ja.html;
+	location / {
+	}
+}

--- a/test/common/config/error_test_files/client_max_body_size/client_max_body_size_out_of_upper_range.conf
+++ b/test/common/config/error_test_files/client_max_body_size/client_max_body_size_out_of_upper_range.conf
@@ -1,0 +1,9 @@
+server {
+	listen localhost:4242;
+	listen 8080;
+	server_name localhost;
+	client_max_body_size 83886089;
+	error_page 404 /error_pages/404-ja.html;
+	location / {
+	}
+}

--- a/test/webserv/unit/config_parse/test_config.cpp
+++ b/test/webserv/unit/config_parse/test_config.cpp
@@ -527,6 +527,18 @@ int ClientMaxBodySizeDirectiveErrorTests() {
 		"client_max_body_size/"
 		"client_max_body_size_duplicated.conf"
 	);
+	ret_code |= RunErrorTest(
+		"client_max_body_size/"
+		"client_max_body_size_out_of_lower_range.conf",
+		"client_max_body_size/"
+		"client_max_body_size_out_of_lower_range.conf"
+	);
+	ret_code |= RunErrorTest(
+		"client_max_body_size/"
+		"client_max_body_size_out_of_upper_range.conf",
+		"client_max_body_size/"
+		"client_max_body_size_out_of_upper_range.conf"
+	);
 
 	return ret_code;
 }


### PR DESCRIPTION
## client_max_body_sizeに上限を設けました

- [x] 0Bの場合と8MB以上の場合を弾きました

自分の環境だと5.5MBで10秒くらいで送れました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `client_max_body_size`の値をチェックするための新しい条件を追加し、1バイト以上8MB未満であることを確認する機能を強化しました。
	- 新しい設定ファイルを追加し、無効な`client_max_body_size`の値に対するエラーハンドリングを強化しました。

- **バグ修正**
	- 無効な`client_max_body_size`の値に対するエラー処理を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->