### PR TITLE
[update] 400,500 は connection: close で返す 

### DIFF
--- a/srcs/http/http_exception.cpp
+++ b/srcs/http/http_exception.cpp
@@ -6,8 +6,8 @@ namespace http {
 
 HttpException::HttpException(const std::string &error_message, const StatusCode &status_code)
 	: runtime_error(error_message), status_code_(status_code) {
-	std::cerr << utils::color::GRAY << "[HttpException] " << error_message << utils::color::RESET
-			  << std::endl;
+	std::cerr << utils::color::GRAY << "[HttpException] " << status_code.GetEStatusCode() << ": "
+			  << error_message << utils::color::RESET << std::endl;
 }
 
 HttpException::~HttpException() throw() {}

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -50,9 +50,9 @@ bool IsErrorConnectionClose(EStatusCode status_code) {
 	return status_code == http::BAD_REQUEST || status_code == http::INTERNAL_SERVER_ERROR;
 }
 
-void SetErrorConnectionClose(HeaderFields &HeaderFields, EStatusCode status_code) {
+void SetErrorConnectionClose(HeaderFields &header_fields, EStatusCode status_code) {
 	if (IsErrorConnectionClose(status_code)) {
-		HeaderFields[CONNECTION] = CLOSE;
+		header_fields[CONNECTION] = CLOSE;
 	}
 }
 

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -58,7 +58,7 @@ void SetErrorConnectionClose(HeaderFields &HeaderFields, EStatusCode status_code
 
 } // namespace
 
-std::string HttpResponse::Run(
+HttpResponseResult HttpResponse::Run(
 	const http::ClientInfos             &client_info,
 	const server::VirtualServerAddrList &server_info,
 	const HttpRequestResult             &request_info,
@@ -67,9 +67,12 @@ std::string HttpResponse::Run(
 	HttpResponseFormatResult response_format_result =
 		CreateHttpResponseFormat(client_info, server_info, request_info, cgi_result);
 	if (cgi_result.is_cgi) {
-		return "";
+		return HttpResponseResult(false, "");
 	}
-	return CreateHttpResponse(response_format_result.http_response_format);
+	return HttpResponseResult(
+		response_format_result.is_connection_close,
+		CreateHttpResponse(response_format_result.http_response_format)
+	);
 }
 
 HttpResponseFormatResult HttpResponse::CreateHttpResponseFormat(

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -46,6 +46,16 @@ std::string ReadErrorFile(const std::string &file_path) {
 	return ss.str();
 }
 
+bool IsErrorConnectionClose(EStatusCode status_code) {
+	return status_code == http::BAD_REQUEST || status_code == http::INTERNAL_SERVER_ERROR;
+}
+
+void SetErrorConnectionClose(HeaderFields &HeaderFields, EStatusCode status_code) {
+	if (IsErrorConnectionClose(status_code)) {
+		HeaderFields[CONNECTION] = CLOSE;
+	}
+}
+
 } // namespace
 
 std::string HttpResponse::Run(
@@ -127,6 +137,7 @@ HttpResponseFormat HttpResponse::CreateHttpResponseFormat(
 		}
 	}
 	response_header_fields[CONTENT_LENGTH] = utils::ToString(response_body_message.length());
+	SetErrorConnectionClose(response_header_fields, status_code.GetEStatusCode());
 	return HttpResponseFormat(
 		StatusLine(HTTP_VERSION, status_code.GetStatusCode(), status_code.GetReasonPhrase()),
 		response_header_fields,

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -39,6 +39,13 @@ class Stat;
 //    GetInternalServerErrorBodyMessage();
 // };
 
+struct HttpResponseResult {
+	HttpResponseResult(bool is_connection_close, const std::string &response)
+		: is_connection_close(is_connection_close), response(response) {}
+	bool        is_connection_close;
+	std::string response;
+};
+
 struct HttpResponseFormatResult {
 	HttpResponseFormatResult(
 		bool is_connection_close, const HttpResponseFormat &http_response_format
@@ -51,7 +58,7 @@ struct HttpResponseFormatResult {
 class HttpResponse {
   public:
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
-	static std::string
+	static HttpResponseResult
 					   Run(const http::ClientInfos             &client_info,
 						   const server::VirtualServerAddrList &server_info,
 						   const HttpRequestResult             &request_info,

--- a/srcs/http/response/http_response.hpp
+++ b/srcs/http/response/http_response.hpp
@@ -39,6 +39,15 @@ class Stat;
 //    GetInternalServerErrorBodyMessage();
 // };
 
+struct HttpResponseFormatResult {
+	HttpResponseFormatResult(
+		bool is_connection_close, const HttpResponseFormat &http_response_format
+	)
+		: is_connection_close(is_connection_close), http_response_format(http_response_format) {}
+	bool               is_connection_close;
+	HttpResponseFormat http_response_format;
+};
+
 class HttpResponse {
   public:
 	typedef std::map<EStatusCode, std::string> ReasonPhrase;
@@ -59,8 +68,8 @@ class HttpResponse {
 	HttpResponse();
 	~HttpResponse();
 
-	static std::string        CreateHttpResponse(const HttpResponseFormat &response);
-	static HttpResponseFormat CreateHttpResponseFormat(
+	static std::string              CreateHttpResponse(const HttpResponseFormat &response);
+	static HttpResponseFormatResult CreateHttpResponseFormat(
 		const http::ClientInfos             &client_info,
 		const server::VirtualServerAddrList &server_info,
 		const HttpRequestResult             &request_info,

--- a/test/common/request/get/4xx/400_25_keep_alive_turns_close_in_400.txt
+++ b/test/common/request/get/4xx/400_25_keep_alive_turns_close_in_400.txt
@@ -1,0 +1,8 @@
+GET /upload/test_upload_file HTTP/1.1
+Host: localhost
+Content-Length: 5
+Transfer-Encoding: chunked
+Connection: keep-alive
+Content-Type: text/plain
+
+abc

--- a/test/common/request/get/4xx/404_02_not_exist_path_keep_alive.txt
+++ b/test/common/request/get/4xx/404_02_not_exist_path_keep_alive.txt
@@ -1,0 +1,4 @@
+GET /not-exist-path HTTP/1.1
+Host: localhost
+Connection: keep-alive
+

--- a/test/webserv/integration/common_response.py
+++ b/test/webserv/integration/common_response.py
@@ -98,8 +98,11 @@ response_header_400 = create_response_header(
 response_header_403 = create_response_header(
     403, CLOSE, error_files_data["forbidden_file_403_length"], TEXT_HTML
 )
-response_header_404 = create_response_header(
+response_header_404_close = create_response_header(
     404, CLOSE, error_files_data["not_found_file_404_length"], TEXT_HTML
+)
+response_header_404_keep = create_response_header(
+    404, KEEP_ALIVE, error_files_data["not_found_file_404_length"], TEXT_HTML
 )
 response_header_405 = create_response_header(
     405, CLOSE, error_files_data["not_allowed_file_405_length"], TEXT_HTML
@@ -132,7 +135,10 @@ bad_request_response = response_header_400 + error_files_data[
 forbidden_response = response_header_403 + error_files_data[
     "forbidden_file_403"
 ].decode("utf-8")
-not_found_response = response_header_404 + error_files_data[
+not_found_response_close = response_header_404_close + error_files_data[
+    "not_found_file_404"
+].decode("utf-8")
+not_found_response_keep = response_header_404_keep + error_files_data[
     "not_found_file_404"
 ].decode("utf-8")
 not_allowed_response = response_header_405 + error_files_data[

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -5,7 +5,7 @@ import pytest
 from common_functions import read_file, send_request_and_assert_response
 from common_response import (forbidden_response, no_content_response_close,
                              no_content_response_keep, not_allowed_response,
-                             not_found_response, timeout_response)
+                             not_found_response_close, timeout_response)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"
@@ -66,7 +66,7 @@ def setup_file_context():
         (
             REQUEST_DELETE_2XX_DIR
             + "204_03_delete_existing_file_then_404_on_second_attempt.txt",
-            no_content_response_keep + not_found_response,
+            no_content_response_keep + not_found_response_close,
             DELETE_FILE_PATH,
             "Sample content for deletion",
         ),
@@ -142,7 +142,7 @@ def cleanup_file_context():
         ),
         (
             REQUEST_DELETE_4XX_DIR + "404_01_delete_nonexistent_file.txt",
-            not_found_response,
+            not_found_response_close,
             NOT_EXISTING_FILE_PATH,
         ),
         (

--- a/test/webserv/integration/test_http_delete.py
+++ b/test/webserv/integration/test_http_delete.py
@@ -2,10 +2,10 @@ import os
 import time
 
 import pytest
-from common_functions import read_file, send_request_and_assert_response
+from common_functions import send_request_and_assert_response
 from common_response import (forbidden_response, no_content_response_close,
                              no_content_response_keep, not_allowed_response,
-                             not_found_response_close, timeout_response)
+                             not_found_response_close)
 
 REQUEST_DIR = "test/common/request/"
 REQUEST_DELETE_2XX_DIR = REQUEST_DIR + "delete/2xx/"

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -198,6 +198,10 @@ def test_get_2xx_responses(request_file, expected_response):
             REQUEST_GET_4XX_DIR + "400_24_non_vchr_http_version.txt",
             bad_request_response,
         ),
+        (
+            REQUEST_GET_4XX_DIR + "400_25_keep_alive_turns_close_in_400.txt",
+            bad_request_response,
+        ),
         (REQUEST_GET_4XX_DIR + "404_01_not_exist_path.txt", not_found_response_close),
         (
             REQUEST_GET_4XX_DIR + "404_02_not_exist_path_keep_alive.txt",
@@ -241,6 +245,7 @@ def test_get_2xx_responses(request_file, expected_response):
         "400_22_non_vchr_method",
         "400_23_non_vchr_request_target",
         "400_24_non_vchr_http_version",
+        "400_25_keep_alive_turns_close_in_400",
         "404_01_not_exist_path",
         "404_02_not_exist_path_keep_alive",
         "405_01_method_not_allowed_for_uri",

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -1,7 +1,8 @@
 import pytest
 from common_functions import send_request_and_assert_response
 from common_response import (bad_request_response, not_allowed_response,
-                             not_found_response, not_implemented_response,
+                             not_found_response_close,
+                             not_implemented_response,
                              response_header_get_root_200_close,
                              response_header_get_root_200_keep,
                              response_header_get_sub_200_close,
@@ -197,7 +198,7 @@ def test_get_2xx_responses(request_file, expected_response):
             REQUEST_GET_4XX_DIR + "400_24_non_vchr_http_version.txt",
             bad_request_response,
         ),
-        (REQUEST_GET_4XX_DIR + "404_01_not_exist_path.txt", not_found_response),
+        (REQUEST_GET_4XX_DIR + "404_01_not_exist_path.txt", not_found_response_close),
         (
             REQUEST_GET_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
             not_allowed_response,

--- a/test/webserv/integration/test_http_get.py
+++ b/test/webserv/integration/test_http_get.py
@@ -1,7 +1,7 @@
 import pytest
 from common_functions import send_request_and_assert_response
 from common_response import (bad_request_response, not_allowed_response,
-                             not_found_response_close,
+                             not_found_response_close, not_found_response_keep,
                              not_implemented_response,
                              response_header_get_root_200_close,
                              response_header_get_root_200_keep,
@@ -200,6 +200,10 @@ def test_get_2xx_responses(request_file, expected_response):
         ),
         (REQUEST_GET_4XX_DIR + "404_01_not_exist_path.txt", not_found_response_close),
         (
+            REQUEST_GET_4XX_DIR + "404_02_not_exist_path_keep_alive.txt",
+            not_found_response_keep,
+        ),
+        (
             REQUEST_GET_4XX_DIR + "405_01_method_not_allowed_for_uri.txt",
             not_allowed_response,
         ),
@@ -238,6 +242,7 @@ def test_get_2xx_responses(request_file, expected_response):
         "400_23_non_vchr_request_target",
         "400_24_non_vchr_http_version",
         "404_01_not_exist_path",
+        "404_02_not_exist_path_keep_alive",
         "405_01_method_not_allowed_for_uri",
         "408_01_no_crlf",
         "408_02_only_space",

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -7,7 +7,8 @@ from common_functions import (delete_file, read_file,
 from common_response import (bad_request_response, created_response_close,
                              created_response_keep, forbidden_response,
                              no_content_response_close, not_allowed_response,
-                             not_found_response, payload_too_large_response,
+                             not_found_response_close,
+                             payload_too_large_response,
                              response_header_get_root_200_close,
                              root_index_file, timeout_response)
 
@@ -241,7 +242,7 @@ def test_post_201_responses(
         # 403 is below -> test_post_403_responses()
         (
             REQUEST_POST_4XX_DIR + "404_01_non_exist_directory.txt",
-            not_found_response,
+            not_found_response_close,
             None,
         ),
         (

--- a/test/webserv/unit/http_response/test_http_response.cpp
+++ b/test/webserv/unit/http_response/test_http_response.cpp
@@ -165,7 +165,7 @@ int main(void) {
 	request_info.request.request_line.request_target = "/";
 	request_info.request.request_line.version        = http::HTTP_VERSION;
 	request_info.request.header_fields[http::HOST]   = "sawa";
-	std::string response1 =
+	http::HttpResponseResult response1 =
 		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected1_status_line =
@@ -177,12 +177,12 @@ int main(void) {
 	const std::string &expected1_response =
 		expected1_status_line + expected1_header_fields + http::CRLF + expected1_body_message;
 
-	ret_code |= HandleResult(response1, expected1_response);
+	ret_code |= HandleResult(response1.response, expected1_response);
 
 	// DELETEメソッドの許可がないhost2にリクエスト
 	request_info.request.request_line.method       = http::DELETE;
 	request_info.request.header_fields[http::HOST] = "host2";
-	std::string response2 =
+	http::HttpResponseResult response2 =
 		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected2_status_line =
@@ -194,14 +194,14 @@ int main(void) {
 	);
 	const std::string &expected2_response =
 		expected2_status_line + expected2_header_fields + http::CRLF + expected2_body_message;
-	ret_code |= HandleResult(response2, expected2_response);
+	ret_code |= HandleResult(response2.response, expected2_response);
 
 	// Redirectのテスト
 	request_info.request.request_line.method         = http::POST;
 	request_info.request.request_line.request_target = "/www/";
 	request_info.request.request_line.version        = http::HTTP_VERSION;
 	request_info.request.header_fields[http::HOST]   = "host1";
-	std::string response3 =
+	http::HttpResponseResult response3 =
 		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected3_status_line =
@@ -216,9 +216,9 @@ int main(void) {
 	);
 	const std::string &expected3_response =
 		expected3_status_line + expected3_header_fields + http::CRLF + expected3_body_message;
-	ret_code |= HandleResult(response3, expected3_response);
+	ret_code |= HandleResult(response3.response, expected3_response);
 	expected2_status_line + expected2_header_fields + http::CRLF + expected2_body_message;
-	ret_code |= HandleResult(response2, expected2_response);
+	ret_code |= HandleResult(response2.response, expected2_response);
 
 	// ContentTypeのテスト
 	const std::string &file_name = "../../../../root/upload/delete_file";
@@ -231,7 +231,7 @@ int main(void) {
 	request_info.request.request_line.request_target = "/www/delete_file";
 	request_info.request.request_line.version        = http::HTTP_VERSION;
 	request_info.request.header_fields[http::HOST]   = "host2";
-	std::string response4 =
+	http::HttpResponseResult response4 =
 		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected4_status_line =
@@ -244,7 +244,7 @@ int main(void) {
 	);
 	const std::string &expected4_response =
 		expected4_status_line + expected4_header_fields + http::CRLF + expected4_body_message;
-	ret_code |= HandleResult(response4, expected4_response);
+	ret_code |= HandleResult(response4.response, expected4_response);
 	std::remove(file_name.c_str());
 
 	// ErrorPageのテスト
@@ -252,7 +252,7 @@ int main(void) {
 	request_info.request.request_line.request_target = "/www/aaa";
 	request_info.request.request_line.version        = http::HTTP_VERSION;
 	request_info.request.header_fields[http::HOST]   = "host2";
-	std::string response5 =
+	http::HttpResponseResult response5 =
 		http::HttpResponse::Run(client_infos, server_info, request_info, cgi_result);
 
 	std::string expected5_status_line =
@@ -264,7 +264,7 @@ int main(void) {
 	);
 	const std::string &expected5_response =
 		expected5_status_line + expected5_header_fields + http::CRLF + expected5_body_message;
-	ret_code |= HandleResult(response5, expected5_response);
+	ret_code |= HandleResult(response5.response, expected5_response);
 
 	DeleteAddrList(server_info);
 	return ret_code;


### PR DESCRIPTION
400 と 500 だけ request header に keep-alive が来ても close で返すようにしました
integration test も少しですが追加

GET
- 400_25 : keep-alive できたが 400 なので close で返す
- 404_02 : 400,500 ではないので、keep-alive で来たらそのまま keep-alive で返す

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- 接続の持続性を判断する新しい機能「IsConnectionKeep」を追加。
	- HTTPレスポンスの構造が強化され、エラーハンドリングが改善されました。
	- 404ステータスコードに対する新しいレスポンスヘッダーを追加。

- **バグ修正**
	- HTTP例外のエラーメッセージにステータスコードを追加し、ログのコンテキストを向上。

- **テスト**
	- HTTPレスポンスの結果処理を改善するため、テストでの変数型を更新。
	- 404エラーに対する期待されるレスポンスを新しい変数に更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->