### PR TITLE
[add] integration テスト追加

### DIFF
--- a/test/common/request/post/4xx/405_01_method_not_allowed_for_uri.txt
+++ b/test/common/request/post/4xx/405_01_method_not_allowed_for_uri.txt
@@ -4,3 +4,4 @@ Connection: close
 Content-Type: text/plain
 Content-Length: 5
 
+abcde

--- a/test/webserv/integration/common_functions.py
+++ b/test/webserv/integration/common_functions.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import time
 
 SERVER_PORT = 8080
 
@@ -15,6 +16,20 @@ def read_file_binary(file):
     with open(file, "rb") as f:
         data = f.read()
     return data, len(data)
+
+
+def delete_file(file_path):
+    if file_path is None:
+        return
+
+    try:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            time.sleep(1)
+            print(f"Deleted file: {file_path}")
+    except Exception as e:
+        print(f"Error deleting file: {file_path}, {e}")
+        raise AssertionError
 
 
 def assert_response(response, expected_response):

--- a/test/webserv/integration/test_cgi.py
+++ b/test/webserv/integration/test_cgi.py
@@ -136,3 +136,11 @@ class TestCGI(unittest.TestCase):
             self.assertEqual(response.status, HTTPStatus.REQUEST_TIMEOUT)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
+
+    def test_not_allowed_method_delete_pl(self):
+        try:
+            self.con.request("DELETE", "/cgi-bin/print_ok.pl")
+            response = self.con.getresponse()
+            self.assertEqual(response.status, HTTPStatus.METHOD_NOT_ALLOWED)
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")

--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -45,7 +45,7 @@ def receive_with_timeout(sock) -> Optional[str]:
 
 # ------------------------------------------------------------------------------
 # 通常のkeep-aliveを送信(各関数の説明付き)
-def test_timeout_keep_alive() -> None:
+def test_01_timeout_keep_alive() -> None:
     try:
         con = HTTPConnection("localhost", SERVER_PORT)
         # serverに接続
@@ -84,7 +84,7 @@ def test_timeout_keep_alive() -> None:
             con.close()
 
 
-def test_timeout_incomplete_request() -> None:
+def test_02_timeout_incomplete_request() -> None:
     try:
         con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
@@ -107,7 +107,7 @@ def test_timeout_incomplete_request() -> None:
             con.close()
 
 
-def test_timeout_no_request() -> None:
+def test_03_timeout_no_request() -> None:
     try:
         con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
@@ -130,7 +130,7 @@ def test_timeout_no_request() -> None:
 
 
 # serverがその後も正常に動いていればOK
-def test_incomplete_request_disconnect() -> None:
+def test_04_incomplete_request_disconnect() -> None:
     try:
         con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
@@ -150,7 +150,7 @@ def test_incomplete_request_disconnect() -> None:
 
 
 # serverがその後も正常に動いていればOK
-def test_timeout_no_request_disconnect() -> None:
+def test_05_timeout_no_request_disconnect() -> None:
     try:
         con = HTTPConnection("localhost", SERVER_PORT)
         con.connect()
@@ -196,7 +196,7 @@ def create_json_request(json_data) -> Tuple[str, Mapping[str, str]]:
     return create_json_body(), create_headers(APPLICATION_JSON)
 
 
-def test_content_type_post_json_and_get_json() -> None:
+def test_06_content_type_post_json_and_get_json() -> None:
     delete_file(JSON_FULL_PATH)
 
     try:
