### PR TITLE
[fix] Cgiスクリプトが存在しない場合に404を返すように

### DIFF
--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -217,7 +217,7 @@ bool HttpResponse::IsCgi(
 	}
 	// methodがGETかPOSTかつallow_methodかどうか
 	if (!(Method::IsAllowedMethod(method, allowed_methods)) || (method != GET && method != POST)) {
-		return false;
+		throw HttpException("Error: Method Not Allowed", StatusCode(METHOD_NOT_ALLOWED));
 	}
 	return true;
 }

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <unistd.h> // access
 
 namespace http {
 namespace {
@@ -54,6 +55,10 @@ void SetErrorConnectionClose(HeaderFields &header_fields, EStatusCode status_cod
 	if (IsErrorConnectionClose(status_code)) {
 		header_fields[CONNECTION] = CLOSE;
 	}
+}
+
+bool IsExistPath(const std::string &path) {
+	return access(path.c_str(), F_OK) == 0;
 }
 
 } // namespace
@@ -110,6 +115,9 @@ HttpResponseFormatResult HttpResponse::CreateHttpResponseFormat(
 				utils::ToString(client_info.listen_server_port),
 				client_info.ip
 			);
+			if (!IsExistPath(cgi_request.meta_variables[cgi::SCRIPT_NAME])) {
+				throw HttpException("Error: Not Found", StatusCode(NOT_FOUND));
+			}
 			cgi_result.is_cgi      = true;
 			cgi_result.cgi_request = cgi_request;
 		} else {

--- a/test/webserv/integration/test_cgi.py
+++ b/test/webserv/integration/test_cgi.py
@@ -189,7 +189,7 @@ class TestCGI(unittest.TestCase):
 
     def test_no_header_pl(self):
         try:
-            self.con.request("GET", "/cgi-bin/no_header.pl")
+            self.con.request("GET", "/cgi-bin/error/no_header.pl")
             response = self.con.getresponse()
             self.assertEqual(response.status, HTTPStatus.INTERNAL_SERVER_ERROR)
             assert_header(response, "Connection", "close")
@@ -199,7 +199,7 @@ class TestCGI(unittest.TestCase):
 
     def test_not_executable_pl(self):
         try:
-            self.con.request("GET", "/cgi-bin/not_executable.pl")
+            self.con.request("GET", "/cgi-bin/error/not_executable.pl")
             response = self.con.getresponse()
             self.assertEqual(response.status, HTTPStatus.INTERNAL_SERVER_ERROR)
             assert_header(response, "Connection", "close")
@@ -209,7 +209,7 @@ class TestCGI(unittest.TestCase):
 
     def test_invalid_header_pl(self):
         try:
-            self.con.request("GET", "/cgi-bin/invalid_header.pl")
+            self.con.request("GET", "/cgi-bin/error/invalid_header.pl")
             response = self.con.getresponse()
             self.assertEqual(response.status, HTTPStatus.INTERNAL_SERVER_ERROR)
             assert_header(response, "Connection", "close")

--- a/test/webserv/integration/test_cgi.py
+++ b/test/webserv/integration/test_cgi.py
@@ -6,6 +6,9 @@ from common_functions import SERVER_PORT
 from http_module.assert_http_response import (assert_body, assert_header,
                                               assert_status_line)
 
+NOT_FOUND_FILE_PATH = (
+    "test/webserv/expected_response/default_body_message/404_not_found.txt"
+)
 METHOD_NOT_ALLOWED_FILE_PATH = (
     "test/webserv/expected_response/default_body_message/405_method_not_allowed.txt"
 )
@@ -224,6 +227,16 @@ class TestCGI(unittest.TestCase):
             self.assertEqual(response.status, HTTPStatus.REQUEST_TIMEOUT)
             assert_header(response, "Connection", "close")
             assert_body_binary(response, TIMEOUT_FILE_PATH)
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")
+
+    def test_script_not_found_pl(self):
+        try:
+            self.con.request("GET", "/cgi-bin/non.pl")
+            response = self.con.getresponse()
+            self.assertEqual(response.status, HTTPStatus.NOT_FOUND)
+            assert_header(response, "Connection", "keep-alive")
+            assert_body_binary(response, NOT_FOUND_FILE_PATH)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
 


### PR DESCRIPTION
### Cgiスクリプトが存在しない場合に404を返すようにしました

今までは500を返していましたので、パスチェックを入れました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいPerlスクリプト`loop_local_redirect.pl`を追加し、リダイレクト機能を提供。
  - HTTPレスポンス処理の強化により、CGIスクリプトの存在確認とエラーハンドリングを改善。

- **バグ修正**
  - 不正なHTTPメソッドに対する適切なエラーメッセージを追加。

- **テスト**
  - CGIスクリプトのテストスイートを強化し、さまざまなエラーシナリオに対するテストケースを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->