### PR TITLE
[update] server / HandleErrorEvent() を反復する可能性を修正

### DIFF
--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -196,7 +196,8 @@ void Server::HandleErrorEvent(int fd) {
 		return;
 	}
 	const int client_fd = IsCgi(fd) ? cgi_manager_.GetClientFd(fd) : fd;
-	SetInternalServerError(client_fd);
+	utils::Debug("server", "An error occurred on the monitored fd", client_fd);
+	Disconnect(client_fd);
 }
 
 void Server::HandleHangUpEvent(const event::Event &event) {


### PR DESCRIPTION
(branch 名ミスりました、無視してください)

今までは何かしらのエラーが起こり `EPOLLERR` が発生して `HandleErrorEvent()` に入ったあと、更に internal server error を送り返そうと試みていましたが、timeout までずっと `EPOLLERR` が起こり続けるということが起きたことからも、`EPOLLERR` は即 `Disconnect()` しても良いのではと思い、修正しました

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- サーバーのエラーハンドリングとイベント管理の改善により、デバッグログが追加されました。
	- クライアント接続の切断やHTTPレスポンス送信時にログを記録し、トラブルシューティングの可視性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->