### PR TITLE
[update] chunked の 16 進数に 0x, 0X がある場合を考慮して上限設定

### DIFF
--- a/srcs/http/request/parse/http_parse.cpp
+++ b/srcs/http/request/parse/http_parse.cpp
@@ -74,7 +74,7 @@ ChunkSizeResult GetChunkSizeStr(const std::string &current_buf) {
 
 	const std::string::size_type end_of_chunk_size_pos = current_buf.find(CRLF);
 	if (end_of_chunk_size_pos == std::string::npos) {
-		if (current_buf.size() > 8) { // INT_MAX: 7FFFFFFF(8digits)
+		if (current_buf.size() > 10) { // INT_MAX: 0x7FFFFFFF(10digits)
 			throw HttpException("Error: incorrect chunk size", StatusCode(BAD_REQUEST));
 		}
 		result.Set(false);

--- a/test/common/request/post/4xx/400_12_only_too_large_chunk_size_early_check.txt
+++ b/test/common/request/post/4xx/400_12_only_too_large_chunk_size_early_check.txt
@@ -6,4 +6,4 @@ Transfer-Encoding: chunked
 
 4
 Wiki
-1234567890
+12345678901

--- a/test/webserv/unit/http_parse/test_http_parse.cpp
+++ b/test/webserv/unit/http_parse/test_http_parse.cpp
@@ -629,7 +629,8 @@ int main(void) {
 	test13_body_message_chunked.request_result.request.body_message = "Wikipedia";
 	test13_body_message_chunked.current_buf                         = "80000000\r\naaa";
 
-	// 24.Chunked Transfer-Encodingの場合で、\r\nが含まれずchunk_sizeが8桁より多い場合は早期に400
+	// 24.Chunked Transfer-Encodingの場合で、
+	//    \r\nが含まれずchunk_sizeが10桁(0x7FFFFFFF)より多い場合は早期に400
 	http::HttpRequestParsedData test14_body_message_chunked;
 	test14_body_message_chunked.request_result.status_code = http::StatusCode(http::BAD_REQUEST);
 	test14_body_message_chunked.request_result.request.request_line =
@@ -638,7 +639,7 @@ int main(void) {
 	test14_body_message_chunked.is_request_format.is_header_fields  = true;
 	test14_body_message_chunked.is_request_format.is_body_message   = false;
 	test14_body_message_chunked.request_result.request.body_message = "Wikipedia";
-	test14_body_message_chunked.current_buf                         = "123456789";
+	test14_body_message_chunked.current_buf                         = "12345678901";
 
 	static const TestCase test_case_http_request_body_message_format_with_chunked[] = {
 		TestCase(
@@ -709,7 +710,7 @@ int main(void) {
 		),
 		TestCase(
 			"POST / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: chunked\r\nContent-Type: "
-			"text/plain\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n123456789",
+			"text/plain\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n12345678901",
 			test14_body_message_chunked
 		),
 	};


### PR DESCRIPTION
chunk size の先頭に 0x, 0X がある場合も許容し、早期 400 を返す条件の上限に `0x` 分の 2 桁を追加しました

今まで：`0x7FFFFFF` (int max 以下) でもエラーになってしまっていた
修正後：`0x7FFFFFFF` (int max) も OK に

10 文字であれば何の文字列でも一旦は許容し、10 文字を超えた時点で `HexToDec()` によって判定されます

 <br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- チャンクサイズの最大値を更新し、HTTPリクエストの処理を改善しました。
- **バグ修正**
	- チャンクサイズが10桁を超える場合に早期400エラーを返すように、テストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->