### PR TITLE
[fix] file_upload_pathを修正

### DIFF
--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -29,17 +29,6 @@ std::string FileToString(const std::ifstream &file) {
 	return ss.str();
 }
 
-// root 以降を抜き出す
-std::string ExtractHttpServerInfoCheckPath(const std::string &full_path) {
-	const std::string target = "root";
-	size_t            pos    = full_path.find(target);
-	if (pos != std::string::npos) {
-		return full_path.substr(pos + target.length());
-	} else {
-		return "";
-	}
-}
-
 // ファイルの拡張子に基づいてContent-Typeを決定する関数: デフォルトはtext/plain
 std::string DetermineContentType(const std::string &path) {
 	const std::string html_extension = ".html";
@@ -146,7 +135,7 @@ StatusCode Method::PostHandler(
 	std::string        &response_body_message
 ) {
 
-	if (ExtractHttpServerInfoCheckPath(file_upload_path).empty()) {
+	if (file_upload_path.empty()) {
 		return EchoPostHandler(request_body_message, response_body_message);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
 			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -222,7 +222,7 @@ StatusCode Method::FileCreationHandler(
 ) {
 	std::ofstream file(path.c_str(), std::ios::binary);
 	if (file.fail()) {
-		throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
+		SystemExceptionHandler(errno);
 	}
 	file.write(request_body_message.c_str(), request_body_message.length());
 	if (file.fail()) {
@@ -230,7 +230,7 @@ StatusCode Method::FileCreationHandler(
 		if (std::remove(path.c_str()) == SYSTEM_ERROR) {
 			SystemExceptionHandler(errno);
 		}
-		throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));
+		SystemExceptionHandler(errno);
 	}
 	StatusCode status_code(CREATED);
 	response_body_message = HttpResponse::CreateDefaultBodyMessage(status_code);

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -65,7 +65,7 @@ StatusCode Method::Handler(
 	HeaderFields       &response_header_fields,
 	const std::string  &index_file_path,
 	bool                autoindex_on,
-	const std::string  &upload_directory
+	const std::string  &file_upload_path
 ) {
 	StatusCode status_code(OK);
 	if (!IsSupportedMethod(method)) {
@@ -84,7 +84,7 @@ StatusCode Method::Handler(
 			request_body_message,
 			request_header_fields,
 			response_body_message,
-			upload_directory
+			file_upload_path
 		);
 	} else if (method == DELETE) {
 		status_code = DeleteHandler(path, response_body_message);
@@ -137,29 +137,29 @@ StatusCode Method::PostHandler(
 	const std::string  &request_body_message,
 	const HeaderFields &request_header_fields,
 	std::string        &response_body_message,
-	const std::string  &upload_directory
+	const std::string  &file_upload_path
 ) {
 	// ex. test.txt
-	const std::string file_name = path.substr(path.find_last_of('/') + 1);
-	// ex. srcs/http/response/http_serverinfo_check/../../../../root
-	const std::string root_path = path.substr(0, path.find("root/") + 4);
-	// ex. srcs/http/response/http_serverinfo_check/../../../../root/save/test.txt
-	const std::string upload_dir_path  = root_path + upload_directory;
-	const std::string upload_file_path = upload_dir_path + "/" + file_name;
+	// const std::string file_name = path.substr(path.find_last_of('/') + 1);
+	// // ex. srcs/http/response/http_serverinfo_check/../../../../root
+	// const std::string root_path = path.substr(0, path.find("root/") + 4);
+	// // ex. srcs/http/response/http_serverinfo_check/../../../../root/save/test.txt
+	// const std::string upload_dir_path  = root_path + upload_directory;
+	// const std::string upload_file_path = upload_dir_path + "/" + file_name;
 
-	if (upload_directory.empty()) {
+	if (file_upload_path.empty()) {
 		return EchoPostHandler(request_body_message, response_body_message);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
 			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {
 		// Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 		// のようにContent-Typeがmultipart/form-dataの場合
 		return FileCreationHandlerForMultiPart(
-			upload_dir_path, request_body_message, request_header_fields, response_body_message
+			file_upload_path, request_body_message, request_header_fields, response_body_message
 		);
-	} else if (!IsExistPath(upload_file_path)) {
-		return FileCreationHandler(upload_file_path, request_body_message, response_body_message);
+	} else if (!IsExistPath(file_upload_path)) {
+		return FileCreationHandler(file_upload_path, request_body_message, response_body_message);
 	}
-	const Stat &info = TryStat(upload_file_path);
+	const Stat &info = TryStat(file_upload_path);
 	StatusCode  status_code(NO_CONTENT);
 	if (info.IsDirectory()) {
 		throw HttpException("Error: Forbidden", StatusCode(FORBIDDEN));

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -80,11 +80,7 @@ StatusCode Method::Handler(
 		);
 	} else if (method == POST) {
 		status_code = PostHandler(
-			path,
-			request_body_message,
-			request_header_fields,
-			response_body_message,
-			file_upload_path
+			file_upload_path, request_body_message, request_header_fields, response_body_message
 		);
 	} else if (method == DELETE) {
 		status_code = DeleteHandler(path, response_body_message);
@@ -133,19 +129,11 @@ StatusCode Method::GetHandler(
 }
 
 StatusCode Method::PostHandler(
-	const std::string  &path,
+	const std::string  &file_upload_path,
 	const std::string  &request_body_message,
 	const HeaderFields &request_header_fields,
-	std::string        &response_body_message,
-	const std::string  &file_upload_path
+	std::string        &response_body_message
 ) {
-	// ex. test.txt
-	// const std::string file_name = path.substr(path.find_last_of('/') + 1);
-	// // ex. srcs/http/response/http_serverinfo_check/../../../../root
-	// const std::string root_path = path.substr(0, path.find("root/") + 4);
-	// // ex. srcs/http/response/http_serverinfo_check/../../../../root/save/test.txt
-	// const std::string upload_dir_path  = root_path + upload_directory;
-	// const std::string upload_file_path = upload_dir_path + "/" + file_name;
 
 	if (file_upload_path.empty()) {
 		return EchoPostHandler(request_body_message, response_body_message);

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -29,6 +29,17 @@ std::string FileToString(const std::ifstream &file) {
 	return ss.str();
 }
 
+// root 以降を抜き出す
+std::string ExtractHttpServerInfoCheckPath(const std::string &full_path) {
+	const std::string target = "root";
+	size_t            pos    = full_path.find(target);
+	if (pos != std::string::npos) {
+		return full_path.substr(pos + target.length());
+	} else {
+		return "";
+	}
+}
+
 // ファイルの拡張子に基づいてContent-Typeを決定する関数: デフォルトはtext/plain
 std::string DetermineContentType(const std::string &path) {
 	const std::string html_extension = ".html";
@@ -135,7 +146,7 @@ StatusCode Method::PostHandler(
 	std::string        &response_body_message
 ) {
 
-	if (file_upload_path.empty()) {
+	if (ExtractHttpServerInfoCheckPath(file_upload_path).empty()) {
 		return EchoPostHandler(request_body_message, response_body_message);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
 			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -23,7 +23,7 @@ class Method {
 					 HeaderFields       &response_header_fields,
 					 const std::string  &index_file_path,
 					 bool                autoindex_on,
-					 const std::string  &upload_directory
+					 const std::string  &file_upload_path
 				 );
 	static bool
 	IsAllowedMethod(const std::string &method, const std::list<std::string> &allow_methods);

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -38,11 +38,10 @@ class Method {
 		bool               autoindex_on
 	);
 	static StatusCode PostHandler(
-		const std::string  &path,
+		const std::string  &file_upload_path,
 		const std::string  &request_body_message,
 		const HeaderFields &request_header_fields,
-		std::string        &response_body_message,
-		const std::string  &upload_directory
+		std::string        &response_body_message
 	);
 	static StatusCode  DeleteHandler(const std::string &path, std::string &response_body_message);
 	static Stat        TryStat(const std::string &path);

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -109,7 +109,7 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 				response_header_fields,
 				server_info_result.index,
 				server_info_result.autoindex,
-				server_info_result.upload_directory
+				server_info_result.file_upload_path
 			);
 		}
 	} catch (const HttpException &e) {

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -174,19 +174,25 @@ void HttpServerInfoCheck::CheckUploadPath(
 	if (location.upload_directory.empty()) {
 		return;
 	}
-	std::size_t pos = result.path.find(location.request_uri);
-	// ex. location.request_uri /www/ result.request_path /www/
-	if (result.path.length() <= pos + location.request_uri.length()) {
+
+	std::string location_uri = location.request_uri;
+	if (!location.alias.empty()) {
+		location_uri = location.alias;
+	}
+	std::size_t pos = result.path.find(location_uri);
+	// ex. location_uri /www/ result.request_path /www/
+	if (result.path.length() <= pos + location_uri.length()) {
+		result.file_upload_path = location_uri;
 		return;
 	}
 	// ex. test.txt, aa/bb/test.txt
 	std::string file_name;
-	if (utils::EndWith(location.request_uri, "/")) {
+	if (utils::EndWith(location_uri, "/")) {
 		// ex. location /www/ request /www/test.txt
-		file_name = result.path.substr(pos + location.request_uri.length());
+		file_name = result.path.substr(pos + location_uri.length());
 	} else {
 		// ex. location /www request /www/test.txt
-		file_name = result.path.substr(pos + location.request_uri.length() + 1);
+		file_name = result.path.substr(pos + location_uri.length() + 1);
 	}
 	// ex. upload/test.txt, upload/aa/bb/test.txt
 	const std::string file_upload_path = location.upload_directory + "/" + file_name;

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -86,7 +86,10 @@ void HttpServerInfoCheck::CheckLocationList(
 	CheckUploadPath(result, match_location);
 	const std::string ROOT_PATH = GetCwd() + "/../../../../root";
 	result.path                 = ROOT_PATH + result.path;
-	result.file_upload_path     = ROOT_PATH + result.file_upload_path;
+	// upload_dirがない場合はそのまま返す
+	if (!result.file_upload_path.empty()) {
+		result.file_upload_path = ROOT_PATH + result.file_upload_path;
+	}
 	return;
 }
 

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -175,10 +175,13 @@ void HttpServerInfoCheck::CheckUploadPath(
 	if (location.upload_directory.empty()) {
 		return;
 	}
+	std::size_t pos = result.path.find(location.request_uri);
+	// ex. location.request_uri /www/ result.request_path /www/
+	if (result.path.length() == pos + location.request_uri.length()) {
+		return;
+	}
 	// ex. test.txt, aa/bb/test.txt
-	const std::string file_name = result.path.substr(
-		result.path.find(location.request_uri) + location.request_uri.length() + 1
-	);
+	const std::string file_name = result.path.substr(pos + location.request_uri.length() + 1);
 	// ex. upload/test.txt, upload/aa/bb/test.txt
 	const std::string file_upload_path = location.upload_directory + "/" + file_name;
 	result.file_upload_path            = file_upload_path;

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -77,7 +77,6 @@ void HttpServerInfoCheck::CheckLocationList(
 	const std::string     &request_target
 ) {
 	const server::Location &match_location = FindLocation(result, locations, request_target);
-	// std::cout << match_location.request_uri << std::endl; // for debug
 	CheckIndex(result, match_location);
 	CheckAutoIndex(result, match_location);
 	CheckAlias(result, match_location);
@@ -181,7 +180,14 @@ void HttpServerInfoCheck::CheckUploadPath(
 		return;
 	}
 	// ex. test.txt, aa/bb/test.txt
-	const std::string file_name = result.path.substr(pos + location.request_uri.length() + 1);
+	std::string file_name;
+	if (utils::EndWith(location.request_uri, "/")) {
+		// ex. location /www/ request /www/test.txt
+		file_name = result.path.substr(pos + location.request_uri.length());
+	} else {
+		// ex. location /www request /www/test.txt
+		file_name = result.path.substr(pos + location.request_uri.length() + 1);
+	}
 	// ex. upload/test.txt, upload/aa/bb/test.txt
 	const std::string file_upload_path = location.upload_directory + "/" + file_name;
 	result.file_upload_path            = file_upload_path;

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -87,6 +87,7 @@ void HttpServerInfoCheck::CheckLocationList(
 	CheckUploadPath(result, match_location);
 	const std::string ROOT_PATH = GetCwd() + "/../../../../root";
 	result.path                 = ROOT_PATH + result.path;
+	result.file_upload_path     = ROOT_PATH + result.file_upload_path;
 	return;
 }
 
@@ -171,7 +172,16 @@ void HttpServerInfoCheck::CheckCgiExtension(
 void HttpServerInfoCheck::CheckUploadPath(
 	CheckServerInfoResult &result, const server::Location &location
 ) {
-	// result.upload_directory = location.upload_directory;
+	if (location.upload_directory.empty()) {
+		return;
+	}
+	// ex. test.txt, aa/bb/test.txt
+	const std::string file_name = result.path.substr(
+		result.path.find(location.request_uri) + location.request_uri.length() + 1
+	);
+	// ex. upload/test.txt, upload/aa/bb/test.txt
+	const std::string file_upload_path = location.upload_directory + "/" + file_name;
+	result.file_upload_path            = file_upload_path;
 }
 
 } // namespace http

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -176,7 +176,7 @@ void HttpServerInfoCheck::CheckUploadPath(
 	}
 	std::size_t pos = result.path.find(location.request_uri);
 	// ex. location.request_uri /www/ result.request_path /www/
-	if (result.path.length() == pos + location.request_uri.length()) {
+	if (result.path.length() <= pos + location.request_uri.length()) {
 		return;
 	}
 	// ex. test.txt, aa/bb/test.txt

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.cpp
@@ -84,7 +84,7 @@ void HttpServerInfoCheck::CheckLocationList(
 	CheckRedirect(result, match_location);
 	CheckAllowedMethods(result, match_location);
 	CheckCgiExtension(result, match_location);
-	CheckUploadDirectory(result, match_location);
+	CheckUploadPath(result, match_location);
 	const std::string ROOT_PATH = GetCwd() + "/../../../../root";
 	result.path                 = ROOT_PATH + result.path;
 	return;
@@ -168,10 +168,10 @@ void HttpServerInfoCheck::CheckCgiExtension(
 	result.cgi_extension = location.cgi_extension;
 }
 
-void HttpServerInfoCheck::CheckUploadDirectory(
+void HttpServerInfoCheck::CheckUploadPath(
 	CheckServerInfoResult &result, const server::Location &location
 ) {
-	result.upload_directory = location.upload_directory;
+	// result.upload_directory = location.upload_directory;
 }
 
 } // namespace http

--- a/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
+++ b/srcs/http/response/http_serverinfo_check/http_serverinfo_check.hpp
@@ -23,7 +23,7 @@ struct CheckServerInfoResult {
 	// メソッドの処理で使用
 	std::list<std::string> allowed_methods;
 	std::string            cgi_extension;
-	std::string            upload_directory;
+	std::string            file_upload_path;
 
 	utils::Result< std::pair<unsigned int, std::string> > redirect;
 	utils::Result< std::pair<unsigned int, std::string> > error_page;
@@ -68,8 +68,7 @@ class HttpServerInfoCheck {
 	static void
 	CheckAllowedMethods(CheckServerInfoResult &result, const server::Location &location);
 	static void CheckCgiExtension(CheckServerInfoResult &result, const server::Location &location);
-	static void
-	CheckUploadDirectory(CheckServerInfoResult &result, const server::Location &location);
+	static void CheckUploadPath(CheckServerInfoResult &result, const server::Location &location);
 
   public:
 	static CheckServerInfoResult

--- a/test/webserv/unit/http_method/test_http_method.cpp
+++ b/test/webserv/unit/http_method/test_http_method.cpp
@@ -23,7 +23,7 @@ struct MethodArgument {
 		http::HeaderFields               &response_header_fields,
 		const std::string                &index_file_path  = "",
 		bool                              autoindex_on     = false,
-		const std::string                &upload_directory = "/upload"
+		const std::string                &upload_file_path = ""
 	)
 		: path(path),
 		  method(method),
@@ -34,7 +34,7 @@ struct MethodArgument {
 		  response_header_fields(response_header_fields),
 		  index_file_path(index_file_path),
 		  autoindex_on(autoindex_on),
-		  upload_directory(upload_directory) {
+		  upload_file_path(upload_file_path) {
 		response_body_message.clear();
 	}
 	const std::string                &path;
@@ -46,7 +46,7 @@ struct MethodArgument {
 	http::HeaderFields               &response_header_fields;
 	const std::string                &index_file_path;
 	bool                              autoindex_on;
-	const std::string                &upload_directory;
+	const std::string                &upload_file_path;
 };
 
 std::string LoadFileContent(const std::string &file_path) {
@@ -142,7 +142,7 @@ int MethodHandlerResult(const MethodArgument &srcs, const std::string &expected_
 			srcs.response_header_fields,
 			srcs.index_file_path,
 			srcs.autoindex_on,
-			srcs.upload_directory
+			srcs.upload_file_path
 		);
 		result = HandleResult(srcs.response_body_message, expected_body_message);
 
@@ -289,7 +289,7 @@ int main(void) {
 			response_header_fields,
 			"",
 			false,
-			"/directory"
+			"root/directory/200_ok.txt"
 		),
 		expected_created
 	);
@@ -307,7 +307,7 @@ int main(void) {
 			response_header_fields,
 			"",
 			false,
-			"/directory"
+			"root/directory/200_ok.txt"
 		),
 		expected_no_content
 	);
@@ -325,7 +325,7 @@ int main(void) {
 			response_header_fields,
 			"",
 			false,
-			"/upload"
+			"root/upload/200_ok.txt"
 		),
 		expected_created
 	);
@@ -339,7 +339,10 @@ int main(void) {
 			request,
 			request_header_fields,
 			response,
-			response_header_fields
+			response_header_fields,
+			"",
+			false,
+			"root/directory/"
 		),
 		expected_forbidden
 	);

--- a/test/webserv/unit/http_serverinfo_check/Makefile
+++ b/test/webserv/unit/http_serverinfo_check/Makefile
@@ -20,6 +20,7 @@ WS_VIRTUAL_SERVER_DIR			:=	$(WS_SRCS_DIR)/server/virtual_server
 SRCS				+=	$(WS_HTTP_SERVERINFO_CHECK_DIR)/http_serverinfo_check.cpp \
 						$(WS_UTILS_DIR)/color.cpp \
 						$(WS_UTILS_DIR)/convert_str.cpp \
+						$(WS_UTILS_DIR)/end_with.cpp \
 						$(WS_HTTP_DIR)/http_message.cpp \
 						$(WS_HTTP_DIR)/http_exception.cpp \
 						$(WS_HTTP_DIR)/status_code.cpp \

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -277,7 +277,8 @@ int Test3() {
 
 int Test4() {
 	// request
-	// "/web/"(locationそのもの)にリクエストを送る場合、upload_directoryは"/data"でupload_fileは""
+	// "/web/"(locationそのもの)にリクエストを送る場合、upload_directoryは"/data"でupload_fileは"/web/"
+	// (multipart/form-data 用)
 	HttpRequestFormat request;
 	request.request_line              = CreateRequestLine("POST", "/web/", "HTTP/1.1");
 	request.header_fields[HOST]       = "host2";
@@ -288,7 +289,7 @@ int Test4() {
 	const server::VirtualServer  *vs     = *(Next(virtual_servers.begin(), 1)); // host2
 	server::Location              location =
 		*(Next(vs->GetLocationList().begin(), 1)); // location2(cgi, upload_directory)
-	std::string upload_file_path = "";
+	std::string upload_file_path = "/web/";
 
 	try {
 		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri);

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -277,8 +277,9 @@ int Test3() {
 
 int Test4() {
 	// request
+	// "/web/"(locationそのもの)にリクエストを送る場合、upload_directoryは"/data"でupload_fileは""
 	HttpRequestFormat request;
-	request.request_line              = CreateRequestLine("GET", "/web/", "HTTP/1.1");
+	request.request_line              = CreateRequestLine("POST", "/web/", "HTTP/1.1");
 	request.header_fields[HOST]       = "host2";
 	request.header_fields[CONNECTION] = KEEP_ALIVE;
 
@@ -309,8 +310,43 @@ int Test4() {
 	return EXIT_SUCCESS;
 }
 
-// host3に"/"がないのでlocation NOFエラー
 int Test5() {
+	// request
+	HttpRequestFormat request;
+	// "/web/aa/bb"にリクエストを送る場合、upload_directoryは"/data"でupload_fileは"/data/aa/bb"
+	request.request_line              = CreateRequestLine("POST", "/web/aa/bb", "HTTP/1.1");
+	request.header_fields[HOST]       = "host2";
+	request.header_fields[CONNECTION] = KEEP_ALIVE;
+
+	server::VirtualServerAddrList virtual_servers = BuildVirtualServerAddrList();
+	CheckServerInfoResult         result = HttpServerInfoCheck::Check(virtual_servers, request);
+	const server::VirtualServer  *vs     = *(Next(virtual_servers.begin(), 1)); // host2
+	server::Location              location =
+		*(Next(vs->GetLocationList().begin(), 1)); // location2(cgi, upload_directory)
+	std::string upload_file_path = "/data/aa/bb";
+
+	try {
+		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri + "aa/bb");
+		COMPARE(result.index, location.index);
+		COMPARE(result.autoindex, location.autoindex);
+		COMPARE(result.allowed_methods, location.allowed_methods);
+		COMPARE(result.cgi_extension, location.cgi_extension);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.file_upload_path), upload_file_path);
+		COMPARE(result.redirect.GetValue(), location.redirect);
+		COMPARE(result.error_page.GetValue(), virtual_servers.front()->GetErrorPage());
+	} catch (const std::exception &e) {
+		PrintNg();
+		utils::Debug(e.what());
+		DeleteVirtualServerAddrList(virtual_servers);
+		return EXIT_FAILURE;
+	}
+	PrintOk();
+	DeleteVirtualServerAddrList(virtual_servers);
+	return EXIT_SUCCESS;
+}
+
+// host3に"/"がないのでlocation NOFエラー
+int Test6() {
 	// request
 	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
 	HttpRequestFormat request;
@@ -334,7 +370,7 @@ int Test5() {
 }
 
 // client_max_body_sizeを超えたエラー
-int Test6() {
+int Test7() {
 	// request
 	const RequestLine request_line = {"GET", "/", "HTTP/1.1"};
 	HttpRequestFormat request;
@@ -369,5 +405,6 @@ int main() {
 	ret |= Test4();
 	ret |= Test5();
 	ret |= Test6();
+	ret |= Test7();
 	return ret;
 }

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -253,7 +253,7 @@ int Test3() {
 	CheckServerInfoResult         result   = HttpServerInfoCheck::Check(virtual_servers, request);
 	const server::VirtualServer  *vs       = *(Next(virtual_servers.begin(), 1)); // host2
 	server::Location              location = vs->GetLocationList().front(); // location1(alias)
-	std::string                   upload_file_path = "";
+	std::string                   upload_file_path = ""; // upload_directoryはないので空文字
 
 	try {
 		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.alias + "test.html");

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -188,6 +188,7 @@ int Test1() {
 	CheckServerInfoResult         result   = HttpServerInfoCheck::Check(virtual_servers, request);
 	const server::VirtualServer  *vs       = virtual_servers.front();       // host1
 	server::Location              location = vs->GetLocationList().front(); // location1
+	std::string                   upload_file_path = "";
 
 	try {
 		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri);
@@ -195,7 +196,7 @@ int Test1() {
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
 		COMPARE(result.cgi_extension, location.cgi_extension);
-		COMPARE(result.upload_directory, location.upload_directory);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.file_upload_path), upload_file_path);
 		COMPARE(result.redirect.GetValue(), location.redirect);
 		COMPARE(result.error_page.GetValue(), virtual_servers.front()->GetErrorPage());
 	} catch (const std::exception &e) {
@@ -220,13 +221,14 @@ int Test2() {
 	CheckServerInfoResult         result = HttpServerInfoCheck::Check(virtual_servers, request);
 	const server::VirtualServer  *vs     = virtual_servers.front();        // host1
 	server::Location location = *(Next(vs->GetLocationList().begin(), 1)); // location2(redirect)
+	std::string      upload_file_path = "";
 
 	try {
 		COMPARE(result.index, location.index);
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
 		COMPARE(result.cgi_extension, location.cgi_extension);
-		COMPARE(result.upload_directory, location.upload_directory);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.file_upload_path), upload_file_path);
 		COMPARE(result.redirect.GetValue(), location.redirect);
 		COMPARE(result.error_page.GetValue(), virtual_servers.front()->GetErrorPage());
 	} catch (const std::exception &e) {
@@ -251,6 +253,7 @@ int Test3() {
 	CheckServerInfoResult         result   = HttpServerInfoCheck::Check(virtual_servers, request);
 	const server::VirtualServer  *vs       = *(Next(virtual_servers.begin(), 1)); // host2
 	server::Location              location = vs->GetLocationList().front(); // location1(alias)
+	std::string                   upload_file_path = "";
 
 	try {
 		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.alias + "test.html");
@@ -258,7 +261,7 @@ int Test3() {
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
 		COMPARE(result.cgi_extension, location.cgi_extension);
-		COMPARE(result.upload_directory, location.upload_directory);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.file_upload_path), upload_file_path);
 		COMPARE(result.redirect.GetValue(), location.redirect);
 		COMPARE(result.error_page.GetValue(), virtual_servers.front()->GetErrorPage());
 	} catch (const std::exception &e) {
@@ -284,6 +287,7 @@ int Test4() {
 	const server::VirtualServer  *vs     = *(Next(virtual_servers.begin(), 1)); // host2
 	server::Location              location =
 		*(Next(vs->GetLocationList().begin(), 1)); // location2(cgi, upload_directory)
+	std::string upload_file_path = "";
 
 	try {
 		COMPARE(ExtractHttpServerInfoCheckPath(result.path), location.request_uri);
@@ -291,7 +295,7 @@ int Test4() {
 		COMPARE(result.autoindex, location.autoindex);
 		COMPARE(result.allowed_methods, location.allowed_methods);
 		COMPARE(result.cgi_extension, location.cgi_extension);
-		COMPARE(result.upload_directory, location.upload_directory);
+		COMPARE(ExtractHttpServerInfoCheckPath(result.file_upload_path), upload_file_path);
 		COMPARE(result.redirect.GetValue(), location.redirect);
 		COMPARE(result.error_page.GetValue(), virtual_servers.front()->GetErrorPage());
 	} catch (const std::exception &e) {

--- a/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
+++ b/test/webserv/unit/http_serverinfo_check/test_http_serverinfo_check.cpp
@@ -67,7 +67,7 @@ server::VirtualServer *BuildVirtualServer2() {
 	server::Location           location1 = // alias_on
 		BuildLocation("/www/data/", "/var/www/", "index.html", true, allowed_methods, redirect);
 	server::Location location2 = // cgi, upload_directory
-		BuildLocation("/web/", "", "index.htm", false, allowed_methods, redirect, ".php", "/data/");
+		BuildLocation("/web/", "", "index.htm", false, allowed_methods, redirect, ".php", "/data");
 	locationlist.push_back(location1);
 	locationlist.push_back(location2);
 


### PR DESCRIPTION
## file_upload_pathを修正しました

- [x] HttpServerInfoCheckの中でupload_fileのフルパスを作成するように変更しました
- [x] 今までは最後の/の後をファイル名としていましたが、locationに一致したところより後をアップロードするパスとしました
- [x] FileCreationHandlerでSystemExceptionを用いることでNotFound等も出すようになりました
- [x] locationが/で終わっているかによってパスをつける対応を変えました
- [x] aliasの場合は検索する部分をlocationにすることでaliasとupload_dir両方が指定された場合でも対応できるようになりました
- [x] echoになるかどうかはupload_dirがない -> file_upload_pathが空文字で判断しています

色々と変えて結構条件分岐が多いのでアルゴリズム的に微妙な点があれば教えてください

## TODO
- [ ] aliasとupload_dir両方が指定された場合のテスト
- [ ] ページの機能一通りのテスト(echo postとかがない)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アップロードパスの処理を改善し、`upload_directory`を`file_upload_path`に変更しました。
	- 新しいテストケースを追加し、アップロード機能の動作を検証します。

- **バグ修正**
	- アップロードパスのエラーハンドリングを強化しました。

- **ドキュメンテーション**
	- メソッドと構造体のパラメータ名を更新し、可読性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->