### PR TITLE
[fix] .devcontainer/Dockerfileを修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,6 +33,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 # 新しいユーザーを作成。この時点ではuserはroot
 RUN useradd -ms /bin/bash user_webserv
+RUN chown -R user_webserv:user_webserv /workspaces
 # root権限が必要なinstall等を終えたら、作成したユーザーに切り替え
 USER user_webserv
 

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ run-dev:
 	fi
 	@sleep 1
 	@if [ -z "$$(docker ps -aqf name=$(DEV_CONTAINER_NAME))" ]; then \
-		docker run -it --name $(DEV_CONTAINER_NAME) -p $(DEV_PORT):$(WEBSERV_PORT) $(DEV_IMAGE_NAME):$(DEV_IMAGE_TAG); \
+		docker run -it --name $(DEV_CONTAINER_NAME) -p $(DEV_PORT):$(WEBSERV_PORT) -v .:/workspaces/webserv/ $(DEV_IMAGE_NAME):$(DEV_IMAGE_TAG); \
 	elif [ -z "$$(docker ps -qf name=$(DEV_CONTAINER_NAME))" ]; then \
 		docker start $(DEV_CONTAINER_NAME); \
 	else \


### PR DESCRIPTION
## .devcontainer/Dockerfileを修正しました

- chmodでwebservディレクトリをuser_webservの権限にするように
- make run-devでマウントするように

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Dockerコンテナのボリュームマウント機能を追加し、プロジェクトファイルへのアクセスを向上。
- **改善**
	- `/workspaces`ディレクトリの所有権を新しいユーザーに変更し、適切な権限を設定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->