@@ -235,7 +235,7 @@ UNKNOWN_FILENAME, UNKNOWN_DATA = (
 UNKNOWN_FULL_PATH = ROOT_DIR + UPLOAD_DIR + UNKNOWN_FILENAME
 
 
-def test_content_type_post_unknown_and_get() -> None:
+def test_07_content_type_post_unknown_and_get() -> None:
     delete_file(UNKNOWN_FULL_PATH)
 
     try:

--- a/test/webserv/integration/test_connection.py
+++ b/test/webserv/integration/test_connection.py
@@ -168,6 +168,13 @@ def test_timeout_no_request_disconnect() -> None:
             con.close()
 
 
+# content-lengthは自動で入る
+def create_headers(content_type) -> Mapping[str, str]:
+    headers = {}
+    headers[CONTENT_TYPE] = content_type
+    return headers
+
+
 JSON_FILENAME, JSON_DATA = (
     "webserv.json",
     {
@@ -186,13 +193,7 @@ def create_json_request(json_data) -> Tuple[str, Mapping[str, str]]:
         encoded_json_data = json.dumps(json_data)
         return encoded_json_data
 
-    # content-lengthは自動で入る
-    def create_headers() -> Mapping[str, str]:
-        headers = {}
-        headers[CONTENT_TYPE] = APPLICATION_JSON
-        return headers
-
-    return create_json_body(), create_headers()
+    return create_json_body(), create_headers(APPLICATION_JSON)
 
 
 def test_content_type_post_json_and_get_json() -> None:
@@ -234,12 +235,6 @@ UNKNOWN_FILENAME, UNKNOWN_DATA = (
 UNKNOWN_FULL_PATH = ROOT_DIR + UPLOAD_DIR + UNKNOWN_FILENAME
 
 
-def create_unknown_headers() -> Mapping[str, str]:
-    headers = {}
-    headers[CONTENT_TYPE] = APPLICATION_OCTET_STREAM
-    return headers
-
-
 def test_content_type_post_unknown_and_get() -> None:
     delete_file(UNKNOWN_FULL_PATH)
 
@@ -251,7 +246,7 @@ def test_content_type_post_unknown_and_get() -> None:
             "POST",
             "/" + UPLOAD_DIR + UNKNOWN_FILENAME,
             UNKNOWN_DATA,
-            create_unknown_headers(),
+            create_headers(APPLICATION_OCTET_STREAM),
         )
 
         response = con.getresponse()

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -1,8 +1,8 @@
 import os
-import time
 
 import pytest
-from common_functions import read_file, send_request_and_assert_response
+from common_functions import (delete_file, read_file,
+                              send_request_and_assert_response)
 from common_response import (bad_request_response, created_response_close,
                              created_response_keep, no_content_response_close,
                              not_allowed_response, payload_too_large_response,
@@ -16,20 +16,6 @@ REQUEST_POST_4XX_DIR = REQUEST_DIR + "post/4xx/"
 UPLOAD_DIR = "root/upload/"
 UPLOAD_FILE_PATH = UPLOAD_DIR + "test_upload_file"
 CHUNKED_FILE_PATH = UPLOAD_DIR + "chunked_request_file"
-
-
-def delete_file(file_path):
-    if file_path is None:
-        return
-
-    try:
-        if os.path.exists(file_path):
-            os.remove(file_path)
-            time.sleep(1)
-            print(f"Deleted file: {file_path}")
-    except Exception as e:
-        print(f"Error deleting file: {file_path}, {e}")
-        raise AssertionError
 
 
 def assert_uploaded_file_content(upload_file_path, expected_upload_file_content):

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -5,7 +5,7 @@ import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (bad_request_response, created_response_close,
                              created_response_keep, no_content_response_close,
-                             payload_too_large_response,
+                             not_allowed_response, payload_too_large_response,
                              response_header_get_root_200_close,
                              root_index_file, timeout_response)
 
@@ -197,6 +197,11 @@ def test_post_upload_responses(
             CHUNKED_FILE_PATH,
         ),
         (
+            REQUEST_POST_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
+            not_allowed_response,
+            None,
+        ),
+        (
             REQUEST_POST_4XX_DIR + "408_01_shortened_body_message.txt",
             timeout_response,
             UPLOAD_DIR + "shortened_body_message",
@@ -245,6 +250,7 @@ def test_post_upload_responses(
         "400_10_chunked_empty_chunk_data",
         "400_11_overflow_chunk_size_and_crlf",
         "400_12_only_too_large_chunk_size_early_check",
+        "405_01_method_not_allowed_for_uri",
         "408_01_shortened_body_message",
         "408_02_no_body_message",
         "408_03_incomplete_chunked_body",


### PR DESCRIPTION
integration test に追加

python のモジュールでまとめられそうな所はたくさんあるのですが、調べる時間削減のため冗長になってます
気になったら全然変えてもらって大丈夫です (追記：-> ここから切った別 PR で軽く class 化しました)

### POST
- 405_01 : body があってこの uri では POST が許可されてない

### DELETE
- 405 : CGI で delete は許可されてない

### GET
- 200 : `POST /upload/webserv.json` ->`GET /upload/webserv.json` した時に content-type が `application/json` かどうか
- 200 : `POST /upload/webserv.unknown` -> `GET /upload/webserv.unknown` した時に content-type が `text/plain` かどうか
 (-> `application/octet-stream` とどっちが良いのか？)

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTTP POSTリクエストに対する405 Method Not Allowedのテストケースを追加。
  - JSONデータの投稿および取得に関する新しいテストを追加。

- **バグ修正**
  - HTTPリクエストの処理に関するテストを強化。

- **ドキュメント**
  - テスト関数の命名規則を改善し、可読性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->