### PR TITLE
[update] HttpResponseでCgiResponseのConnectionを参照するように

### DIFF
--- a/root/cgi-bin/print_ok_close.pl
+++ b/root/cgi-bin/print_ok_close.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+print "Connection: close\r\n";
+print "Content-Type: text/plain\r\n\r\n";
+print "OK\n"

--- a/root/cgi-bin/print_ok_keep.pl
+++ b/root/cgi-bin/print_ok_keep.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+print "Connection: keep-alive\r\n";
+print "Content-Type: text/plain\r\n\r\n";
+print "OK\n"

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -68,7 +68,10 @@ HttpResult Http::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_r
 		result.is_response_complete = true;
 	}
 	result.is_connection_keep =
-		HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
+		cgi_parse_result.GetValue().header_fields.find(CONNECTION) !=
+				cgi_parse_result.GetValue().header_fields.end()
+			? cgi_parse_result.GetValue().header_fields.at(CONNECTION) == KEEP_ALIVE
+			: HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
 	result.response =
 		HttpResponse::GetResponseFromCgi(cgi_parse_result.GetValue(), data.request_result);
 	storage_.DeleteClientSaveData(client_fd);

--- a/srcs/http/http.cpp
+++ b/srcs/http/http.cpp
@@ -68,9 +68,9 @@ HttpResult Http::GetResponseFromCgi(int client_fd, const cgi::CgiResponse &cgi_r
 		result.is_response_complete = true;
 	}
 	result.is_connection_keep =
-		cgi_parse_result.GetValue().header_fields.find(CONNECTION) !=
-				cgi_parse_result.GetValue().header_fields.end()
-			? cgi_parse_result.GetValue().header_fields.at(CONNECTION) == KEEP_ALIVE
+		(cgi_parse_result.GetValue().header_fields.find(CONNECTION) !=
+		 cgi_parse_result.GetValue().header_fields.end())
+			? (cgi_parse_result.GetValue().header_fields.at(CONNECTION) == KEEP_ALIVE)
 			: HttpResponse::IsConnectionKeep(data.request_result.request.header_fields);
 	result.response =
 		HttpResponse::GetResponseFromCgi(cgi_parse_result.GetValue(), data.request_result);

--- a/srcs/http/response/http_response.cpp
+++ b/srcs/http/response/http_response.cpp
@@ -281,10 +281,11 @@ std::string HttpResponse::GetResponseFromCgi(
 	} else {
 		response_header_fields[CONTENT_LENGTH] = cgi_parsed_data.header_fields.at(CONTENT_LENGTH);
 	}
-	if (IsConnectionKeep(request_info.request.header_fields)) {
-		response_header_fields[CONNECTION] = KEEP_ALIVE;
+	if (cgi_parsed_data.header_fields.find(CONNECTION) != cgi_parsed_data.header_fields.end()) {
+		response_header_fields[CONNECTION] = cgi_parsed_data.header_fields.at(CONNECTION);
 	} else {
-		response_header_fields[CONNECTION] = CLOSE;
+		response_header_fields[CONNECTION] =
+			IsConnectionKeep(request_info.request.header_fields) ? KEEP_ALIVE : CLOSE;
 	}
 	if (cgi_parsed_data.header_fields.find(LOCATION) != cgi_parsed_data.header_fields.end()) {
 		status_code                      = StatusCode(FOUND);

--- a/test/webserv/integration/test_cgi.py
+++ b/test/webserv/integration/test_cgi.py
@@ -63,6 +63,33 @@ class TestCGI(unittest.TestCase):
         except HTTPException as e:
             self.fail(f"Request failed: {e}")
 
+    # CgiResponseの中のConnectionヘッダーが適用されているか
+    def test_print_ok_close_pl(self):
+        try:
+            self.con.request(
+                "GET",
+                "/cgi-bin/print_ok_close.pl",
+                headers={"Connection": "keep-alive"},
+            )
+            response = self.con.getresponse()
+            assert_status_line(response, HTTPStatus.OK)
+            assert_header(response, "Connection", "close")
+            self.assertEqual(response.read(), b"OK\n")
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")
+
+    def test_print_ok_keep_pl(self):
+        try:
+            self.con.request(
+                "GET", "/cgi-bin/print_ok_keep.pl", headers={"Connection": "close"}
+            )
+            response = self.con.getresponse()
+            assert_status_line(response, HTTPStatus.OK)
+            assert_header(response, "Connection", "keep-alive")
+            self.assertEqual(response.read(), b"OK\n")
+        except HTTPException as e:
+            self.fail(f"Request failed: {e}")
+
     def test_print_env_pl(self):
         try:
             self.con.request("GET", "/cgi-bin/print_env.pl")


### PR DESCRIPTION
## HttpResponseでCgiResponseのConnectionを参照するようにしました

- [x] スクリプト中でConnection: keep-alive / close がプリントされていたらそれを適用するようにしています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 新しいCGIスクリプト `print_ok_close.pl` と `print_ok_keep.pl` を追加しました。これにより、HTTPレスポンスの接続状態を制御できます。
  
- **バグ修正**
  - CGIレスポンスの `CONNECTION` ヘッダーを優先して扱うように、接続持続のロジックを改善しました。

- **テスト**
  - 新しいテストメソッドを追加し、CGIスクリプトの接続処理を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->