### PR TITLE
[add] EchoPostのテストを追加

### DIFF
--- a/config/routing_test.conf
+++ b/config/routing_test.conf
@@ -10,9 +10,6 @@ server {
 	listen 9000;
 	server_name host host.com;
 
-	# small client_max_body_size (default 1m)
-	client_max_body_size 1;
-
 	# alias
 	# index
 	location / {
@@ -28,6 +25,9 @@ server {
 	# listen to all interfaces
 	listen 127.0.0.1:9000;
 	server_name host3;
+
+    # small client_max_body_size (default 1m)
+	client_max_body_size 1;
 
 	location / {
 		return 302 /sub/;

--- a/config/routing_test.conf
+++ b/config/routing_test.conf
@@ -3,6 +3,7 @@
 # - client_max_body_sizeに設定されたものが有効か
 # - return の挙動
 # - error_page は有効か
+# - upload_dirがない場合はecho postになるか
 
 server {
 	# the port only

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -87,7 +87,11 @@ StatusCode Method::Handler(
 		);
 	} else if (method == POST) {
 		status_code = PostHandler(
-			file_upload_path, request_body_message, request_header_fields, response_body_message
+			file_upload_path,
+			request_body_message,
+			request_header_fields,
+			response_body_message,
+			response_header_fields
 		);
 	} else if (method == DELETE) {
 		status_code = DeleteHandler(path, response_body_message);
@@ -139,11 +143,12 @@ StatusCode Method::PostHandler(
 	const std::string  &file_upload_path,
 	const std::string  &request_body_message,
 	const HeaderFields &request_header_fields,
-	std::string        &response_body_message
+	std::string        &response_body_message,
+	HeaderFields       &response_header_fields
 ) {
 
 	if (file_upload_path.empty()) {
-		return EchoPostHandler(request_body_message, response_body_message);
+		return EchoPostHandler(request_body_message, response_body_message, response_header_fields);
 	} else if (request_header_fields.find(CONTENT_TYPE) != request_header_fields.end() &&
 			   utils::StartWith(request_header_fields.at(CONTENT_TYPE), MULTIPART_FORM_DATA)) {
 		// Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
@@ -345,9 +350,12 @@ utils::Result<std::string> Method::AutoindexHandler(const std::string &path) {
 }
 
 StatusCode Method::EchoPostHandler(
-	const std::string &request_body_message, std::string &response_body_message
+	const std::string &request_body_message,
+	std::string       &response_body_message,
+	HeaderFields      &response_header_fields
 ) {
-	response_body_message = request_body_message;
+	response_body_message                = request_body_message;
+	response_header_fields[CONTENT_TYPE] = TEXT_PLAIN;
 	return StatusCode(OK);
 }
 

--- a/srcs/http/response/http_method.hpp
+++ b/srcs/http/response/http_method.hpp
@@ -41,7 +41,8 @@ class Method {
 		const std::string  &file_upload_path,
 		const std::string  &request_body_message,
 		const HeaderFields &request_header_fields,
-		std::string        &response_body_message
+		std::string        &response_body_message,
+		HeaderFields       &response_header_fields
 	);
 	static StatusCode  DeleteHandler(const std::string &path, std::string &response_body_message);
 	static Stat        TryStat(const std::string &path);
@@ -58,8 +59,11 @@ class Method {
 		const HeaderFields &request_header_fields,
 		std::string        &response_body_message
 	);
-	static StatusCode
-	EchoPostHandler(const std::string &request_body_message, std::string &response_body_message);
+	static StatusCode EchoPostHandler(
+		const std::string &request_body_message,
+		std::string       &response_body_message,
+		HeaderFields      &response_header_fields
+	);
 	static utils::Result<std::string> AutoindexHandler(const std::string &path);
 
 	// マルチパート用のパートを表す構造体

--- a/test/webserv/integration/test_routing.py
+++ b/test/webserv/integration/test_routing.py
@@ -164,3 +164,37 @@ class TestServerRouting(unittest.TestCase):
             assert_body(response, CUSTOM_ERROR_PAGE)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
+
+    # echo postのテスト
+    def test_echo_post_close(self):
+        try:
+            body = "This is a echo test"
+            headers = {
+                "Host": "host1",
+                "Content-Type": "text/plain",
+                "Content-Length": str(len(body)),
+                "Connection": "close",
+            }
+            self.con.request("POST", "/", headers=headers, body=body)
+            response = self.con.getresponse()
+            assert_status_line(response, HTTPStatus.OK)
+            assert_header(response, "Connection", "close")
+            self.assertEqual(response.read().decode(), body)
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")
+
+    def test_echo_post_keep(self):
+        try:
+            body = "This is a echo test"
+            headers = {
+                "Host": "host1",
+                "Content-Type": "text/plain",
+                "Content-Length": str(len(body)),
+            }
+            self.con.request("POST", "/", headers=headers, body=body)
+            response = self.con.getresponse()
+            assert_status_line(response, HTTPStatus.OK)
+            assert_header(response, "Connection", "keep-alive")
+            self.assertEqual(response.read().decode(), body)
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")

--- a/test/webserv/integration/test_routing.py
+++ b/test/webserv/integration/test_routing.py
@@ -179,6 +179,7 @@ class TestServerRouting(unittest.TestCase):
             response = self.con.getresponse()
             assert_status_line(response, HTTPStatus.OK)
             assert_header(response, "Connection", "close")
+            assert_header(response, "Content-Length", str(len(body)))
             self.assertEqual(response.read().decode(), body)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
@@ -195,6 +196,7 @@ class TestServerRouting(unittest.TestCase):
             response = self.con.getresponse()
             assert_status_line(response, HTTPStatus.OK)
             assert_header(response, "Connection", "keep-alive")
+            assert_header(response, "Content-Length", str(len(body)))
             self.assertEqual(response.read().decode(), body)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")

--- a/test/webserv/integration/test_routing.py
+++ b/test/webserv/integration/test_routing.py
@@ -75,11 +75,11 @@ class TestServerRouting(unittest.TestCase):
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
 
-    def test_post_root_host1(self):
+    def test_post_root_host3(self):
         try:
             body = "This is a test payload"
             headers = {
-                "Host": "no_exist_host",
+                "Host": "host3",
                 "Content-Type": "text/plain",
                 "Content-Length": str(len(body)),
             }

--- a/test/webserv/integration/test_routing.py
+++ b/test/webserv/integration/test_routing.py
@@ -180,13 +180,14 @@ class TestServerRouting(unittest.TestCase):
             assert_status_line(response, HTTPStatus.OK)
             assert_header(response, "Connection", "close")
             assert_header(response, "Content-Length", str(len(body)))
+            assert_header(response, "Content-Type", "text/plain")
             self.assertEqual(response.read().decode(), body)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
 
     def test_echo_post_keep(self):
         try:
-            body = "This is a echo test"
+            body = "This is a echo test 22222222222222222222222"
             headers = {
                 "Host": "host1",
                 "Content-Type": "text/plain",
@@ -197,6 +198,7 @@ class TestServerRouting(unittest.TestCase):
             assert_status_line(response, HTTPStatus.OK)
             assert_header(response, "Connection", "keep-alive")
             assert_header(response, "Content-Length", str(len(body)))
+            assert_header(response, "Content-Type", "text/plain")
             self.assertEqual(response.read().decode(), body)
         except HTTPException as e:
             self.fail(f"Request failed: {e}")


### PR DESCRIPTION
## EchoPostのテストを追加しました(test_routingの中)

- Content-Length等がメッセージによって違うため、common_responseとtest_http_postは使わず別に作りました
- Echoの場合はContent-Typeをtext/plainにセットして返すように修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - POSTリクエストの処理を改善し、レスポンスヘッダーの設定を強化しました。
  - 新しいテストメソッドを追加し、異なる接続ヘッダーに対するPOSTリクエストのテストを実施しました。

- **バグ修正**
  - テストメソッドのリクエストメソッドを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->