### PR TITLE
[add] test_routingにerror_pageのテストも追加

### DIFF
--- a/config/routing_test.conf
+++ b/config/routing_test.conf
@@ -2,6 +2,7 @@
 # - hostがない場合に一番上のサーバーに入るか
 # - client_max_body_sizeに設定されたものが有効か
 # - return の挙動
+# - error_page は有効か
 
 server {
 	# the port only
@@ -18,6 +19,8 @@ server {
 		index index.html;
         allowed_methods GET POST;
 	}
+
+    error_page 404 /html/error_pages/404.html;
 }
 
 server {
@@ -47,4 +50,6 @@ server {
 	location /redirect {
 		return 303 http://localhost:9000/;
 	}
+
+    error_page 501 /html/error_pages/404.html;
 }

--- a/test/webserv/integration/http_module/assert_http_response.py
+++ b/test/webserv/integration/http_module/assert_http_response.py
@@ -31,9 +31,9 @@ def assert_header(
 def assert_body(response: HTTPResponse, path: str) -> None:
     response_body = response.read()
     expected_body = b""
-    with open(path) as f:
-        expected_body = f.read().encode("utf-8")
+    with open(path, "rb") as f:
+        expected_body = f.read()
     assert (
         response_body == expected_body
-    ), f"Expected response body\n\n {expected_body.decode('utf-8')}\n, but got\n\n {response_body.decode('utf-8')}"
+    ), f"Expected response body\n\n {expected_body}\n, but got\n\n {response_body}"
     assert_header(response, "Content-Length", str(len(expected_body)))


### PR DESCRIPTION
## test_routingにerror_pageのテストも追加しました

- routing_test.confを少し書き換えてerror_pageを追加して、テストも追加しました
- 対応できるのは限られたステータスコードだけだと思います(400とかは無理そう)

#685 と同じ箇所変更している部分があります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 404および501エラー用のカスタムエラーページ設定を追加しました。
	- 新しいテストメソッドを追加し、エラーハンドリングのテストカバレッジを強化しました。

- **バグ修正**
	- レスポンスボディの比較方法を改善し、バイナリモードでの読み込みを実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->