### PR TITLE
[update] boundaryのみ大文字小文字を保持するようにしました

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -326,7 +326,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		std::string header_field_name  = utils::ToLowerString((*it).substr(0, colon_pos));
 		std::string header_field_value = (*it).substr(colon_pos + 1);
 		header_field_value             = utils::Trim(header_field_value, OPTIONAL_WHITESPACE);
-		if (header_field_name == "content-type") {
+		if (header_field_name == CONTENT_TYPE) {
 			ToLowerContentTypeHeaderExceptBoundary(header_field_value);
 		} else {
 			header_field_value = utils::ToLowerString(header_field_value);

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -155,6 +155,30 @@ void ValidateInvalidHeaderFields(const HeaderFields &header_fields, const std::s
 	}
 }
 
+// Boundary以外のContent-Typeヘッダーを小文字に変換
+void ToLowerContentTypeHeaderExceptBoundary(std::string &header_field_value) {
+	// Content-Typeヘッダーの処理
+	std::size_t boundary_pos = header_field_value.find("boundary=");
+	if (boundary_pos != std::string::npos) {
+		std::string before_boundary = header_field_value.substr(0, boundary_pos);
+		std::string boundary_value  = header_field_value.substr(boundary_pos);
+		before_boundary             = utils::ToLowerString(before_boundary);
+
+		// 他のパラメータがある場合の処理 (boundary=----WebKitFormBouKx7oK7;charset=utf-8)
+		std::size_t semicolon_pos = boundary_value.find(';', 9); // "boundary="の長さは9
+		if (semicolon_pos != std::string::npos) {
+			std::string boundary_param = boundary_value.substr(0, semicolon_pos);
+			std::string other_params   = boundary_value.substr(semicolon_pos);
+			other_params               = utils::ToLowerString(other_params);
+			header_field_value         = before_boundary + boundary_param + other_params;
+		} else {
+			header_field_value = before_boundary + boundary_value;
+		}
+	} else {
+		header_field_value = utils::ToLowerString(header_field_value);
+	}
+}
+
 } // namespace
 
 void HttpParse::ParseRequestLine(HttpRequestParsedData &data) {
@@ -300,8 +324,14 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 	for (It it = header_fields_info.begin(); it != header_fields_info.end(); ++it) {
 		std::size_t colon_pos          = (*it).find_first_of(':');
 		std::string header_field_name  = utils::ToLowerString((*it).substr(0, colon_pos));
-		std::string header_field_value = utils::ToLowerString((*it).substr(colon_pos + 1));
+		std::string header_field_value = (*it).substr(colon_pos + 1);
 		header_field_value             = utils::Trim(header_field_value, OPTIONAL_WHITESPACE);
+		if (header_field_name == "content-type") {
+			ToLowerContentTypeHeaderExceptBoundary(header_field_value);
+		} else {
+			header_field_value = utils::ToLowerString(header_field_value);
+		}
+
 		CheckValidHeaderFieldNameAndValue(header_field_name, header_field_value);
 		// todo:
 		// マルチパートを対応する場合はutils::SplitStrを使用して、セミコロン区切りのstd::vector<std::string>になる。

--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -156,7 +156,7 @@ void ValidateInvalidHeaderFields(const HeaderFields &header_fields, const std::s
 }
 
 // Boundary以外のContent-Typeヘッダーを小文字に変換
-void ToLowerContentTypeHeaderExceptBoundary(std::string &header_field_value) {
+std::string ToLowerContentTypeHeaderExceptBoundary(const std::string &header_field_value) {
 	// Content-Typeヘッダーの処理
 	std::size_t boundary_pos = header_field_value.find("boundary=");
 	if (boundary_pos != std::string::npos) {
@@ -170,12 +170,12 @@ void ToLowerContentTypeHeaderExceptBoundary(std::string &header_field_value) {
 			std::string boundary_param = boundary_value.substr(0, semicolon_pos);
 			std::string other_params   = boundary_value.substr(semicolon_pos);
 			other_params               = utils::ToLowerString(other_params);
-			header_field_value         = before_boundary + boundary_param + other_params;
+			return before_boundary + boundary_param + other_params;
 		} else {
-			header_field_value = before_boundary + boundary_value;
+			return before_boundary + boundary_value;
 		}
 	} else {
-		header_field_value = utils::ToLowerString(header_field_value);
+		return utils::ToLowerString(header_field_value);
 	}
 }
 
@@ -327,7 +327,7 @@ HeaderFields HttpParse::SetHeaderFields(const std::vector<std::string> &header_f
 		std::string header_field_value = (*it).substr(colon_pos + 1);
 		header_field_value             = utils::Trim(header_field_value, OPTIONAL_WHITESPACE);
 		if (header_field_name == CONTENT_TYPE) {
-			ToLowerContentTypeHeaderExceptBoundary(header_field_value);
+			header_field_value = ToLowerContentTypeHeaderExceptBoundary(header_field_value);
 		} else {
 			header_field_value = utils::ToLowerString(header_field_value);
 		}

--- a/srcs/http/response/http_method.cpp
+++ b/srcs/http/response/http_method.cpp
@@ -392,10 +392,15 @@ Method::DecodeMultipartFormData(const std::string &content_type, const std::stri
 std::string Method::ExtractBoundary(const std::string &content_type) {
 	const std::string boundary_prefix = BOUNDARY + "=";
 	std::size_t       pos             = content_type.find(boundary_prefix);
-	// Content-Type: multipart/form-data; boundary=--WebKitFormBoundary7MA4YWxkTrZu0gW
+	// Content-Type: multipart/form-data; boundary=--WebKitFormBoundary7MA4YWxkTrZu0gW; abcd=efgh
 	if (pos != std::string::npos) {
 		// ----WebKitFormBoundary7MA4YWxkTrZu0gW\r\n のような形式になっている
-		return "--" + content_type.substr(pos + boundary_prefix.length());
+		std::size_t start = pos + boundary_prefix.length();
+		std::size_t end   = content_type.find(';', start);
+		if (end == std::string::npos) {
+			end = content_type.length();
+		}
+		return "--" + content_type.substr(start, end - start);
 	}
 	throw HttpException(
 		"Error: Boundary not found in Content-Type header", StatusCode(BAD_REQUEST)

--- a/test/common/request/post/2xx/201_13_upload_multipart_multi_files_case_sensitive_boundary.txt
+++ b/test/common/request/post/2xx/201_13_upload_multipart_multi_files_case_sensitive_boundary.txt
@@ -1,0 +1,27 @@
+POST /upload HTTP/1.1
+Host: localhost
+Connection: close
+Content-Type: multipart/form-data; boundary=----webkitformboundary
+Content-Length: 564
+
+------webkitformboundary
+Content-Disposition: form-data; name="field"; filename="filename1.txt"
+Content-Type: text/plain
+
+value1
+------webkitformboundarY
+Content-Disposition: form-data; name="field"; filename="filename2.txt"
+Content-Type: text/plain
+
+value2
+------webkitformboundary
+Content-Disposition: form-data; name="field"; filename="filename2.txt"
+Content-Type: text/plain
+
+value3
+------wEbkitformboundary
+Content-Disposition: form-data; name="field"; filename="filename3.txt"
+Content-Type: text/plain
+
+value4
+------webkitformboundary--

--- a/test/common/request/post/2xx/201_14_upload_multipart_extra_parameter.txt
+++ b/test/common/request/post/2xx/201_14_upload_multipart_extra_parameter.txt
@@ -1,0 +1,12 @@
+POST /upload HTTP/1.1
+Host: localhost
+Connection: close
+Content-Type: multipart/form-data; boundary=----webkitformboundary; abc=def
+Content-Length: 163
+
+------webkitformboundary
+Content-Disposition: form-data; name="field1"; filename="filename1.txt"
+Content-Type: text/plain
+
+value1
+------webkitformboundary--

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -174,9 +174,20 @@ def cleanup_files_context():
             [MULTIPART_FILE_PATH1, MULTIPART_FILE_PATH2],
             ["value1", "value2"],
         ),
+        (
+            REQUEST_POST_2XX_DIR
+            + "201_13_upload_multipart_multi_files_case_sensitive_boundary.txt",
+            created_response_close,
+            [MULTIPART_FILE_PATH1, MULTIPART_FILE_PATH2],
+            [
+                'value1\n------webkitformboundarY\nContent-Disposition: form-data; name="field"; filename="filename2.txt"\nContent-Type: text/plain\n\nvalue2',
+                'value3\n------wEbkitformboundary\nContent-Disposition: form-data; name="field"; filename="filename3.txt"\nContent-Type: text/plain\n\nvalue4',
+            ],
+        ),
     ],
     ids=[
         "201_12_upload_multipart_multi_files",
+        "201_13_upload_multipart_multi_files_case_sensitive_boundary",
     ],
 )
 def test_post_upload_multi_file_responses(

--- a/test/webserv/integration/test_http_post.py
+++ b/test/webserv/integration/test_http_post.py
@@ -119,7 +119,13 @@ def cleanup_file_context():
             MULTIPART_FILE_PATH1,
             "value1",
         ),
-        # 201_12 is below -> test_post_upload_multi_file_responses()
+        # 201_12, 201_13 is below -> test_post_upload_multi_file_responses()
+        (
+            REQUEST_POST_2XX_DIR + "201_14_upload_multipart_extra_parameter.txt",
+            created_response_close,
+            MULTIPART_FILE_PATH1,
+            "value1",
+        ),
     ],
     ids=[
         "201_01_upload_file",
@@ -132,6 +138,7 @@ def cleanup_file_context():
         "201_08_unchunked_body_size_just_client_max_body_size",
         "201_10_upload_multipart",
         "201_11_upload_multipart_no_quote",
+        "201_14_upload_multipart_extra_parameter",
     ],
 )
 def test_post_upload_responses(


### PR DESCRIPTION
## Content-Typeのboundaryパラメータのみ大文字小文字を保持するようにしました

boundaryの後に";"がある場合はそれで区切るような処理も追加しました

- [x] `201_13`のテストケースでboundaryの大文字小文字が違う場合は区切られないというテストケースも追加しました
- [x] `201_14`のテストケースでboundaryの後に";"で区切られた他のパラメータが入るテストも追加しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `Content-Type` ヘッダーの処理を改善し、境界パラメータを除いて小文字に変換する新しい機能を追加しました。
  - マルチパートファイルアップロードのケースセンシティブな境界文字列を検証するための新しいテストケースを追加しました。
  - マルチパートフォームデータを使用した新しいHTTP POSTリクエストの例を追加しました。

- **テスト**
  - マルチパートファイルアップロードのテストカバレッジを強化する新しいテストファイルとテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->