### PR TITLE
[refactor] http / content-length セットしてる箇所でまとめられるところをまとめる

### DIFF
--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -188,7 +188,7 @@ void Parser::HandleErrorPage(std::pair<unsigned int, std::string> &error_page, N
 	}
 	// ex. 404 /404.html
 	NodeItr tmp_it = it; // 404
-	it++;                // /404.html
+	++it;                // /404.html
 	utils::Result<unsigned int> status_code = utils::ConvertStrToUint((*tmp_it).token);
 	if (!status_code.IsOk() || status_code.GetValue() < STATUS_CODE_MIN ||
 		status_code.GetValue() > STATUS_CODE_MAX) {
@@ -344,7 +344,7 @@ void Parser::HandleReturn(std::pair<unsigned int, std::string> &redirect, NodeIt
 	}
 	// ex. 302 /index.html
 	NodeItr tmp_it = it; // 302
-	it++;                // /index.html
+	++it;                // /index.html
 	utils::Result<unsigned int> status_code = utils::ConvertStrToUint((*tmp_it).token);
 	if (!status_code.IsOk() || status_code.GetValue() < STATUS_CODE_MIN ||
 		status_code.GetValue() > STATUS_CODE_MAX) {

--- a/srcs/config_parse/parser.cpp
+++ b/srcs/config_parse/parser.cpp
@@ -8,7 +8,7 @@
 namespace config {
 namespace parser {
 
-Parser::Parser(std::list<node::Node> &tokens) : tokens_(tokens) {
+Parser::Parser(const std::list<node::Node> &tokens) : tokens_(tokens) {
 	ParseNode();
 }
 

--- a/srcs/config_parse/parser.hpp
+++ b/srcs/config_parse/parser.hpp
@@ -64,7 +64,7 @@ class Parser {
 	LocationUriList                location_uri_list_;
 
   public:
-	explicit Parser(std::list<node::Node> &);
+	explicit Parser(const std::list<node::Node> &);
 	~Parser();
 
 	std::list<context::ServerCon> GetServers() const;

--- a/srcs/event/event.hpp
+++ b/srcs/event/event.hpp
@@ -7,7 +7,7 @@
 namespace event {
 
 enum Type {
-	EVENT_NONE   = 1 << 0, // todo: tmp
+	EVENT_NONE   = 1 << 0,
 	EVENT_READ   = 1 << 1,
 	EVENT_WRITE  = 1 << 2,
 	EVENT_ERROR  = 1 << 3,

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -117,9 +117,4 @@ bool Http::IsHttpRequestFormatComplete(int client_fd) {
 		   save_data.is_request_format.is_body_message;
 }
 
-// For test
-HttpRequestParsedData Http::GetClientData(int client_fd) {
-	return storage_.GetClientSaveData(client_fd);
-}
-
 } // namespace http

--- a/srcs/http/http.hpp
+++ b/srcs/http/http.hpp
@@ -29,9 +29,8 @@ class Http : public IHttp {
 	HttpResult          CreateHttpResponse(
 				 const ClientInfos &client_info, const server::VirtualServerAddrList &server_info
 			 );
-	HttpResult            CreateBadRequestResponse(int client_fd);
-	bool                  IsHttpRequestFormatComplete(int client_fd);
-	HttpRequestParsedData GetClientData(int client_fd);
+	HttpResult CreateBadRequestResponse(int client_fd);
+	bool       IsHttpRequestFormatComplete(int client_fd);
 };
 
 } // namespace http

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -238,12 +238,12 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 		);
 	}
 
-	ChunkSizeResult result = GetChunkSizeStr(data.current_buf);
-	if (!result.IsOk()) {
+	ChunkSizeResult chunk_size_result = GetChunkSizeStr(data.current_buf);
+	if (!chunk_size_result.IsOk()) {
 		return;
 	}
-	std::string::size_type end_of_chunk_size_pos = result.GetValue().first;
-	std::string            chunk_size_str        = result.GetValue().second;
+	std::string::size_type end_of_chunk_size_pos = chunk_size_result.GetValue().first;
+	std::string            chunk_size_str        = chunk_size_result.GetValue().second;
 	std::size_t            chunk_size            = HexToDec(chunk_size_str).GetValue();
 
 	while (true) {
@@ -267,12 +267,12 @@ void HttpParse::ParseChunkedRequest(HttpRequestParsedData &data) {
 			break;
 		}
 
-		ChunkSizeResult result = GetChunkSizeStr(data.current_buf);
-		if (!result.IsOk()) {
+		chunk_size_result = GetChunkSizeStr(data.current_buf);
+		if (!chunk_size_result.IsOk()) {
 			return;
 		}
-		end_of_chunk_size_pos = result.GetValue().first;
-		chunk_size_str        = result.GetValue().second;
+		end_of_chunk_size_pos = chunk_size_result.GetValue().first;
+		chunk_size_str        = chunk_size_result.GetValue().second;
 		chunk_size            = HexToDec(chunk_size_str).GetValue();
 	}
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -156,16 +156,10 @@ StatusCode Method::PostHandler(
 		// Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 		// のようにContent-Typeがmultipart/form-dataの場合
 		return FileCreationHandlerForMultiPart(
-			upload_dir_path,
-			request_body_message,
-			request_header_fields,
-			response_body_message,
-			response_header_fields
+			upload_dir_path, request_body_message, request_header_fields, response_body_message
 		);
 	} else if (!IsExistPath(upload_file_path)) {
-		return FileCreationHandler(
-			upload_file_path, request_body_message, response_body_message, response_header_fields
-		);
+		return FileCreationHandler(upload_file_path, request_body_message, response_body_message);
 	}
 	const Stat &info = TryStat(upload_file_path);
 	StatusCode  status_code(NO_CONTENT);
@@ -216,8 +210,7 @@ StatusCode Method::FileCreationHandlerForMultiPart(
 	const std::string  &path,
 	const std::string  &request_body_message,
 	const HeaderFields &request_header_fields,
-	std::string        &response_body_message,
-	HeaderFields       &response_header_fields
+	std::string        &response_body_message
 ) {
 	std::vector<Method::Part> parts =
 		DecodeMultipartFormData(request_header_fields.at(CONTENT_TYPE), request_body_message);
@@ -235,19 +228,17 @@ StatusCode Method::FileCreationHandlerForMultiPart(
 		std::string file_name = content_disposition[FILENAME];
 		std::string file_path = path + "/" + file_name;
 		// upload_dir + "/" + file_name にファイルを作成
-		FileCreationHandler(file_path, (*it).body, response_body_message, response_header_fields);
+		FileCreationHandler(file_path, (*it).body, response_body_message);
 	}
 	StatusCode status_code(CREATED);
-	response_body_message                  = HttpResponse::CreateDefaultBodyMessage(status_code);
-	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
+	response_body_message = HttpResponse::CreateDefaultBodyMessage(status_code);
 	return status_code;
 }
 
 StatusCode Method::FileCreationHandler(
 	const std::string &path,
 	const std::string &request_body_message,
-	std::string       &response_body_message,
-	HeaderFields      &response_header_fields
+	std::string       &response_body_message
 ) {
 	std::ofstream file(path.c_str(), std::ios::binary);
 	if (file.fail()) {
@@ -262,8 +253,7 @@ StatusCode Method::FileCreationHandler(
 		throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
 	}
 	StatusCode status_code(CREATED);
-	response_body_message                  = HttpResponse::CreateDefaultBodyMessage(status_code);
-	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
+	response_body_message = HttpResponse::CreateDefaultBodyMessage(status_code);
 	return status_code;
 }
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -84,7 +84,6 @@ StatusCode Method::Handler(
 			request_body_message,
 			request_header_fields,
 			response_body_message,
-			response_header_fields,
 			upload_directory
 		);
 	} else if (method == DELETE) {
@@ -138,7 +137,6 @@ StatusCode Method::PostHandler(
 	const std::string  &request_body_message,
 	const HeaderFields &request_header_fields,
 	std::string        &response_body_message,
-	HeaderFields       &response_header_fields,
 	const std::string  &upload_directory
 ) {
 	// ex. test.txt
@@ -150,7 +148,7 @@ StatusCode Method::PostHandler(
 	const std::string upload_file_path = upload_dir_path + "/" + file_name;
 
 	if (upload_directory.empty()) {
-		return EchoPostHandler(request_body_message, response_body_message, response_header_fields);
+		return EchoPostHandler(request_body_message, response_body_message);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
 			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {
 		// Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
@@ -167,7 +165,6 @@ StatusCode Method::PostHandler(
 		throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
 	} else if (info.IsRegularFile()) {
 		response_body_message = HttpResponse::CreateDefaultBodyMessage(status_code);
-		response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
 	} else {
 		// - upload_file_pathがシンボリックリンク
 		// - upload_file_pathが特殊ファイル（デバイスファイル、ソケットファイルなど）
@@ -358,12 +355,9 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 }
 
 StatusCode Method::EchoPostHandler(
-	const std::string &request_body_message,
-	std::string       &response_body_message,
-	HeaderFields      &response_header_fields
+	const std::string &request_body_message, std::string &response_body_message
 ) {
-	response_body_message                  = request_body_message;
-	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
+	response_body_message = request_body_message;
 	return StatusCode(OK);
 }
 

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -87,7 +87,7 @@ StatusCode Method::Handler(
 			upload_directory
 		);
 	} else if (method == DELETE) {
-		status_code = DeleteHandler(path, response_body_message, response_header_fields);
+		status_code = DeleteHandler(path, response_body_message);
 	}
 	return status_code;
 }
@@ -173,11 +173,7 @@ StatusCode Method::PostHandler(
 	return status_code;
 }
 
-StatusCode Method::DeleteHandler(
-	const std::string &path,
-	std::string       &response_body_message,
-	HeaderFields      &response_header_fields
-) {
+StatusCode Method::DeleteHandler(const std::string &path, std::string &response_body_message) {
 	const Stat &info        = TryStat(path);
 	StatusCode  status_code = StatusCode(NO_CONTENT);
 	if (info.IsDirectory()) {
@@ -187,7 +183,6 @@ StatusCode Method::DeleteHandler(
 		SystemExceptionHandler(errno);
 	} else {
 		response_body_message = HttpResponse::CreateDefaultBodyMessage(status_code);
-		response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
 	}
 	return status_code;
 }

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -107,15 +107,11 @@ StatusCode Method::GetHandler(
 		if (path[path.size() - 1] != '/') {
 			throw HttpException("Error: Moved Permanently", StatusCode(MOVED_PERMANENTLY));
 		} else if (!index_file_path.empty()) {
-			response_body_message = ReadFile(path + index_file_path);
-			response_header_fields[CONTENT_LENGTH] =
-				utils::ToString(response_body_message.length());
+			response_body_message                = ReadFile(path + index_file_path);
 			response_header_fields[CONTENT_TYPE] = DetermineContentType(path + index_file_path);
 		} else if (autoindex_on) {
 			utils::Result<std::string> result = AutoindexHandler(path);
 			response_body_message             = result.GetValue();
-			response_header_fields[CONTENT_LENGTH] =
-				utils::ToString(response_body_message.length());
 			if (!result.IsOk()) {
 				throw HttpException(
 					"Error: Internal Server Error", StatusCode(INTERNAL_SERVER_ERROR)
@@ -128,9 +124,7 @@ StatusCode Method::GetHandler(
 		if (!info.IsReadableFile()) {
 			throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
 		} else {
-			response_body_message = ReadFile(path);
-			response_header_fields[CONTENT_LENGTH] =
-				utils::ToString(response_body_message.length());
+			response_body_message                = ReadFile(path);
 			response_header_fields[CONTENT_TYPE] = DetermineContentType(path);
 		}
 	} else {

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -42,7 +42,6 @@ class Method {
 		const std::string  &request_body_message,
 		const HeaderFields &request_header_fields,
 		std::string        &response_body_message,
-		HeaderFields       &response_header_fields,
 		const std::string  &upload_directory
 	);
 	static StatusCode DeleteHandler(
@@ -64,11 +63,8 @@ class Method {
 		const HeaderFields &request_header_fields,
 		std::string        &response_body_message
 	);
-	static StatusCode EchoPostHandler(
-		const std::string &request_body_message,
-		std::string       &response_body_message,
-		HeaderFields      &response_header_fields
-	);
+	static StatusCode
+	EchoPostHandler(const std::string &request_body_message, std::string &response_body_message);
 	static utils::Result<std::string> AutoindexHandler(const std::string &path);
 
 	// マルチパート用のパートを表す構造体

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -56,15 +56,13 @@ class Method {
 	static StatusCode  FileCreationHandler(
 		 const std::string &path,
 		 const std::string &request_body_message,
-		 std::string       &response_body_message,
-		 HeaderFields      &response_header_fields
+		 std::string       &response_body_message
 	 );
 	static StatusCode FileCreationHandlerForMultiPart(
 		const std::string  &path,
 		const std::string  &request_body_message,
 		const HeaderFields &request_header_fields,
-		std::string        &response_body_message,
-		HeaderFields       &response_header_fields
+		std::string        &response_body_message
 	);
 	static StatusCode EchoPostHandler(
 		const std::string &request_body_message,

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -44,11 +44,7 @@ class Method {
 		std::string        &response_body_message,
 		const std::string  &upload_directory
 	);
-	static StatusCode DeleteHandler(
-		const std::string &path,
-		std::string       &response_body_message,
-		HeaderFields      &response_header_fields
-	);
+	static StatusCode  DeleteHandler(const std::string &path, std::string &response_body_message);
 	static Stat        TryStat(const std::string &path);
 	static std::string ReadFile(const std::string &file_path);
 	static void        SystemExceptionHandler(int error_number);

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -25,11 +25,11 @@ class Method {
 					 bool                autoindex_on,
 					 const std::string  &upload_directory
 				 );
-	static bool IsSupportedMethod(const std::string &method);
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);
 
   private:
+	static bool       IsSupportedMethod(const std::string &method);
 	static StatusCode GetHandler(
 		const std::string &path,
 		std::string       &body_message,

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -125,8 +125,8 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 		} else {
 			response_body_message = CreateDefaultBodyMessage(status_code);
 		}
-		response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
 	}
+	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
 	return HttpResponseFormat(
 		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),
 		response_header_fields,

--- a/srcs/server/message_manager/message.hpp
+++ b/srcs/server/message_manager/message.hpp
@@ -13,7 +13,6 @@ enum ConnectionState {
 	CLOSE
 };
 
-// todo: tmp
 struct Response {
 	Response() : connection_state(KEEP) {};
 	Response(ConnectionState connection_state, const std::string &response_str)


### PR DESCRIPTION
`content-length` は最後にセットすれば良いはずなので、ミス防止の為にもまとめて最後に 1 度セットするように変更しました
`HandleRedirect()` の中の `0` をセットしてるのも不要かと思ったのですが、あった方が良いのかもしれずそのままにしてあります

ついでに `cppcheck` の直せそうな箇所の修正

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - `ConnectionState` 列挙型を追加し、`Response` 構造体にデフォルトコンストラクタを追加しました。

- **バグ修正**
  - `CONTENT_LENGTH` ヘッダーの設定を修正し、常に正しい長さが更新されるようにしました。

- **リファクタリング**
  - `Parser` クラスのコンストラクタのパラメータを変更し、より安全にしました。
  - HTTP メソッドのハンドラーのシグネチャを簡素化しました。
  - `HttpResponse` クラスの `CreateHttpResponseFormat` メソッドにおける `CONTENT_LENGTH` ヘッダーの設定を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->